### PR TITLE
feat: church dashboard with real data + impersonation banner fix

### DIFF
--- a/front-end/src/components/ImpersonationBanner.tsx
+++ b/front-end/src/components/ImpersonationBanner.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import { IconArrowBack } from '@tabler/icons-react';
+
+const ImpersonationBanner = () => {
+  const [impersonating, setImpersonating] = useState(false);
+  const [originalEmail, setOriginalEmail] = useState('');
+  const [currentEmail, setCurrentEmail] = useState('');
+  const [returning, setReturning] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/admin/impersonate/status', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        if (data.impersonating) {
+          setImpersonating(true);
+          setOriginalEmail(data.originalAdmin?.email || '');
+          setCurrentEmail(data.currentUser?.email || '');
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleReturn = async () => {
+    setReturning(true);
+    try {
+      const res = await fetch('/api/admin/impersonate/return', {
+        method: 'POST',
+        credentials: 'include'
+      });
+      const data = await res.json();
+      if (data.success) {
+        localStorage.setItem('auth_user', JSON.stringify(data.user));
+        window.location.href = '/dashboards/modern';
+      }
+    } catch {
+      setReturning(false);
+    }
+  };
+
+  if (!impersonating) return null;
+
+  return (
+    <>
+      <Box
+        sx={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          zIndex: 9999,
+          bgcolor: '#d32f2f',
+          color: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 2,
+          py: 0.75,
+          px: 2,
+          fontSize: '0.875rem',
+          boxShadow: '0 2px 8px rgba(0,0,0,0.3)'
+        }}
+      >
+        <Typography variant="body2" sx={{ color: 'inherit', fontWeight: 500 }}>
+          Viewing as <strong>{currentEmail}</strong>
+        </Typography>
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<IconArrowBack size={16} />}
+          onClick={handleReturn}
+          disabled={returning}
+          sx={{
+            color: '#fff',
+            borderColor: 'rgba(255,255,255,0.5)',
+            '&:hover': { borderColor: '#fff', bgcolor: 'rgba(255,255,255,0.1)' },
+            textTransform: 'none',
+            py: 0.25
+          }}
+        >
+          Return to Admin
+        </Button>
+      </Box>
+      {/* Spacer to push page content below the fixed banner */}
+      <Box sx={{ height: '40px', flexShrink: 0 }} />
+    </>
+  );
+};
+
+export default ImpersonationBanner;

--- a/front-end/src/features/dashboard/ModernDashboard.tsx
+++ b/front-end/src/features/dashboard/ModernDashboard.tsx
@@ -1,0 +1,136 @@
+import { useState, useEffect } from 'react';
+import { Box, Alert, Skeleton } from '@mui/material';
+import Grid2 from '@/components/compat/Grid2';
+import PageContainer from '@/shared/ui/PageContainer';
+import { useChurch } from '@/context/ChurchContext';
+import { apiClient } from '@/api/utils/axiosInstance';
+
+import SacramentCountCards from './widgets/SacramentCountCards';
+import SacramentsByYearChart from './widgets/SacramentsByYearChart';
+import TypeDistributionChart from './widgets/TypeDistributionChart';
+import RecentActivityList from './widgets/RecentActivityList';
+import YearOverYearCard from './widgets/YearOverYearCard';
+import CompletenessGauge from './widgets/CompletenessGauge';
+
+interface DashboardData {
+  counts: { baptisms: number; marriages: number; funerals: number; total: number };
+  recentActivity: { name: string; type: 'baptism' | 'marriage' | 'funeral'; date: string }[];
+  typeDistribution: { name: string; value: number }[];
+  monthlyActivity: { month: string; baptism: number; marriage: number; funeral: number }[];
+  yearOverYear: { currentYear: number; previousYear: number; current: number; previous: number; changePercent: number };
+  completeness: number;
+  dateRange: { earliest: number | null; latest: number | null };
+}
+
+const Modern = () => {
+  const { activeChurchId } = useChurch();
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!activeChurchId) {
+      setData(null);
+      return;
+    }
+
+    let cancelled = false;
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await apiClient.get<any>(`/churches/${activeChurchId}/dashboard`);
+        if (!cancelled) {
+          setData(res.data || res);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err?.response?.data?.error || err?.message || 'Failed to load dashboard');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    fetchData();
+    return () => { cancelled = true; };
+  }, [activeChurchId]);
+
+  if (!activeChurchId) {
+    return (
+      <PageContainer title="Dashboard" description="Church Dashboard">
+        <Alert severity="info" sx={{ mt: 2 }}>
+          Select a church from the sidebar to view dashboard data.
+        </Alert>
+      </PageContainer>
+    );
+  }
+
+  if (loading) {
+    return (
+      <PageContainer title="Dashboard" description="Church Dashboard">
+        <Box>
+          <Grid2 container spacing={3}>
+            <Grid2 size={12}>
+              <Grid2 container spacing={3}>
+                {[1, 2, 3, 4].map(i => (
+                  <Grid2 key={i} size={{ xs: 12, sm: 6, md: 3 }}>
+                    <Skeleton variant="rounded" height={100} />
+                  </Grid2>
+                ))}
+              </Grid2>
+            </Grid2>
+            <Grid2 size={{ xs: 12, lg: 8 }}><Skeleton variant="rounded" height={400} /></Grid2>
+            <Grid2 size={{ xs: 12, lg: 4 }}><Skeleton variant="rounded" height={400} /></Grid2>
+            <Grid2 size={{ xs: 12, md: 4 }}><Skeleton variant="rounded" height={350} /></Grid2>
+            <Grid2 size={{ xs: 12, md: 4 }}><Skeleton variant="rounded" height={350} /></Grid2>
+            <Grid2 size={{ xs: 12, md: 4 }}><Skeleton variant="rounded" height={350} /></Grid2>
+          </Grid2>
+        </Box>
+      </PageContainer>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageContainer title="Dashboard" description="Church Dashboard">
+        <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert>
+      </PageContainer>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <PageContainer title="Dashboard" description="Church Dashboard">
+      <Box>
+        <Grid2 container spacing={3}>
+          {/* Top row: 4 count cards */}
+          <Grid2 size={12}>
+            <SacramentCountCards counts={data.counts} yearOverYear={data.yearOverYear} />
+          </Grid2>
+
+          {/* Middle row: bar chart + donut */}
+          <Grid2 size={{ xs: 12, lg: 8 }}>
+            <SacramentsByYearChart data={data.monthlyActivity} />
+          </Grid2>
+          <Grid2 size={{ xs: 12, lg: 4 }}>
+            <TypeDistributionChart data={data.typeDistribution} />
+          </Grid2>
+
+          {/* Bottom row: recent activity, year-over-year, completeness */}
+          <Grid2 size={{ xs: 12, md: 4 }}>
+            <RecentActivityList data={data.recentActivity} />
+          </Grid2>
+          <Grid2 size={{ xs: 12, md: 4 }}>
+            <YearOverYearCard data={data.yearOverYear} />
+          </Grid2>
+          <Grid2 size={{ xs: 12, md: 4 }}>
+            <CompletenessGauge value={data.completeness} dateRange={data.dateRange} />
+          </Grid2>
+        </Grid2>
+      </Box>
+    </PageContainer>
+  );
+};
+
+export default Modern;

--- a/front-end/src/features/dashboard/widgets/CompletenessGauge.tsx
+++ b/front-end/src/features/dashboard/widgets/CompletenessGauge.tsx
@@ -1,0 +1,47 @@
+import { Paper, Typography, Box, useTheme } from '@mui/material';
+import Chart from 'react-apexcharts';
+
+interface Props {
+  value: number;
+  dateRange: { earliest: number | null; latest: number | null };
+}
+
+const CompletenessGauge = ({ value, dateRange }: Props) => {
+  const theme = useTheme();
+  const color = value >= 80 ? '#2e7d32' : value >= 50 ? '#ed6c02' : '#d32f2f';
+
+  const options: ApexCharts.ApexOptions = {
+    chart: { type: 'radialBar', fontFamily: theme.typography.fontFamily },
+    plotOptions: {
+      radialBar: {
+        startAngle: -135,
+        endAngle: 135,
+        hollow: { size: '65%' },
+        track: { background: theme.palette.mode === 'dark' ? '#333' : '#f0f0f0', strokeWidth: '100%' },
+        dataLabels: {
+          name: { show: true, offsetY: -10, color: theme.palette.text.secondary, fontSize: '13px' },
+          value: { show: true, fontSize: '28px', fontWeight: 700, color: theme.palette.text.primary, formatter: (val: number) => `${val}%` },
+        },
+      },
+    },
+    colors: [color],
+    labels: ['Complete'],
+    stroke: { lineCap: 'round' },
+  };
+
+  return (
+    <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid', borderColor: 'divider', height: '100%' }}>
+      <Typography variant="h6" fontWeight={600} mb={1}>Data Completeness</Typography>
+      <Chart options={options} series={[value]} type="radialBar" height={220} />
+      {dateRange.earliest && dateRange.latest && (
+        <Box sx={{ textAlign: 'center', mt: -1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Records span {dateRange.earliest} &ndash; {dateRange.latest}
+          </Typography>
+        </Box>
+      )}
+    </Paper>
+  );
+};
+
+export default CompletenessGauge;

--- a/front-end/src/features/dashboard/widgets/RecentActivityList.tsx
+++ b/front-end/src/features/dashboard/widgets/RecentActivityList.tsx
@@ -1,0 +1,56 @@
+import { Paper, Typography, List, ListItem, ListItemIcon, ListItemText, Box } from '@mui/material';
+import { IconDroplet, IconHeart, IconCross } from '@tabler/icons-react';
+
+interface ActivityItem {
+  name: string;
+  type: 'baptism' | 'marriage' | 'funeral';
+  date: string;
+}
+
+interface Props {
+  data: ActivityItem[];
+}
+
+const typeConfig = {
+  baptism: { icon: IconDroplet, color: '#1e88e5', label: 'Baptism' },
+  marriage: { icon: IconHeart, color: '#e91e63', label: 'Marriage' },
+  funeral: { icon: IconCross, color: '#7b1fa2', label: 'Funeral' },
+};
+
+const RecentActivityList = ({ data }: Props) => {
+  return (
+    <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid', borderColor: 'divider', height: '100%' }}>
+      <Typography variant="h6" fontWeight={600} mb={1}>Recent Records</Typography>
+      {data.length > 0 ? (
+        <List dense disablePadding>
+          {data.map((item, i) => {
+            const cfg = typeConfig[item.type] || typeConfig.baptism;
+            const Icon = cfg.icon;
+            const dateStr = item.date ? new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : '';
+            return (
+              <ListItem key={i} disablePadding sx={{ py: 0.75 }}>
+                <ListItemIcon sx={{ minWidth: 36 }}>
+                  <Box sx={{ width: 28, height: 28, borderRadius: 1, bgcolor: `${cfg.color}14`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <Icon size={16} color={cfg.color} />
+                  </Box>
+                </ListItemIcon>
+                <ListItemText
+                  primary={item.name}
+                  secondary={`${cfg.label} · ${dateStr}`}
+                  primaryTypographyProps={{ variant: 'body2', noWrap: true }}
+                  secondaryTypographyProps={{ variant: 'caption' }}
+                />
+              </ListItem>
+            );
+          })}
+        </List>
+      ) : (
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 200, color: 'text.secondary' }}>
+          <Typography variant="body2">No recent records</Typography>
+        </Box>
+      )}
+    </Paper>
+  );
+};
+
+export default RecentActivityList;

--- a/front-end/src/features/dashboard/widgets/SacramentCountCards.tsx
+++ b/front-end/src/features/dashboard/widgets/SacramentCountCards.tsx
@@ -1,0 +1,74 @@
+import { Box, Typography, Paper, useTheme } from '@mui/material';
+import Grid2 from '@/components/compat/Grid2';
+import { IconDroplet, IconHeart, IconCross, IconDatabase } from '@tabler/icons-react';
+
+interface Props {
+  counts: { baptisms: number; marriages: number; funerals: number; total: number };
+  yearOverYear: { changePercent: number };
+}
+
+const cards = [
+  { key: 'baptisms', label: 'Baptisms', icon: IconDroplet, color: '#1e88e5' },
+  { key: 'marriages', label: 'Marriages', icon: IconHeart, color: '#e91e63' },
+  { key: 'funerals', label: 'Funerals', icon: IconCross, color: '#7b1fa2' },
+  { key: 'total', label: 'Total Records', icon: IconDatabase, color: '#00897b' },
+] as const;
+
+const SacramentCountCards = ({ counts, yearOverYear }: Props) => {
+  const theme = useTheme();
+
+  return (
+    <Grid2 container spacing={3}>
+      {cards.map(({ key, label, icon: Icon, color }) => (
+        <Grid2 key={key} size={{ xs: 12, sm: 6, md: 3 }}>
+          <Paper
+            elevation={0}
+            sx={{
+              p: 2.5,
+              borderRadius: 2,
+              bgcolor: theme.palette.mode === 'dark' ? 'background.paper' : '#fff',
+              border: '1px solid',
+              borderColor: 'divider',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 2,
+            }}
+          >
+            <Box
+              sx={{
+                width: 48,
+                height: 48,
+                borderRadius: 2,
+                bgcolor: `${color}14`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <Icon size={24} color={color} />
+            </Box>
+            <Box>
+              <Typography variant="h4" fontWeight={700}>
+                {counts[key].toLocaleString()}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {label}
+              </Typography>
+              {key === 'total' && yearOverYear.changePercent !== 0 && (
+                <Typography
+                  variant="caption"
+                  sx={{ color: yearOverYear.changePercent > 0 ? 'success.main' : 'error.main' }}
+                >
+                  {yearOverYear.changePercent > 0 ? '+' : ''}{yearOverYear.changePercent}% vs last year
+                </Typography>
+              )}
+            </Box>
+          </Paper>
+        </Grid2>
+      ))}
+    </Grid2>
+  );
+};
+
+export default SacramentCountCards;

--- a/front-end/src/features/dashboard/widgets/SacramentsByYearChart.tsx
+++ b/front-end/src/features/dashboard/widgets/SacramentsByYearChart.tsx
@@ -1,0 +1,57 @@
+import { useTheme } from '@mui/material';
+import { Paper, Typography, Box } from '@mui/material';
+import Chart from 'react-apexcharts';
+
+interface MonthlyData {
+  month: string;
+  baptism: number;
+  marriage: number;
+  funeral: number;
+}
+
+interface Props {
+  data: MonthlyData[];
+}
+
+const SacramentsByYearChart = ({ data }: Props) => {
+  const theme = useTheme();
+
+  const categories = data.map(d => {
+    const [y, m] = d.month.split('-');
+    const date = new Date(Number(y), Number(m) - 1);
+    return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+  });
+
+  const options: ApexCharts.ApexOptions = {
+    chart: { type: 'bar', stacked: false, toolbar: { show: false }, fontFamily: theme.typography.fontFamily },
+    plotOptions: { bar: { borderRadius: 3, columnWidth: '60%' } },
+    colors: ['#1e88e5', '#e91e63', '#7b1fa2'],
+    xaxis: { categories, labels: { style: { colors: theme.palette.text.secondary } } },
+    yaxis: { labels: { style: { colors: theme.palette.text.secondary } } },
+    legend: { position: 'top', labels: { colors: theme.palette.text.primary } },
+    grid: { borderColor: theme.palette.divider, strokeDashArray: 4 },
+    tooltip: { theme: theme.palette.mode },
+    dataLabels: { enabled: false },
+  };
+
+  const series = [
+    { name: 'Baptisms', data: data.map(d => d.baptism) },
+    { name: 'Marriages', data: data.map(d => d.marriage) },
+    { name: 'Funerals', data: data.map(d => d.funeral) },
+  ];
+
+  return (
+    <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid', borderColor: 'divider', height: '100%' }}>
+      <Typography variant="h6" fontWeight={600} mb={2}>Monthly Activity (Last 12 Months)</Typography>
+      {data.length > 0 ? (
+        <Chart options={options} series={series} type="bar" height={320} />
+      ) : (
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 320, color: 'text.secondary' }}>
+          <Typography>No dated records found</Typography>
+        </Box>
+      )}
+    </Paper>
+  );
+};
+
+export default SacramentsByYearChart;

--- a/front-end/src/features/dashboard/widgets/TypeDistributionChart.tsx
+++ b/front-end/src/features/dashboard/widgets/TypeDistributionChart.tsx
@@ -1,0 +1,48 @@
+import { useTheme } from '@mui/material';
+import { Paper, Typography, Box } from '@mui/material';
+import Chart from 'react-apexcharts';
+
+interface Props {
+  data: { name: string; value: number }[];
+}
+
+const TypeDistributionChart = ({ data }: Props) => {
+  const theme = useTheme();
+  const total = data.reduce((sum, d) => sum + d.value, 0);
+
+  const options: ApexCharts.ApexOptions = {
+    chart: { type: 'donut', fontFamily: theme.typography.fontFamily },
+    labels: data.map(d => d.name),
+    colors: ['#1e88e5', '#e91e63', '#7b1fa2'],
+    legend: { position: 'bottom', labels: { colors: theme.palette.text.primary } },
+    plotOptions: {
+      pie: {
+        donut: {
+          size: '65%',
+          labels: {
+            show: true,
+            total: { show: true, label: 'Total', formatter: () => total.toLocaleString() },
+          },
+        },
+      },
+    },
+    stroke: { width: 0 },
+    tooltip: { theme: theme.palette.mode },
+    dataLabels: { enabled: false },
+  };
+
+  return (
+    <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid', borderColor: 'divider', height: '100%' }}>
+      <Typography variant="h6" fontWeight={600} mb={2}>Record Types</Typography>
+      {total > 0 ? (
+        <Chart options={options} series={data.map(d => d.value)} type="donut" height={320} />
+      ) : (
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 320, color: 'text.secondary' }}>
+          <Typography>No records yet</Typography>
+        </Box>
+      )}
+    </Paper>
+  );
+};
+
+export default TypeDistributionChart;

--- a/front-end/src/features/dashboard/widgets/YearOverYearCard.tsx
+++ b/front-end/src/features/dashboard/widgets/YearOverYearCard.tsx
@@ -1,0 +1,46 @@
+import { Paper, Typography, Box } from '@mui/material';
+import { IconTrendingUp, IconTrendingDown, IconMinus } from '@tabler/icons-react';
+
+interface Props {
+  data: {
+    currentYear: number;
+    previousYear: number;
+    current: number;
+    previous: number;
+    changePercent: number;
+  };
+}
+
+const YearOverYearCard = ({ data }: Props) => {
+  const isUp = data.changePercent > 0;
+  const isDown = data.changePercent < 0;
+  const TrendIcon = isUp ? IconTrendingUp : isDown ? IconTrendingDown : IconMinus;
+  const trendColor = isUp ? '#2e7d32' : isDown ? '#d32f2f' : '#757575';
+
+  return (
+    <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid', borderColor: 'divider', height: '100%' }}>
+      <Typography variant="h6" fontWeight={600} mb={2}>Year over Year</Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box>
+          <Typography variant="body2" color="text.secondary">{data.currentYear}</Typography>
+          <Typography variant="h4" fontWeight={700}>{data.current.toLocaleString()}</Typography>
+        </Box>
+        <Box>
+          <Typography variant="body2" color="text.secondary">{data.previousYear}</Typography>
+          <Typography variant="h5" fontWeight={600} color="text.secondary">{data.previous.toLocaleString()}</Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+          <Box sx={{ width: 32, height: 32, borderRadius: '50%', bgcolor: `${trendColor}14`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <TrendIcon size={18} color={trendColor} />
+          </Box>
+          <Typography variant="body1" fontWeight={600} sx={{ color: trendColor }}>
+            {isUp ? '+' : ''}{data.changePercent}%
+          </Typography>
+          <Typography variant="body2" color="text.secondary">change</Typography>
+        </Box>
+      </Box>
+    </Paper>
+  );
+};
+
+export default YearOverYearCard;

--- a/front-end/src/layouts/full/FullLayout.tsx
+++ b/front-end/src/layouts/full/FullLayout.tsx
@@ -1,0 +1,127 @@
+import { FC, useContext, useEffect } from 'react';
+import { styled, Container, Box, useTheme } from '@mui/material';
+import { Outlet, useLocation } from 'react-router-dom';
+import Header from './vertical/header/Header';
+import Sidebar from './vertical/sidebar/Sidebar';
+import Customizer from './shared/customizer/Customizer';
+import Navigation from '../full/horizontal/navbar/Navigation';
+import HorizontalHeader from '../full/horizontal/header/Header';
+import ScrollToTop from '../../shared/ui/ScrollToTop';
+// import SuperadminSourcePathOverlay from '../../features/overlays'; // TEMPORARILY DISABLED
+// import { VersionSwitcher } from '../../features/overlays'; // TEMPORARILY DISABLED
+// import LoadingBar from '../../LoadingBar';
+import { CustomizerContext } from '@/context/CustomizerContext';
+import config from '@/context/config';
+import { useAuth } from '@/context/AuthContext';
+import AdminFloatingHUD from '../../components/AdminFloatingHUD';
+import ImpersonationBanner from '../../components/ImpersonationBanner';
+import { getPageTitle } from '../../config/pageTitles';
+// import SiteEditorOverlay from '../../components/SiteEditorOverlay';
+// import GlobalOMAI from '../../components/global/GlobalOMAI';
+// import ErrorNotificationToast from '../../components/global/ErrorNotificationToast';
+
+const MainWrapper = styled('div')(({ theme }) => ({
+  display: 'flex',
+  minHeight: '100vh',
+  width: '100%',
+  backgroundColor: theme.palette.background.default,
+}));
+
+const PageWrapper = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexGrow: 1,
+  paddingBottom: '60px',
+  flexDirection: 'column',
+  zIndex: 1,
+  width: '100%',
+  backgroundColor: theme.palette.background.default,
+}));
+
+const FullLayout: FC = () => {
+  const { activeLayout, isLayout, activeMode, isCollapse } = useContext(CustomizerContext);
+  const theme = useTheme();
+  const { isSuperAdmin } = useAuth();
+  const location = useLocation();
+  const MiniSidebarWidth = config.miniSidebarWidth;
+
+  // Update page title based on current route
+  useEffect(() => {
+    const title = getPageTitle(location.pathname);
+    document.title = `${title} | OrthodoxMetrics`;
+  }, [location.pathname]);
+
+  return (
+    <>
+      {/* <LoadingBar /> */}
+      <MainWrapper className={activeMode === 'dark' ? 'darkbg mainwrapper' : 'mainwrapper'}>
+
+        {/* ------------------------------------------- */}
+        {/* Sidebar */}
+        {/* ------------------------------------------- */}
+        {activeLayout === 'horizontal' ? '' : <Sidebar />}
+        {/* ------------------------------------------- */}
+        {/* Main Wrapper */}
+        {/* ------------------------------------------- */}
+        <PageWrapper
+          className="page-wrapper"
+          sx={{
+            ...(isCollapse === "mini-sidebar" && {
+              [theme.breakpoints.up('lg')]: { ml: `${MiniSidebarWidth}px` },
+            }),
+          }}
+        >
+          {/* ------------------------------------------- */}
+          {/* Impersonation Banner (pushes content down when active) */}
+          {/* ------------------------------------------- */}
+          <ImpersonationBanner />
+          {/* ------------------------------------------- */}
+          {/* Header */}
+          {/* ------------------------------------------- */}
+          {activeLayout === 'horizontal' ? <HorizontalHeader /> : <Header />}
+          {/* PageContent */}
+          {activeLayout === 'horizontal' ? <Navigation /> : ''}
+          <Container
+            sx={{
+              pt: '30px',
+              maxWidth: isLayout === 'boxed' ? 'lg' : '100%!important',
+              mx: 'auto', // Center the container
+              px: { xs: 2, sm: 3, md: 4 }, // Responsive padding
+            }}
+          >
+            {/* ------------------------------------------- */}
+            {/* PageContent */}
+            {/* ------------------------------------------- */}
+
+            <Box sx={{ minHeight: 'calc(100vh - 170px)' }}>
+              <ScrollToTop>
+                {/* <SiteEditorOverlay> */}
+                  <Outlet />
+                {/* </SiteEditorOverlay> */}
+              </ScrollToTop>
+            </Box>
+
+            {/* ------------------------------------------- */}
+            {/* End Page */}
+            {/* ------------------------------------------- */}
+          </Container>
+          <Customizer />
+        </PageWrapper>
+      </MainWrapper>
+      
+      {/* ------------------------------------------- */}
+      {/* Global OMAI Assistant - DISABLED */}
+      {/* ------------------------------------------- */}
+      {/* <GlobalOMAI /> */}
+      {/* <SuperadminSourcePathOverlay /> TEMPORARILY DISABLED */}
+      {/* <VersionSwitcher /> TEMPORARILY DISABLED */}
+      {/* <ErrorNotificationToast /> */}
+      
+      {/* ------------------------------------------- */}
+      {/* Admin Floating HUD - Super Admin Only */}
+      {/* ------------------------------------------- */}
+      {/* {isSuperAdmin() && <AdminFloatingHUD />} */}
+    </>
+  );
+};
+
+export default FullLayout;

--- a/server/src/api/dashboard-home.js
+++ b/server/src/api/dashboard-home.js
@@ -1,0 +1,196 @@
+/**
+ * Dashboard Home API
+ * Provides summary data for the church dashboard home page
+ *
+ * Endpoint: GET /api/churches/:churchId/dashboard
+ */
+
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+const { requireAuth } = require('../middleware/auth');
+const { getTenantPool } = require('../config/db');
+const { detectColumns } = require('../utils/detectColumns');
+
+/**
+ * GET /
+ * Returns dashboard summary: counts, recent activity, type distribution,
+ * monthly activity, year-over-year, completeness, date range
+ */
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const churchId = req.params.churchId;
+    if (!churchId) {
+      return res.status(400).json({ success: false, error: 'Church ID is required' });
+    }
+
+    const pool = getTenantPool(churchId);
+    const cols = await detectColumns(pool);
+
+    // --- 1. Record counts ---
+    const [countRows] = await pool.query(`
+      SELECT 'baptisms' AS type, COUNT(*) AS count FROM baptism_records
+      UNION ALL
+      SELECT 'marriages' AS type, COUNT(*) AS count FROM marriage_records
+      UNION ALL
+      SELECT 'funerals' AS type, COUNT(*) AS count FROM funeral_records
+    `);
+    const counts = { baptisms: 0, marriages: 0, funerals: 0, total: 0 };
+    countRows.forEach(r => {
+      counts[r.type] = Number(r.count);
+      counts.total += Number(r.count);
+    });
+
+    // --- 2. Recent activity (10 most recent records across all types) ---
+    const recentParts = [];
+    if (cols.baptismDate) {
+      const nameCol = cols.baptismName || `'Baptism Record'`;
+      recentParts.push(`(SELECT ${nameCol} AS name, 'baptism' AS type, ${cols.baptismDate} AS record_date FROM baptism_records WHERE ${cols.baptismDate} IS NOT NULL ORDER BY ${cols.baptismDate} DESC LIMIT 10)`);
+    }
+    if (cols.marriageDate) {
+      const nameCol = cols.marriageName || `'Marriage Record'`;
+      recentParts.push(`(SELECT ${nameCol} AS name, 'marriage' AS type, ${cols.marriageDate} AS record_date FROM marriage_records WHERE ${cols.marriageDate} IS NOT NULL ORDER BY ${cols.marriageDate} DESC LIMIT 10)`);
+    }
+    if (cols.funeralDate) {
+      const nameCol = cols.funeralName || `'Funeral Record'`;
+      recentParts.push(`(SELECT ${nameCol} AS name, 'funeral' AS type, ${cols.funeralDate} AS record_date FROM funeral_records WHERE ${cols.funeralDate} IS NOT NULL ORDER BY ${cols.funeralDate} DESC LIMIT 10)`);
+    }
+
+    let recentActivity = [];
+    if (recentParts.length > 0) {
+      const [recentRows] = await pool.query(
+        `SELECT * FROM (${recentParts.join(' UNION ALL ')}) AS combined ORDER BY record_date DESC LIMIT 10`
+      );
+      recentActivity = recentRows.map(r => ({
+        name: r.name || 'Unknown',
+        type: r.type,
+        date: r.record_date
+      }));
+    }
+
+    // --- 3. Type distribution (for pie/donut chart) ---
+    const typeDistribution = [
+      { name: 'Baptisms', value: counts.baptisms },
+      { name: 'Marriages', value: counts.marriages },
+      { name: 'Funerals', value: counts.funerals },
+    ];
+
+    // --- 4. Monthly activity (last 12 months grouped by type) ---
+    const monthlyParts = [];
+    if (cols.baptismDate) {
+      monthlyParts.push(`SELECT DATE_FORMAT(${cols.baptismDate}, '%Y-%m') AS month, 'baptism' AS type FROM baptism_records WHERE ${cols.baptismDate} IS NOT NULL AND ${cols.baptismDate} >= DATE_SUB(CURDATE(), INTERVAL 12 MONTH)`);
+    }
+    if (cols.marriageDate) {
+      monthlyParts.push(`SELECT DATE_FORMAT(${cols.marriageDate}, '%Y-%m') AS month, 'marriage' AS type FROM marriage_records WHERE ${cols.marriageDate} IS NOT NULL AND ${cols.marriageDate} >= DATE_SUB(CURDATE(), INTERVAL 12 MONTH)`);
+    }
+    if (cols.funeralDate) {
+      monthlyParts.push(`SELECT DATE_FORMAT(${cols.funeralDate}, '%Y-%m') AS month, 'funeral' AS type FROM funeral_records WHERE ${cols.funeralDate} IS NOT NULL AND ${cols.funeralDate} >= DATE_SUB(CURDATE(), INTERVAL 12 MONTH)`);
+    }
+
+    let monthlyActivity = [];
+    if (monthlyParts.length > 0) {
+      const [monthRows] = await pool.query(
+        `SELECT month, type, COUNT(*) AS count FROM (${monthlyParts.join(' UNION ALL ')}) combined GROUP BY month, type ORDER BY month`
+      );
+      const monthMap = {};
+      monthRows.forEach(r => {
+        if (!monthMap[r.month]) monthMap[r.month] = { month: r.month, baptism: 0, marriage: 0, funeral: 0 };
+        monthMap[r.month][r.type] = Number(r.count);
+      });
+      monthlyActivity = Object.values(monthMap).sort((a, b) => a.month.localeCompare(b.month));
+    }
+
+    // --- 5. Year-over-year comparison ---
+    const currentYear = new Date().getFullYear();
+    const yoyParts = [];
+    if (cols.baptismDate) {
+      yoyParts.push(`SELECT YEAR(${cols.baptismDate}) AS yr, 'baptism' AS type FROM baptism_records WHERE YEAR(${cols.baptismDate}) IN (${currentYear}, ${currentYear - 1})`);
+    }
+    if (cols.marriageDate) {
+      yoyParts.push(`SELECT YEAR(${cols.marriageDate}) AS yr, 'marriage' AS type FROM marriage_records WHERE YEAR(${cols.marriageDate}) IN (${currentYear}, ${currentYear - 1})`);
+    }
+    if (cols.funeralDate) {
+      yoyParts.push(`SELECT YEAR(${cols.funeralDate}) AS yr, 'funeral' AS type FROM funeral_records WHERE YEAR(${cols.funeralDate}) IN (${currentYear}, ${currentYear - 1})`);
+    }
+
+    let yearOverYear = { currentYear, previousYear: currentYear - 1, current: 0, previous: 0, changePercent: 0 };
+    if (yoyParts.length > 0) {
+      const [yoyRows] = await pool.query(
+        `SELECT yr, COUNT(*) AS count FROM (${yoyParts.join(' UNION ALL ')}) combined GROUP BY yr`
+      );
+      yoyRows.forEach(r => {
+        if (Number(r.yr) === currentYear) yearOverYear.current = Number(r.count);
+        else yearOverYear.previous = Number(r.count);
+      });
+      if (yearOverYear.previous > 0) {
+        yearOverYear.changePercent = Math.round(((yearOverYear.current - yearOverYear.previous) / yearOverYear.previous) * 100);
+      }
+    }
+
+    // --- 6. Data completeness ---
+    // Check what % of records have key fields filled
+    const completenessChecks = [];
+    if (cols.baptismDate && cols.baptismName) {
+      completenessChecks.push(`SELECT COUNT(*) AS total, SUM(CASE WHEN ${cols.baptismName} IS NOT NULL AND ${cols.baptismName} != '' AND ${cols.baptismDate} IS NOT NULL THEN 1 ELSE 0 END) AS complete FROM baptism_records`);
+    }
+    if (cols.marriageDate && cols.marriageName) {
+      completenessChecks.push(`SELECT COUNT(*) AS total, SUM(CASE WHEN ${cols.marriageName} IS NOT NULL AND ${cols.marriageName} != '' AND ${cols.marriageDate} IS NOT NULL THEN 1 ELSE 0 END) AS complete FROM marriage_records`);
+    }
+    if (cols.funeralDate && cols.funeralName) {
+      completenessChecks.push(`SELECT COUNT(*) AS total, SUM(CASE WHEN ${cols.funeralName} IS NOT NULL AND ${cols.funeralName} != '' AND ${cols.funeralDate} IS NOT NULL THEN 1 ELSE 0 END) AS complete FROM funeral_records`);
+    }
+
+    let completeness = 0;
+    if (completenessChecks.length > 0) {
+      const results = await Promise.all(completenessChecks.map(q => pool.query(q)));
+      let totalRecords = 0;
+      let completeRecords = 0;
+      results.forEach(([rows]) => {
+        totalRecords += Number(rows[0]?.total || 0);
+        completeRecords += Number(rows[0]?.complete || 0);
+      });
+      completeness = totalRecords > 0 ? Math.round((completeRecords / totalRecords) * 100) : 0;
+    }
+
+    // --- 7. Date range ---
+    const rangeParts = [];
+    if (cols.baptismDate) rangeParts.push(`SELECT MIN(${cols.baptismDate}) AS earliest, MAX(${cols.baptismDate}) AS latest FROM baptism_records WHERE ${cols.baptismDate} IS NOT NULL`);
+    if (cols.marriageDate) rangeParts.push(`SELECT MIN(${cols.marriageDate}) AS earliest, MAX(${cols.marriageDate}) AS latest FROM marriage_records WHERE ${cols.marriageDate} IS NOT NULL`);
+    if (cols.funeralDate) rangeParts.push(`SELECT MIN(${cols.funeralDate}) AS earliest, MAX(${cols.funeralDate}) AS latest FROM funeral_records WHERE ${cols.funeralDate} IS NOT NULL`);
+
+    let dateRange = { earliest: null, latest: null };
+    if (rangeParts.length > 0) {
+      const [rangeRows] = await pool.query(
+        `SELECT MIN(earliest) AS earliest, MAX(latest) AS latest FROM (${rangeParts.join(' UNION ALL ')}) combined`
+      );
+      if (rangeRows[0]) {
+        const e = rangeRows[0].earliest;
+        const l = rangeRows[0].latest;
+        dateRange.earliest = e ? new Date(e).getFullYear() : null;
+        dateRange.latest = l ? new Date(l).getFullYear() : null;
+      }
+    }
+
+    res.json({
+      success: true,
+      data: {
+        counts,
+        recentActivity,
+        typeDistribution,
+        monthlyActivity,
+        yearOverYear,
+        completeness,
+        dateRange
+      }
+    });
+
+  } catch (error) {
+    console.error('[Dashboard Home] Error:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to fetch dashboard data',
+      message: error.message
+    });
+  }
+});
+
+module.exports = router;

--- a/server/src/api/om-charts.js
+++ b/server/src/api/om-charts.js
@@ -1,0 +1,187 @@
+/**
+ * OM Charts API
+ * Provides chart data from church sacramental records (baptisms, marriages, funerals)
+ *
+ * Endpoint: GET /api/churches/:churchId/charts/summary
+ */
+
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+const { requireAuth } = require('../middleware/auth');
+const { getTenantPool } = require('../config/db');
+const { getAppPool } = require('../config/db-compat');
+const { getEffectiveFeatures } = require('../utils/featureFlags');
+const { detectColumns } = require('../utils/detectColumns');
+
+/**
+ * GET /summary
+ * Returns 6 chart datasets from the church's sacramental records
+ */
+router.get('/summary', requireAuth, async (req, res) => {
+  try {
+    const churchId = req.params.churchId;
+    if (!churchId) {
+      return res.status(400).json({ success: false, error: 'Church ID is required' });
+    }
+
+    // Check feature flag
+    const appPool = getAppPool();
+    const { effective } = await getEffectiveFeatures(appPool, churchId);
+    if (!effective.om_charts_enabled) {
+      return res.status(403).json({
+        success: false,
+        error: 'OM Charts is not enabled for this church'
+      });
+    }
+
+    const pool = getTenantPool(churchId);
+    const cols = await detectColumns(pool);
+
+    // Build UNION parts only for tables that have the right columns
+    const yearParts = [];
+    const monthParts = [];
+    const seasonParts = [];
+    const clergyParts = [];
+
+    if (cols.baptismDate) {
+      yearParts.push(`SELECT YEAR(${cols.baptismDate}) AS year_val, 'baptism' AS type FROM baptism_records WHERE ${cols.baptismDate} IS NOT NULL`);
+      monthParts.push(`SELECT DATE_FORMAT(${cols.baptismDate}, '%Y-%m') AS month_val, 'baptism' AS type FROM baptism_records WHERE ${cols.baptismDate} IS NOT NULL`);
+      seasonParts.push(`SELECT MONTH(${cols.baptismDate}) AS month_num, 'baptism' AS type FROM baptism_records WHERE ${cols.baptismDate} IS NOT NULL`);
+    }
+    if (cols.marriageDate) {
+      yearParts.push(`SELECT YEAR(${cols.marriageDate}) AS year_val, 'marriage' AS type FROM marriage_records WHERE ${cols.marriageDate} IS NOT NULL`);
+      monthParts.push(`SELECT DATE_FORMAT(${cols.marriageDate}, '%Y-%m') AS month_val, 'marriage' AS type FROM marriage_records WHERE ${cols.marriageDate} IS NOT NULL`);
+      seasonParts.push(`SELECT MONTH(${cols.marriageDate}) AS month_num, 'marriage' AS type FROM marriage_records WHERE ${cols.marriageDate} IS NOT NULL`);
+    }
+    if (cols.funeralDate) {
+      yearParts.push(`SELECT YEAR(${cols.funeralDate}) AS year_val, 'funeral' AS type FROM funeral_records WHERE ${cols.funeralDate} IS NOT NULL`);
+      monthParts.push(`SELECT DATE_FORMAT(${cols.funeralDate}, '%Y-%m') AS month_val, 'funeral' AS type FROM funeral_records WHERE ${cols.funeralDate} IS NOT NULL`);
+      seasonParts.push(`SELECT MONTH(${cols.funeralDate}) AS month_num, 'funeral' AS type FROM funeral_records WHERE ${cols.funeralDate} IS NOT NULL`);
+    }
+    if (cols.baptismClergy) {
+      clergyParts.push(`SELECT TRIM(${cols.baptismClergy}) AS clergy_name FROM baptism_records WHERE ${cols.baptismClergy} IS NOT NULL AND TRIM(${cols.baptismClergy}) != ''`);
+    }
+    if (cols.marriageClergy) {
+      clergyParts.push(`SELECT TRIM(${cols.marriageClergy}) AS clergy_name FROM marriage_records WHERE ${cols.marriageClergy} IS NOT NULL AND TRIM(${cols.marriageClergy}) != ''`);
+    }
+    if (cols.funeralClergy) {
+      clergyParts.push(`SELECT TRIM(${cols.funeralClergy}) AS clergy_name FROM funeral_records WHERE ${cols.funeralClergy} IS NOT NULL AND TRIM(${cols.funeralClergy}) != ''`);
+    }
+
+    // Build queries (return empty results if no date columns found)
+    const yearQuery = yearParts.length > 0
+      ? `SELECT year_val AS year, type, COUNT(*) AS count FROM (${yearParts.join(' UNION ALL ')}) combined WHERE year_val IS NOT NULL GROUP BY year_val, type ORDER BY year_val`
+      : null;
+
+    const monthQuery = monthParts.length > 0
+      ? `SELECT month_val AS month, type, COUNT(*) AS count FROM (${monthParts.join(' UNION ALL ')}) combined WHERE month_val IS NOT NULL GROUP BY month_val, type ORDER BY month_val`
+      : null;
+
+    const seasonQuery = seasonParts.length > 0
+      ? `SELECT month_num, type, COUNT(*) AS count FROM (${seasonParts.join(' UNION ALL ')}) combined WHERE month_num IS NOT NULL GROUP BY month_num, type ORDER BY month_num`
+      : null;
+
+    const clergyQuery = clergyParts.length > 0
+      ? `SELECT clergy_name, COUNT(*) AS count FROM (${clergyParts.join(' UNION ALL ')}) combined GROUP BY clergy_name ORDER BY count DESC LIMIT 15`
+      : null;
+
+    const ageQuery = (cols.baptismDate && cols.birthDate)
+      ? `SELECT
+          CASE
+            WHEN age_days <= 90 THEN '0-3 months'
+            WHEN age_days <= 180 THEN '3-6 months'
+            WHEN age_days <= 365 THEN '6-12 months'
+            WHEN age_days <= 730 THEN '1-2 years'
+            WHEN age_days <= 1825 THEN '2-5 years'
+            ELSE '5+ years'
+          END AS age_range,
+          COUNT(*) AS count
+        FROM (
+          SELECT DATEDIFF(${cols.baptismDate}, ${cols.birthDate}) AS age_days
+          FROM baptism_records
+          WHERE ${cols.baptismDate} IS NOT NULL AND ${cols.birthDate} IS NOT NULL
+        ) ages
+        WHERE age_days >= 0
+        GROUP BY age_range
+        ORDER BY MIN(age_days)`
+      : null;
+
+    // Run all queries in parallel
+    const [
+      sacramentsByYear,
+      monthlyTrends,
+      byPriest,
+      baptismAge,
+      typeDistribution,
+      seasonalPatterns
+    ] = await Promise.all([
+      yearQuery ? pool.query(yearQuery) : [[]],
+      monthQuery ? pool.query(monthQuery) : [[]],
+      clergyQuery ? pool.query(clergyQuery) : [[]],
+      ageQuery ? pool.query(ageQuery) : [[]],
+      pool.query(`
+        SELECT 'Baptisms' AS type, COUNT(*) AS count FROM baptism_records
+        UNION ALL
+        SELECT 'Marriages' AS type, COUNT(*) AS count FROM marriage_records
+        UNION ALL
+        SELECT 'Funerals' AS type, COUNT(*) AS count FROM funeral_records
+      `),
+      seasonQuery ? pool.query(seasonQuery) : [[]],
+    ]);
+
+    // Extract rows (mysql2 returns [rows, fields])
+    const getRows = (result) => Array.isArray(result[0]) ? result[0] : result;
+
+    // Pivot helpers for Recharts format
+    const pivotByYear = (rows) => {
+      const map = {};
+      rows.forEach(r => {
+        if (!map[r.year]) map[r.year] = { year: r.year, baptism: 0, marriage: 0, funeral: 0 };
+        map[r.year][r.type] = Number(r.count);
+      });
+      return Object.values(map).sort((a, b) => a.year - b.year);
+    };
+
+    const pivotByMonth = (rows) => {
+      const map = {};
+      rows.forEach(r => {
+        if (!map[r.month]) map[r.month] = { month: r.month, baptism: 0, marriage: 0, funeral: 0 };
+        map[r.month][r.type] = Number(r.count);
+      });
+      return Object.values(map).sort((a, b) => a.month.localeCompare(b.month));
+    };
+
+    const monthNames = ['', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const pivotBySeason = (rows) => {
+      const map = {};
+      rows.forEach(r => {
+        const key = r.month_num;
+        if (!map[key]) map[key] = { month: monthNames[key] || key, baptism: 0, marriage: 0, funeral: 0 };
+        map[key][r.type] = Number(r.count);
+      });
+      return Object.values(map).sort((a, b) => monthNames.indexOf(a.month) - monthNames.indexOf(b.month));
+    };
+
+    res.json({
+      success: true,
+      data: {
+        sacramentsByYear: pivotByYear(getRows(sacramentsByYear)),
+        monthlyTrends: pivotByMonth(getRows(monthlyTrends)),
+        byPriest: getRows(byPriest).map(r => ({ name: r.clergy_name, count: Number(r.count) })),
+        baptismAge: getRows(baptismAge).map(r => ({ range: r.age_range, count: Number(r.count) })),
+        typeDistribution: getRows(typeDistribution).map(r => ({ name: r.type, value: Number(r.count) })),
+        seasonalPatterns: pivotBySeason(getRows(seasonalPatterns))
+      }
+    });
+
+  } catch (error) {
+    console.error('[OM Charts] Error fetching chart data:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to fetch chart data',
+      message: error.message
+    });
+  }
+});
+
+module.exports = router;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,1711 @@
+// ?? backend/server/index.js
+// Load centralized configuration first (this will also load .env files)
+// In src: ./config -> src/config/index.ts (compiled to dist/src/config/index.js)
+// In dist: ./config -> dist/src/config/index.js
+let serverConfig: any;
+try {
+  // Try to load from src/config (works in both src and dist after compilation)
+  serverConfig = require('./config');
+} catch (error: any) {
+  // Fallback: try alternative path (for dist environment)
+  try {
+    serverConfig = require('./config');
+  } catch (e) {
+    console.error('❌ Failed to load centralized config:', error.message);
+    console.error('   Falling back to process.env (backward compatibility)');
+    // Create a minimal config object for backward compatibility
+    const corsOrigins = process.env.CORS_ORIGINS 
+      ? process.env.CORS_ORIGINS.split(',').map((s: string) => s.trim())
+      : [
+          'https://orthodoxmetrics.com',
+          'http://orthodoxmetrics.com',
+          'https://www.orthodoxmetrics.com',
+          'http://www.orthodoxmetrics.com',
+          'http://localhost:3000',
+          'https://localhost:3000',
+          'http://localhost:5173',
+          'https://localhost:5173',
+          'http://localhost:5174',
+          'https://localhost:5174',
+          'http://192.168.1.239:5174',
+          'http://192.168.1.239:5173',
+        ];
+    serverConfig = {
+      server: {
+        env: process.env.NODE_ENV || 'development',
+        port: parseInt(process.env.PORT || '3001'),
+        host: process.env.HOST || '0.0.0.0',
+        trustProxy: process.env.TRUST_PROXY !== 'false',
+      },
+      db: {
+        app: {
+          host: process.env.DB_HOST || 'localhost',
+          user: process.env.DB_USER || 'orthodoxapps',
+          password: process.env.DB_PASSWORD || '',
+          database: process.env.DB_NAME || 'orthodoxmetrics_db',
+          port: parseInt(process.env.DB_PORT || '3306'),
+        },
+        auth: {
+          host: process.env.AUTH_DB_HOST || process.env.DB_HOST || 'localhost',
+          user: process.env.AUTH_DB_USER || process.env.DB_USER || 'orthodoxapps',
+          password: process.env.AUTH_DB_PASSWORD || process.env.DB_PASSWORD || '',
+          database: process.env.AUTH_DB_NAME || process.env.AUTH_DB || process.env.DB_NAME || 'orthodoxmetrics_db',
+          port: parseInt(process.env.AUTH_DB_PORT || process.env.DB_PORT || '3306'),
+        },
+      },
+      session: {
+        secret: process.env.SESSION_SECRET || 'dev-secret-change-in-production',
+        cookieName: process.env.SESSION_COOKIE_NAME || 'orthodoxmetrics.sid',
+        cookieDomain: process.env.SESSION_COOKIE_DOMAIN,
+        secure: process.env.SESSION_SECURE === 'true',
+        sameSite: process.env.SESSION_SAME_SITE || 'lax',
+        maxAgeMs: parseInt(process.env.SESSION_MAX_AGE_MS || '86400000'),
+        store: process.env.SESSION_STORE || 'mysql',
+      },
+      cors: {
+        allowedOrigins: corsOrigins,
+        credentials: process.env.CORS_CREDENTIALS !== 'false',
+      },
+      paths: {},
+      features: {
+        interactiveReports: process.env.FEATURE_INTERACTIVE_REPORTS !== 'false',
+        notifications: process.env.FEATURE_NOTIFICATIONS !== 'false',
+        ocr: process.env.FEATURE_OCR !== 'false',
+        certificates: process.env.FEATURE_CERTIFICATES !== 'false',
+        invoices: process.env.FEATURE_INVOICES !== 'false',
+      },
+    };
+  }
+}
+
+// Boot signature to verify PM2 is running the correct dist/index.js
+console.log('BOOT_SIGNATURE_OCR', __filename, new Date().toISOString());
+
+const express = require('express');
+const morgan = require('morgan');
+const cors = require('cors');
+const cookieParser = require('cookie-parser');
+const path = require('path');
+const fs = require('fs');
+const http = require('http');
+
+// Runtime will use dist/ as root; import session from ./config once dist is self-contained
+const sessionMiddleware = require('./config/session');
+const db = require('./config/db');
+// Once build copies middleware into dist/, use dist-local imports
+const { requestLogger, errorLogger } = require('./middleware/logger');
+const { versionSwitcherMiddleware, getBuildPath, getSelectedVersion } = require('./middleware/versionSwitcher');
+const { requestLogger: dbRequestLogger } = require('./middleware/requestLogger');
+// Import client context middleware for multi-tenant support
+const { clientContext, clientContextCleanup } = require('./middleware/clientContext');
+
+// Refactor Console router (CommonJS require for compatibility)
+let refactorConsoleRouter: any;
+try {
+  console.log('[Server] Loading Refactor Console router...');
+  refactorConsoleRouter = require('./routes/refactorConsole');
+  console.log('[Server] Refactor Console router loaded, type:', typeof refactorConsoleRouter);
+  if (refactorConsoleRouter) {
+    console.log('[Server] Router has use method:', typeof refactorConsoleRouter.use === 'function');
+    console.log('[Server] Router stack length:', refactorConsoleRouter.stack?.length || 0);
+  }
+} catch (error: any) {
+  console.error('[Server] ❌ Failed to load Refactor Console router:', error.message);
+  console.error('[Server] Error stack:', error.stack);
+  refactorConsoleRouter = null;
+}
+
+// --- API ROUTES -----------------------------------------------------
+const authRoutes = require('./routes/auth');
+const adminRoutes = require('./api/admin'); // Admin routes are in api/admin.js, not routes/admin.js
+const omtraceRoutes = require('./api/omtrace'); // OMTrace dependency analysis routes
+const maintenancePublicRoutes = require('./api/maintenance-public'); // Public maintenance status
+const adminLogsRouter = require('./api/adminLogs'); // Admin log monitoring API
+const socketService = require('./services/socketService'); // Socket.IO service for real-time log alerts
+const logMonitor = require('./services/logMonitor'); // PM2 log monitoring service
+const debugRoutes = require('./routes/debug');
+const menuManagementRoutes = require('./routes/menuManagement');
+const menuPermissionsRoutes = require('./routes/menuPermissions');
+const notesRoutes = require('./routes/notes');
+const baptismRouter = require('./routes/baptism');
+const marriageRouter = require('./routes/marriage');
+const funeralRouter = require('./routes/funeral');
+const uniqueValuesRouter = require('./routes/unique-values');
+const dropdownOptionsRouter = require('./routes/dropdownOptions');
+// Load baptismCertificates router with error handling for native module issues
+let baptismCertificatesRouter: any;
+try {
+    baptismCertificatesRouter = require('./routes/baptismCertificates');
+} catch (e: any) {
+    console.error('⚠️  [Server] Failed to load baptismCertificates router:', e.message);
+    console.error('   Creating stub router. Certificate routes will return 503.');
+    // Create a stub router that returns 503 for all requests
+    const express = require('express');
+    const stubRouter = express.Router();
+    stubRouter.use((req: any, res: any) => {
+        res.status(503).json({
+            success: false,
+            error: 'Service temporarily unavailable',
+            message: 'Baptism certificates module failed to load. Native dependencies may need rebuilding.',
+            details: e.message
+        });
+    });
+    baptismCertificatesRouter = stubRouter;
+}
+// Load marriageCertificates router with error handling for native module issues
+let marriageCertificatesRouter: any;
+try {
+    marriageCertificatesRouter = require('./routes/marriageCertificates');
+} catch (e: any) {
+    console.error('⚠️  [Server] Failed to load marriageCertificates router:', e.message);
+    const express = require('express');
+    const stubRouter = express.Router();
+    stubRouter.use((req: any, res: any) => {
+        res.status(503).json({
+            success: false,
+            error: 'Service temporarily unavailable',
+            message: 'Marriage certificates module failed to load. Native dependencies may need rebuilding.',
+            details: e.message
+        });
+    });
+    marriageCertificatesRouter = stubRouter;
+}
+// Load churchCertificates router with error handling for native module issues
+let churchCertificatesRouter: any;
+try {
+    churchCertificatesRouter = require('./api/churchCertificates');
+} catch (e: any) {
+    console.error('⚠️  [Server] Failed to load churchCertificates router:', e.message);
+    const express = require('express');
+    const stubRouter = express.Router({ mergeParams: true });
+    stubRouter.use((req: any, res: any) => {
+        res.status(503).json({
+            success: false,
+            error: 'Service temporarily unavailable',
+            message: 'Church certificates module failed to load. Canvas native module needs rebuilding.',
+            details: e.message,
+            fix: 'Run: cd /var/www/orthodoxmetrics/prod/server && npm rebuild canvas'
+        });
+    });
+    churchCertificatesRouter = stubRouter;
+}
+const calendarRouter = require('./routes/calendar');
+const dashboardRouter = require('./routes/dashboard');
+const invoicesRouter = require('./routes/invoices');
+const invoicesMultilingualRouter = require('./routes/invoicesMultilingual');
+const enhancedInvoicesRouter = require('./routes/enhancedInvoices');
+const billingRouter = require('./routes/billing');
+const churchesRouter = require('./routes/churches');
+const provisionRouter = require('./routes/provision');
+// Load certificates router with error handling for native module issues
+let certificatesRouter: any;
+try {
+    certificatesRouter = require('./routes/certificates');
+} catch (e: any) {
+    console.error('⚠️  [Server] Failed to load certificates router:', e.message);
+    const express = require('express');
+    const stubRouter = express.Router();
+    stubRouter.use((req: any, res: any) => {
+        res.status(503).json({
+            success: false,
+            error: 'Service temporarily unavailable',
+            message: 'Certificates module failed to load. Native dependencies may need rebuilding.',
+            details: e.message
+        });
+    });
+    certificatesRouter = stubRouter;
+}
+const ecommerceRouter = require('./routes/ecommerce');
+const { router: notificationRouter } = require('./routes/notifications');
+const kanbanRouter = require('./routes/kanban');
+const { router: logsRouter } = require('./routes/logs');
+const globalOmaiRouter = require('./routes/globalOmai');
+const versionRouter = require('./routes/version');
+const systemStatusRouter = require('./api/systemStatus');
+const dailyTasksRouter = require('./api/dailyTasks');
+const omDailyRouter = require('./routes/om-daily');
+const crmRouter = require('./routes/crm');
+const analyticsRouter = require('./routes/analytics'); // US Church Map analytics
+const omChartsRouter = require('./api/om-charts'); // OM Charts: graphical charts from church records
+const dashboardHomeRouter = require('./api/dashboard-home'); // Dashboard Home: summary data for church dashboard
+const { routesRouter: apiExplorerRoutesRouter, testsRouter: apiExplorerTestsRouter } = require('./api/apiExplorer');
+// Add missing router imports
+const churchRecordsRouter = require('./routes/records'); // Church records functionality
+const powerSearchRouter = require('./api/powerSearchApi'); // Power Search API for advanced record filtering
+const uploadTokenRouter = require('./routes/uploadToken');
+const templatesRouter = require('./routes/templates');
+const globalTemplatesRouter = require('./routes/globalTemplates');
+// Load admin templates router (for /api/admin/templates)
+let adminTemplatesRouter;
+try {
+  adminTemplatesRouter = require('./routes/admin/templates');
+  console.log('✅ [Server] Admin templates router loaded successfully');
+} catch (error) {
+  console.error('❌ [Server] Failed to load admin templates router:', error);
+  // Create a dummy router that returns 500 to prevent crashes
+  const express = require('express');
+  adminTemplatesRouter = express.Router();
+  adminTemplatesRouter.use((req, res) => {
+    res.status(500).json({ success: false, error: 'Admin templates router failed to load' });
+  });
+}
+const metricsRouter = require('./routes/metrics');
+// Removed duplicate: recordsRouter - already loaded as churchRecordsRouter
+const importRecordsRouter = require('./routes/records-import'); // Records import functionality
+const scriptRunnerRouter = require('./routes/runScript'); // Secure script runner for admin users
+
+// Import client API router for multi-tenant client endpoints (with safe loader)
+let clientApiRouter;
+try {
+  clientApiRouter = require('./routes/clientApi');
+  console.log('✅ [Server] Client API router loaded successfully');
+} catch (error) {
+  console.error('❌ [Server] Failed to load client API router:', error.message);
+  console.error('   This is non-fatal - server will continue without client API routes');
+  // Create a dummy router that returns 501 (Not Implemented) to prevent crashes
+  const express = require('express');
+  clientApiRouter = express.Router();
+  clientApiRouter.use((req, res) => {
+    res.status(501).json({ 
+      error: 'Client API feature not available',
+      message: 'Router module not found. Check build process.'
+    });
+  });
+}
+// Import admin system management router
+const adminSystemRouter = require('./routes/adminSystem');
+// Import church admin management router for multi-database support
+const churchAdminRouter = require('./routes/admin/church');
+// Import churches management router for church provisioning
+const churchesManagementRouter = require('./routes/admin/churches');
+const sessionsRouter = require('./routes/admin/sessions');
+const usersRouter = require('./routes/admin/users');
+const adminInvitesRouter = require('./routes/admin/invites');
+const inviteRegisterRouter = require('./routes/invite-register');
+const activityLogsRouter = require('./routes/admin/activity-logs');
+// Import new modular admin route files (extracted from monolithic admin.js)
+const churchUsersRouter = require('./routes/admin/church-users');
+const churchDatabaseRouter = require('./routes/admin/church-database');
+const userRouter = require('./routes/user'); // User routes
+// Load funeralCertificates router with error handling for native module issues
+let funeralCertificatesRouter: any;
+try {
+    funeralCertificatesRouter = require('./routes/funeralCertificates');
+} catch (e: any) {
+    console.error('⚠️  [Server] Failed to load funeralCertificates router:', e.message);
+    const express = require('express');
+    const stubRouter = express.Router();
+    stubRouter.use((req: any, res: any) => {
+        res.status(503).json({
+            success: false,
+            error: 'Service temporarily unavailable',
+            message: 'Funeral certificates module failed to load. Native dependencies may need rebuilding.',
+            details: e.message
+        });
+    });
+    funeralCertificatesRouter = stubRouter;
+}
+// Import pages and uploads management routes
+const pagesRouter = require('./routes/pages');
+const uploadsRouter = require('./routes/uploads');
+const orthodoxCalendarRouter = require('./routes/orthodoxCalendar');
+// Import global images management router for super admin content management
+const globalImagesRouter = require('./routes/admin/globalImages');
+// Import OCR feeder router for content ingestion
+const feederRouter = require('./routes/feeder');
+// Import service management router for system monitoring and control
+const servicesRouter = require('./routes/admin/services');
+// Import components management router for system component control
+const componentsRouter = require('./routes/admin/components');
+const settingsRouter = require('./routes/settings');
+// Import system update routes (safe to fail if not available)
+let systemUpdateRouter;
+try {
+    systemUpdateRouter = require('./routes/system');
+    console.log('✅ [Server] System update routes loaded');
+} catch (error) {
+    console.warn('⚠️  [Server] System update routes not available:', error.message);
+    // Create stub router to prevent crashes
+    systemUpdateRouter = require('express').Router();
+    systemUpdateRouter.all('*', (req, res) => {
+        res.status(503).json({
+            success: false,
+            error: 'System update functionality not available',
+            message: 'The update system is not configured on this server'
+        });
+    });
+}
+// Import social module routers
+const socialBlogRouter = require('./routes/social/blog');
+const socialFriendsRouter = require('./routes/social/friends');
+const socialChatRouter = require('./routes/social/chat');
+const socialNotificationsRouter = require('./routes/social/notifications');
+// Import backup management routers
+const backupRouter = require('./api/backups'); // New database-integrated backup API
+const legacyBackupRouter = require('./routes/admin/backups'); // Legacy backup router
+// Import original backup system router
+const originalBackupRouter = require('./routes/backup');
+// Import NFS backup configuration router
+const nfsBackupRouter = require('./routes/admin/nfs-backup');
+// Import Big Book system router
+const bigBookRouter = require('./routes/bigbook');
+const libraryRouter = require('./routes/library');
+const menuRouter = require('./routes/menu');
+
+// Import OM-AI system router
+const omaiRouter = require('./routes/omai');
+const omaiMemoriesRouter = require('./routes/omai/memories');
+// const omaiRouter = require('./routes/omai-test'); // TEMPORARY TEST
+const ombRouter = require('./routes/omb');
+// Import mock APIs to prevent 404 errors
+const mockApisRouter = require('./routes/mock-apis');
+// Import JIT Terminal router for secure server access (with error handling)
+let jitTerminalRouter: any;
+try {
+    jitTerminalRouter = require('./routes/jit-terminal');
+} catch (e: any) {
+    console.error('⚠️  [Server] Failed to load jit-terminal router:', e.message);
+    const express = require('express');
+    const stubRouter = express.Router();
+    stubRouter.use((req: any, res: any) => {
+        res.status(503).json({
+            success: false,
+            error: 'Service temporarily unavailable',
+            message: 'JIT Terminal module failed to load. Native dependencies may need rebuilding.',
+            details: e.message,
+            fix: 'Run: cd /var/www/orthodoxmetrics/prod/server && npm rebuild node-pty'
+        });
+    });
+    // Stub WebSocket setup function
+    stubRouter.setupJITWebSocket = () => {
+        console.warn('⚠️  [Server] JIT WebSocket setup skipped - module not available');
+        return null;
+    };
+    jitTerminalRouter = stubRouter;
+}
+// Import Backend Diagnostics router for system monitoring
+const backendDiagnosticsRouter = require('./routes/backend_diagnostics');
+// Import Build System router for build orchestration
+const buildRouter = require('./routes/build');
+// Import AI Administration Panel router
+const aiRouter = require('./routes/ai');
+// Import Logger API router for SUCCESS/DEBUG log support
+const loggerRouter = require('./routes/logger');
+// Import GitHub Issues router for error reporting
+const githubIssuesRouter = require('./routes/github-issues');
+const routerMenuRouter = require('./routes/routerMenu');
+const { registerRouterMenuStudio } = require("./features/routerMenuStudio");
+// Import Router/Menu Studio feature (JavaScript version)
+// Import Router/Menu Studio feature
+
+const app = express();
+const server = http.createServer(app);
+
+// NOTE: Socket.IO is initialized once by websocketService (at server startup below).
+// socketService was previously initialized here too, causing duplicate Socket.IO servers
+// on the same HTTP server → "Invalid frame header" WebSocket errors.
+// websocketService already handles admin log streaming via broadcastLogEntry().
+
+// Trust proxy configuration (from centralized config)
+app.set('trust proxy', serverConfig.server.trustProxy ? 1 : 0);
+
+// --- CORS SETUP -----------------------------------------------------
+// Use centralized configuration for CORS
+const allowedOrigins = serverConfig.cors.allowedOrigins;
+
+app.use(cors({
+  origin: function (origin, callback) {
+    // Allow requests with no origin (like mobile apps or curl requests)
+    if (!origin) return callback(null, true);
+    if (allowedOrigins.includes(origin)) return callback(null, true);
+    console.warn('❌ CORS blocked origin:', origin);
+    callback(new Error('CORS policy does not allow access from origin: ' + origin));
+  },
+  credentials: serverConfig.cors.credentials,
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'Accept', 'Origin'],
+  exposedHeaders: ['Set-Cookie']
+}));
+
+const PORT = serverConfig.server.port;
+const HOST = serverConfig.server.host;
+
+// 🔧 FIXED: Middleware order is CRITICAL for session authentication
+console.log('🔧 Setting up middleware in correct order...');
+
+// Log auth-optional paths configuration
+const { logAuthConfiguration } = require('./middleware/auth');
+logAuthConfiguration();
+
+// 1. Logging middleware (first)
+app.use(morgan('dev'));
+
+// 2. Body parsing middleware (before session)
+// Note: express.json() and express.urlencoded() automatically skip multipart/form-data
+// So they won't interfere with multer file uploads
+app.use(express.json({ limit: '50mb' }));
+app.use(express.urlencoded({ extended: true, limit: '50mb' }));
+// !! CRITICAL — cookieParser MUST receive the session secret — SEE server/CONFIG.md !!
+// Without the secret, express-session's signed cookies break and every request gets a new session.
+// This caused a production outage on 2026-02-02. NEVER call cookieParser() without the secret.
+console.log('🔑 cookieParser secret check:', {
+  length: serverConfig.session.secret?.length || 0,
+  prefix: serverConfig.session.secret?.substring(0, 8) || 'MISSING',
+});
+app.use(cookieParser(serverConfig.session.secret));
+
+// Multer setup for file uploads (must be after body parsers)
+const multer = require('multer');
+const upload = multer({ 
+  dest: 'uploads/temp/',
+  limits: { fileSize: 100 * 1024 * 1024 } // 100MB limit
+});
+
+// 3. Session middleware (CRITICAL: before any auth-protected routes)
+console.log('🍪 Applying session middleware...');
+app.use(sessionMiddleware);
+
+// 4. Database routing middleware
+const { databaseRouter } = require('./middleware/databaseRouter');
+app.use(databaseRouter);
+
+// 4a. Database-backed API logger (captures all routes + status code + duration)
+app.use(dbRequestLogger);
+
+// 5. Request debugging (after session, before routes)
+app.use((req, res, next) => {
+  // Log ALL POST requests immediately (especially uploads)
+  if (req.method === 'POST') {
+    console.log(`📤📤📤 POST REQUEST RECEIVED: ${req.method} ${req.originalUrl || req.path}`, {
+      path: req.path,
+      originalUrl: req.originalUrl,
+      url: req.url,
+      contentType: req.headers['content-type'],
+      contentLength: req.headers['content-length'],
+      hasBody: !!req.body,
+      bodyKeys: req.body ? Object.keys(req.body) : [],
+      sessionID: req.sessionID,
+      sessionUser: req.session?.user?.email || 'Not authenticated',
+    });
+  } else {
+    // Only log non-POST requests if they're not polling endpoints
+    if (!req.path.includes('notifications') && !req.path.includes('counts')) {
+      console.log(`🌍 Request: ${req.method} ${req.path}`);
+    }
+  }
+  next();
+});
+
+// --- ROUTES ---------------------------------------------------------
+console.log('🛤️  Setting up routes in correct order...');
+
+// ============================================================================
+// PUBLIC HEALTH ENDPOINTS - Registered BEFORE all other routes
+// ============================================================================
+// These MUST be defined before any auth middleware or routers that might
+// intercept them. Direct app.get() registration ensures they are never blocked.
+
+// GET /api/system/health - System health check (NO AUTH)
+app.get('/api/system/health', async (req, res) => {
+  try {
+    const dbStatus = await db.testConnection();
+    const memoryUsage = process.memoryUsage();
+    
+    res.json({
+      status: dbStatus.success ? 'ok' : 'error',
+      uptime: Math.floor(process.uptime()),
+      timestamp: new Date().toISOString(),
+      database: dbStatus,
+      memory: {
+        heapUsed: Math.round(memoryUsage.heapUsed / 1024 / 1024),
+        heapTotal: Math.round(memoryUsage.heapTotal / 1024 / 1024),
+        rss: Math.round(memoryUsage.rss / 1024 / 1024),
+      }
+    });
+  } catch (err) {
+    res.status(500).json({ 
+      status: 'error', 
+      message: err.message,
+      timestamp: new Date().toISOString()
+    });
+  }
+});
+
+// GET /api/maintenance/status - Maintenance status check (NO AUTH)
+app.get('/api/maintenance/status', (req, res) => {
+  try {
+    const fs = require('fs');
+    const MAINTENANCE_FILE = '/var/www/orthodoxmetrics/maintenance.on';
+    const exists = fs.existsSync(MAINTENANCE_FILE);
+    let startTime = null;
+    
+    if (exists) {
+      const stats = fs.statSync(MAINTENANCE_FILE);
+      startTime = stats.mtime.toISOString();
+    }
+    
+    res.json({
+      maintenance: exists,
+      status: exists ? 'updating' : 'production',
+      startTime: startTime,
+      message: exists ? 'System is currently under maintenance' : null
+    });
+  } catch (error) {
+    res.json({
+      maintenance: false,
+      status: 'production',
+      message: null
+    });
+  }
+});
+
+console.log('✅ Public health endpoints registered (no auth required)');
+// ============================================================================
+
+// Removed root route to allow SPA to serve index.html
+
+// --- DEBUG HELPERS (read‑only) ------------------------------------
+app.get('/__debug/current-db', async (req, res) => {
+  try {
+    const { getAuthPool } = require('./config/db');
+    const pool = getAuthPool();
+    const [rows] = await pool.query('SELECT DATABASE() AS db');
+    res.json({ db: rows?.[0]?.db || null });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.get('/__debug/session', (req, res) => {
+  res.json({
+    hasSession: !!req.session,
+    sessionID: req.sessionID || null,
+    user: req.session?.user || null
+  });
+});
+
+// Public routes first (no authentication required)
+app.use('/api/invite', inviteRegisterRouter); // Public invite validation + registration
+console.log('✅ [Server] Mounted /api/invite route (public invite registration)');
+app.use('/api/churches', churchesRouter);
+// Mount churches router at /api/my to handle /api/my/churches
+app.use('/api/my', churchesRouter);
+
+// Authentication routes (no auth required for login itself)
+
+// Register Router/Menu Studio feature (requires authentication)
+app.use('/api/auth', authRoutes);
+
+// Internal build events endpoint (token-protected, no auth middleware)
+const buildEventsRouter = require('./routes/internal/buildEvents');
+app.use('/api/internal', buildEventsRouter);
+console.log('✅ [Server] Mounted /api/internal/build-events route');
+
+// 🔧 FIXED: Specific admin routes BEFORE general admin routes
+app.use('/api/admin/church', churchAdminRouter);
+
+app.use('/api/admin/system', adminSystemRouter);
+// Admin churches routes - mount compatibility router first to catch legacy paths
+const churchesCompatRouter = require('./routes/admin/churches-compat');
+// Mount compatibility router for both /churches (plural) and /church (singular) paths
+app.use('/api/admin/churches', churchesCompatRouter);
+app.use('/api/admin/church', churchesCompatRouter); // Legacy singular path support
+// Mount main churches router after compatibility router
+app.use('/api/admin/churches', churchesManagementRouter);
+app.use('/api/admin/sessions', sessionsRouter);
+app.use('/api/admin/users', usersRouter); // 🎯 CRITICAL: This route was being intercepted
+app.use('/api/admin/invites', adminInvitesRouter);
+console.log('✅ [Server] Mounted /api/admin/invites route (invite user management)');
+// Removed duplicate mounting - users are managed through /api/admin/users
+app.use('/api/admin/activity-logs', activityLogsRouter);
+app.use('/api/admin/templates', adminTemplatesRouter);
+console.log('✅ [Server] Mounted /api/admin/templates route');
+app.use('/api/admin/logs', adminLogsRouter);
+console.log('✅ [Server] Mounted /api/admin/logs route (log monitoring)');
+const logSearchRouter = require('./routes/admin/log-search');
+app.use('/api/admin/log-search', logSearchRouter);
+console.log('✅ [Server] Mounted /api/admin/log-search route');
+app.use('/api/admin/global-images', globalImagesRouter);
+// Build status endpoint for admins
+const buildStatusRouter = require('./routes/admin/buildStatus');
+app.use('/api/admin', buildStatusRouter);
+console.log('✅ [Server] Mounted /api/admin/build-status route');
+
+// Admin auth check (for Nginx auth_request)
+const authCheckRouter = require('./routes/admin/auth-check');
+app.use('/api/admin/auth', authCheckRouter);
+console.log('✅ [Server] Mounted /api/admin/auth/check route (for Nginx auth_request)');
+
+// OM-Ops Reports Hub (includes Git Operations)
+const opsRouter = require('./routes/admin/ops');
+app.use('/api/ops', opsRouter);
+console.log('✅ [Server] Mounted /api/ops route (includes Git Operations)');
+
+// Health/Diagnostics endpoint for route verification (admin-only)
+const { requireAuth: requireAuthForRoutes } = require('./middleware/requireAuth');
+const requireAdminForRoutes = (req, res, next) => {
+  const user = req.session?.user || req.user;
+  if (!user) {
+    return res.status(401).json({ success: false, error: 'Authentication required' });
+  }
+  const userRole = user.role;
+  if (userRole !== 'admin' && userRole !== 'super_admin') {
+    return res.status(403).json({ success: false, error: 'Admin access required' });
+  }
+  next();
+};
+app.get('/api/admin/_routes', requireAuthForRoutes, requireAdminForRoutes, (req, res) => {
+  const routes = {
+    success: true,
+    timestamp: new Date().toISOString(),
+    entrypoint: 'dist/index.js (compiled from src/index.ts)',
+    routes: {
+      '/api/admin/templates': {
+        mounted: true,
+        router: 'routes/admin/templates',
+        methods: ['GET', 'POST', 'PUT', 'DELETE']
+      },
+      '/api/admin/churches': {
+        mounted: true,
+        router: 'routes/admin/churches',
+        methods: ['GET', 'POST', 'PUT', 'DELETE']
+      },
+      '/api/admin/users': {
+        mounted: true,
+        router: 'routes/admin/users',
+        methods: ['GET', 'POST', 'PUT', 'DELETE']
+      }
+    },
+    build_info: {
+      node_version: process.version,
+      node_env: serverConfig.server.env,
+      port: serverConfig.server.port
+    }
+  };
+  res.json(routes);
+});
+app.use('/api/feeder', feederRouter);
+app.use('/api/backups', backupRouter);
+app.use('/api/backup', originalBackupRouter);
+app.use('/api/admin/nfs-backup', nfsBackupRouter);
+const socialPermissionsRouter = require('./routes/admin/social-permissions');
+const menuPermissionsRouter = require('./routes/admin/menu-permissions');
+const menuPermissionsApiRouter = require('./routes/menuPermissionsApi'); // Enhanced menu permissions API
+const headlinesRouter = require('./routes/headlines');
+const headlinesConfigRouter = require('./routes/headlines-config');
+app.use('/api/admin/social-permissions', socialPermissionsRouter);
+app.use('/api/admin/menu-permissions', menuPermissionsRouter);
+app.use('/api/menu-permissions', menuPermissionsApiRouter); // Enhanced menu configuration API
+app.use('/api/headlines', headlinesRouter);
+app.use('/api/headlines/config', headlinesConfigRouter);
+app.use('/api/admin/services', servicesRouter);
+app.use('/api/admin/components', componentsRouter);
+// OMAI-Spin environment mirroring routes
+const omaiSpinRouter = require('./routes/admin/omaiSpin');
+app.use('/api/admin/omai-spin', omaiSpinRouter);
+app.use('/api/settings', settingsRouter);
+app.use('/api/system', systemUpdateRouter); // System update routes (super_admin only, with safe fallback)
+console.log('✅ [Server] Mounted /api/system route (updates, build-info)');
+// Import unified backup routes
+const backupsRouter = require('./routes/backups');
+app.use('/api/backups', backupsRouter);
+console.log('✅ [Server] Mounted /api/backups route (backup management)');
+app.use('/api/build', buildRouter);
+app.use('/api/ai', aiRouter);
+// Logger API routes for SUCCESS/DEBUG log support  
+app.use('/api/logger', loggerRouter);
+// OMAI Logger API routes for error tracking database
+const { router: omaiLoggerRouter } = require('./routes/omaiLogger');
+app.use('/api/omai-logger', omaiLoggerRouter);
+// GitHub Issues API routes for error reporting
+app.use('/api/errors', githubIssuesRouter);
+
+// Big Book system routes
+app.use('/api/bigbook', bigBookRouter);
+// OM-Library routes (documentation library indexed by om-librarian)
+app.use('/api/library', libraryRouter);
+console.log('✅ [Server] Mounted /api/library routes (OM-Library documentation)');
+// Menu API routes for super_admin editable navigation
+app.use('/api', menuRouter);
+console.log('✅ [Server] Mounted /api/ui/menu and /api/admin/menus routes (Editable Menu System)');
+// OM-AI system routes
+app.use('/api/omai', omaiRouter);
+app.use('/api/omai/memories', omaiMemoriesRouter);
+// Global OMAI system routes for site-wide AI assistance
+app.use('/api/omai/global', globalOmaiRouter); // Changed to avoid conflict with /api/omai
+app.use('/api/omb', ombRouter);
+// JIT Terminal routes for secure server access
+app.use('/api/jit', jitTerminalRouter);
+// Backend Diagnostics routes for system monitoring (super_admin only)
+app.use('/api/server', backendDiagnosticsRouter);
+// 🔧 NEW: Modular admin routes (extracted from monolithic admin.js)
+app.use('/api/admin/church-users', churchUsersRouter);
+app.use('/api/admin/church-database', churchDatabaseRouter);
+
+// Impersonation ("Login As") routes (auth checked inside each handler)
+const impersonateRouter = require('./api/impersonate');
+app.use('/api/admin/impersonate', impersonateRouter);
+console.log('✅ [Server] Mounted /api/admin/impersonate route');
+
+// General admin routes (AFTER specific routes to prevent conflicts)
+app.use('/api/admin', adminRoutes);
+console.log(`✅ Admin routes mounted at /api/admin from ${require.resolve('./api/admin')}`);
+
+// OMTrace dependency analysis routes (admin-only)
+app.use('/api/omtrace', omtraceRoutes);
+console.log('✅ [Server] Mounted /api/omtrace routes (dependency analysis)');
+
+// Public maintenance status (no auth — polled by front-end)
+app.use('/api/maintenance', maintenancePublicRoutes);
+console.log('✅ [Server] Mounted /api/maintenance routes (public status)');
+
+app.use('/api/version', versionRouter); // Version switcher for superadmins
+app.use('/api/system', systemStatusRouter); // System status for admin HUD
+app.use('/api/system', apiExplorerRoutesRouter); // API Explorer route introspection (super_admin)
+app.use('/api/admin/api-tests', apiExplorerTestsRouter); // API Explorer test cases CRUD + runner (super_admin)
+console.log('✅ [Server] Mounted /api/system/routes and /api/admin/api-tests (API Explorer)');
+app.use('/api/admin/tasks', dailyTasksRouter); // Daily tasks management
+app.use('/api/om-daily', omDailyRouter); // OM Daily work pipelines
+console.log('✅ [Server] Mounted /api/om-daily routes (Work Pipelines)');
+app.use('/api/crm', crmRouter); // CRM pipeline & outreach
+console.log('✅ [Server] Mounted /api/crm routes (CRM & Outreach)');
+app.use('/api/analytics', analyticsRouter); // US Church Map analytics
+console.log('✅ [Server] Mounted /api/analytics routes (US Church Map)');
+app.use('/api/churches/:churchId/charts', omChartsRouter); // OM Charts
+console.log('✅ [Server] Mounted /api/churches/:churchId/charts routes (OM Charts)');
+app.use('/api/churches/:churchId/dashboard', dashboardHomeRouter); // Dashboard Home
+console.log('✅ [Server] Mounted /api/churches/:churchId/dashboard routes (Dashboard Home)');
+
+// Other authenticated routes
+app.use('/api/user', userRouter);
+app.use('/api/church-records', churchRecordsRouter);
+app.use('/api/churches/:churchId/records', churchRecordsRouter);
+
+// Power Search API - Advanced record filtering with server-side pagination
+// Feature can be disabled per-church via power_search_enabled flag
+app.use('/api/records', powerSearchRouter);
+console.log('[BOOT] Power Search routes mounted at /api/records');
+
+app.use('/api/kanban', kanbanRouter);
+
+// User profile routes (authenticated)
+const userProfileRouter = require('./routes/user-profile');
+app.use('/api/user/profile', userProfileRouter);
+
+// Profile image upload routes (avatar + banner)
+const profileUploadRouter = require('./routes/upload');
+app.use('/api/upload', profileUploadRouter);
+
+// Contact form (public - no auth required)
+app.post('/api/contact', async (req: any, res: any) => {
+  try {
+    const { firstName, lastName, phone, email, enquiryType, message } = req.body;
+    if (!firstName || !lastName || !email || !phone || !message) {
+      return res.status(400).json({ success: false, message: 'All required fields must be filled out.' });
+    }
+    // Send email to info@orthodoxmetrics.com
+    const { sendContactEmail } = require('./utils/emailService');
+    const emailResult = await sendContactEmail({ firstName, lastName, phone, email, enquiryType, message });
+    if (!emailResult.success) {
+      console.error('Contact email failed:', emailResult.error);
+    }
+    // Create contact_us notification for all super_admins
+    try {
+      const { getAppPool } = require('./config/db-compat');
+      const [admins] = await getAppPool().query(
+        "SELECT id FROM orthodoxmetrics_db.users WHERE role = 'super_admin' AND is_active = 1"
+      );
+      const { notificationService } = require('./api/notifications');
+      const enquiryLabels: Record<string, string> = {
+        general: 'General Enquiry', parish_registration: 'Parish Registration',
+        records: 'Records & Certificates', technical: 'Technical Support',
+        billing: 'Billing & Pricing', other: 'Other',
+      };
+      for (const admin of admins) {
+        await notificationService.createNotification(
+          admin.id,
+          'contact_us',
+          'New Contact Form Submission',
+          `${firstName} ${lastName} (${email}) sent a ${enquiryLabels[enquiryType] || enquiryType} enquiry.`,
+          {
+            priority: 'normal',
+            actionUrl: null,
+            data: { firstName, lastName, email, phone, enquiryType, message: message.substring(0, 500) },
+          }
+        );
+      }
+      console.log(`📬 Contact Us notification sent to ${admins.length} super_admin(s)`);
+    } catch (notifErr: any) {
+      console.error('Contact notification failed (non-fatal):', notifErr.message);
+    }
+    res.json({ success: true, message: 'Your message has been sent successfully.' });
+  } catch (error: any) {
+    console.error('Contact form error:', error);
+    res.status(500).json({ success: false, message: 'Failed to send your message. Please try again later.' });
+  }
+});
+
+// Notification routes (authenticated)
+app.use('/api', notificationRouter);
+
+// Social module routes
+app.use('/api/social/blog', socialBlogRouter);
+app.use('/api/social/friends', socialFriendsRouter);
+app.use('/api/social/chat', socialChatRouter);
+app.use('/api/social/notifications', socialNotificationsRouter);
+
+// OM Profile routes (for user profiles)
+const omProfileRouter = require('./routes/om/profile');
+app.use('/api/om/profile', omProfileRouter);
+
+// Record management routes
+app.use('/api/baptism-records', baptismRouter);
+app.use('/api/marriage-records', marriageRouter);
+app.use('/api/funeral-records', funeralRouter);
+app.use('/api/unique-values', uniqueValuesRouter);
+
+// Certificate routes
+app.use('/api/baptismCertificates', baptismCertificatesRouter);
+// Certificate routes
+app.use('/api/certificate/baptism', baptismCertificatesRouter);
+app.use('/api/marriageCertificates', marriageCertificatesRouter);
+app.use('/api/certificate/marriage', marriageCertificatesRouter);
+app.use('/api/funeralCertificates', funeralCertificatesRouter);
+app.use('/api/certificate/funeral', funeralCertificatesRouter);
+
+// Church-specific certificate routes (uses church database pools)
+app.use('/api/church/:churchId/certificate', churchCertificatesRouter);
+
+// Upload token management routes
+app.use('/api', uploadTokenRouter);
+
+// Business routes
+app.use('/api/calendar', calendarRouter);
+app.use('/api/orthodox-calendar', orthodoxCalendarRouter); // Changed to avoid conflict with /api/calendar
+app.use('/api/dashboard', dashboardRouter);
+app.use('/api/invoices', invoicesRouter);
+app.use('/api/invoices-enhanced', enhancedInvoicesRouter);
+app.use('/api/invoices-ml', invoicesMultilingualRouter);
+app.use('/api/enhanced-invoices', enhancedInvoicesRouter);
+app.use('/api/billing', billingRouter);
+app.use('/api/provision', provisionRouter);
+app.use('/api/certificates', certificatesRouter);
+app.use('/api/eCommerce', ecommerceRouter);
+app.use('/api/admin/logs', logsRouter); // 🔧 FIXED: Mount logsRouter under /api/admin/logs
+app.use("/api/logs", logsRouter); // Add logs router at /api/logs for admin-errors
+
+// CMS Routes
+app.use('/api/pages', pagesRouter);
+app.use('/api/blogs', require('./routes/blogs')); // Blog functionality for Task 132
+app.use('/api/uploads', uploadsRouter);
+// Add middleware to log ALL requests to /api/gallery before routing
+app.use('/api/gallery', (req, res, next) => {
+  console.log(`🖼️🖼️🖼️ GALLERY REQUEST: ${req.method} ${req.path}`, {
+    originalUrl: req.originalUrl,
+    url: req.url,
+    contentType: req.headers['content-type'],
+    contentLength: req.headers['content-length'],
+    sessionID: req.sessionID,
+    sessionUser: req.session?.user?.email || 'Not authenticated',
+  });
+  next();
+});
+
+const galleryRouter = require('./routes/gallery');
+console.log('🖼️ Registering /api/gallery routes');
+app.use('/api/gallery', galleryRouter);
+console.log('✅ /api/gallery routes registered');
+const docsRouter = require('./routes/docs');
+console.log('📚 Registering /api/docs routes');
+app.use('/api/docs', docsRouter);
+console.log('✅ /api/docs routes registered');
+
+// User Files Routes
+const userFilesRouter = require('./routes/user-files');
+console.log('👤 Registering /api/user-files routes');
+app.use('/api/user-files', userFilesRouter);
+console.log('✅ /api/user-files routes registered');
+
+// Conversation Log Routes (super_admin only)
+const conversationLogRouter = require('./routes/conversation-log');
+app.use('/api/conversation-log', requireAuthForRoutes, requireAdminForRoutes, conversationLogRouter);
+console.log('✅ [Server] Mounted /api/conversation-log routes');
+
+// OCR Feeder Worker — polls platform DB for pending jobs
+try {
+  const { workerLoop } = require('./workers/ocrFeederWorker');
+  workerLoop().catch((err: any) => console.error('[OCR Worker] Fatal error:', err));
+  console.log('✅ [OCR] Feeder worker started');
+} catch (e: any) {
+  console.warn('⚠️  [OCR] Failed to start feeder worker:', e.message);
+}
+
+// OCR Routes — modular routers (admin + church-scoped)
+try {
+  const { mountOcrRoutes } = require('./routes/ocr');
+  mountOcrRoutes(app, upload);
+} catch (e: any) {
+  console.error('❌ [OCR] Failed to mount OCR routes:', e.message);
+}
+
+// Survey Routes (Task 131)
+app.use('/api/survey', require('./routes/survey')); // OMSiteSurvey functionality
+
+// Menu and admin routes
+app.use('/api/menu-management', menuManagementRoutes);
+// Removed duplicate - using enhanced menu permissions API at line 234
+app.use('/api/notes', notesRoutes);
+// Removed duplicate kanban router - already mounted at line 270
+// Removed duplicate survey router - already mounted at line 323
+
+// Multi-tenant client routes
+app.use('/client/:clientSlug/api', clientContext, clientApiRouter, clientContextCleanup);
+
+// ?? Mount dropdownOptions routes here to prevent override
+app.use('/api', dropdownOptionsRouter);
+
+// Records import routes
+app.use('/api/records/import', importRecordsRouter);
+
+// Interactive Reports routes (with safe loader to prevent crashes)
+let interactiveReportsRouter;
+try {
+  interactiveReportsRouter = require('./routes/interactiveReports');
+  console.log('✅ [Server] Interactive reports router loaded successfully');
+  app.use('/api/records/interactive-reports', interactiveReportsRouter);
+  app.use('/r/interactive', interactiveReportsRouter); // Public routes
+} catch (error) {
+  console.error('❌ [Server] Failed to load interactive reports router:', error.message);
+  console.error('   This is non-fatal - server will continue without interactive reports feature');
+  // Create a dummy router that returns 501 (Not Implemented) to prevent crashes
+  const express = require('express');
+  interactiveReportsRouter = express.Router();
+  interactiveReportsRouter.use((req, res) => {
+    res.status(501).json({ 
+      error: 'Interactive reports feature not available',
+      message: 'Router module not found. Check build process.'
+    });
+  });
+  app.use('/api/records/interactive-reports', interactiveReportsRouter);
+  app.use('/r/interactive', interactiveReportsRouter);
+}
+
+// Additional utility routes expected by frontend
+app.get('/api/dropdown-options', (req, res) => {
+  // Return dropdown options for forms
+  res.json({
+    countries: ['United States', 'Canada', 'Greece', 'Romania', 'Russia'],
+    states: ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA'],
+    languages: ['en', 'gr', 'ru', 'ro'],
+    roles: ['admin', 'priest', 'supervisor', 'volunteer', 'viewer', 'church'],
+    recordTypes: ['baptism', 'marriage', 'funeral']
+  });
+});
+
+app.get('/api/config', (req, res) => {
+  // Return app configuration
+  res.json({
+    appName: 'OrthodoxMetrics',
+    version: '1.0.0',
+    supportedLanguages: ['en', 'gr', 'ru', 'ro'],
+    features: {
+
+      certificates: true,
+      invoices: true,
+      calendar: true
+    }
+  });
+});
+
+app.get('/api/search', (req, res) => {
+  // Basic search functionality placeholder
+  const { q, type } = req.query;
+  res.json({
+    query: q,
+    type: type || 'all',
+    results: [],
+    message: 'Search functionality not yet implemented'
+  });
+});
+
+// --- HEALTHCHECK ----------------------------------------------------
+app.get('/api/health', async (req, res) => {
+  try {
+    const dbStatus = await db.testConnection();
+    res.json({
+      status: dbStatus.success ? 'ok' : 'error',
+      user: req.session.user || null,
+      database: dbStatus
+    });
+  } catch (err) {
+    res.status(500).json({ status: 'error', message: err.message });
+  }
+});
+
+// --- FRONTEND COMPATIBILITY ALIASES ---------------------------------
+
+// /api/system/version -> server + frontend build info
+app.get('/api/system/version', (req, res) => {
+  // Auto-detect GIT_SHA from git if not in env
+  let gitSha = process.env.GIT_SHA || 'unknown';
+  if (gitSha === 'unknown') {
+    try {
+      const { execSync } = require('child_process');
+      gitSha = execSync('git rev-parse --short=7 HEAD', { cwd: path.resolve(__dirname, '..'), timeout: 3000 }).toString().trim();
+    } catch (_) { /* git not available or not a repo */ }
+  }
+
+  let packageVersion = '1.0.0';
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'));
+    packageVersion = pkg.version || '1.0.0';
+  } catch (_) {}
+
+  res.json({
+    success: true,
+    server: {
+      version: packageVersion,
+      gitSha: gitSha.length > 7 ? gitSha.substring(0, 7) : gitSha,
+      gitShaFull: gitSha,
+      buildTime: process.env.BUILD_TIME || null,
+      nodeVersion: process.version,
+      environment: process.env.NODE_ENV || 'development',
+      uptime: process.uptime(),
+    },
+    timestamp: new Date().toISOString()
+  });
+});
+
+// /api/system/config -> Get current configuration (redacted, admin/dev only)
+app.get('/api/system/config', (req, res) => {
+  try {
+    // Check if user is admin OR if we're in development
+    const isAdmin = req.session?.user?.role === 'super_admin' || req.session?.user?.role === 'admin';
+    const isDev = serverConfig.server.env === 'development';
+    
+    if (!isAdmin && !isDev) {
+      return res.status(403).json({ 
+        success: false,
+        error: 'Access denied. Admin role required.' 
+      });
+    }
+    
+    // Use the formatConfigForLog function to redact secrets
+    const { formatConfigForLog } = require('./config/redact');
+    
+    res.json({
+      success: true,
+      config: formatConfigForLog ? formatConfigForLog(serverConfig) : serverConfig,
+      environment: serverConfig.server.env,
+      timestamp: new Date().toISOString()
+    });
+  } catch (err) {
+    res.status(500).json({ 
+      success: false,
+      error: 'Failed to load configuration',
+      message: err.message 
+    });
+  }
+});
+
+// /api/admin/session-stats -> same router as /api/admin/sessions
+app.use('/api/admin/session-stats', (req, res, next) => {
+  // Rewrite to /stats so the sessions router handles it
+  req.url = '/stats' + req.url;
+  sessionsRouter(req, res, next);
+});
+
+// --- OMAI FRONTEND COMPATIBILITY ENDPOINTS --------------------------
+// These endpoints are for frontend compatibility with the OMAI system
+
+// GET /api/status - OMAI status check for frontend
+app.get('/api/status', async (req, res) => {
+  try {
+    // Import OMAI health check function
+    const { getOMAIHealth } = require('/var/www/orthodoxmetrics/prod/misc/omai/services/index.js');
+    const health = await getOMAIHealth();
+    
+    res.json({
+      success: true,
+      status: health.status,
+      version: '1.0.0',
+      activeAgents: health.components?.agents || [],
+      timestamp: health.timestamp,
+      uptime: process.uptime(),
+      memory: process.memoryUsage()
+    });
+  } catch (error) {
+    console.error('OMAI status check failed:', error);
+    res.status(500).json({
+      success: false,
+      status: 'unhealthy',
+      error: error.message
+    });
+  }
+});
+
+// POST /api/fix - OMAI fix endpoint for frontend
+app.post('/api/fix', async (req, res) => {
+  try {
+    const { route, component, issues, props, currentCode, errorDetails } = req.body;
+    
+    // Log the fix request
+    console.log(`[OMAI] Fix request from user ${req.user?.id || 'unknown'} for component ${component}`);
+
+    // For now, return a stub response
+    // This would be implemented with actual AI fix logic
+    res.json({
+      success: true,
+      suggestion: `Fix for ${component} component`,
+      codeDiff: '',
+      explanation: 'This is a placeholder fix response. AI fix functionality will be implemented.',
+      confidence: 0.8,
+      estimatedTime: '5 minutes',
+      requiresManualReview: true
+    });
+  } catch (error) {
+    console.error('OMAI fix failed:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message
+    });
+  }
+});
+
+// Router Menu Studio API
+app.use('/api/router-menu', routerMenuRouter);
+
+// Refactor Console API - Hard-wired route for Phase 1 analysis (backward-compatible)
+// This ensures the route works even if router mounting fails
+// Now uses async job system to prevent timeouts
+app.get('/api/refactor-console/phase1-analysis', async (req: any, res: any) => {
+  console.log('[Server] Hard-wired phase1-analysis route called (backward-compatible)');
+  try {
+    res.setHeader('Content-Type', 'application/json');
+    
+    // Import the service (handles both src and dist paths)
+    let phase1Service: any;
+    try {
+      phase1Service = require('./services/phase1RecoveryAnalysis');
+    } catch (e1) {
+      try {
+        phase1Service = require('./services/phase1RecoveryAnalysis');
+      } catch (e2) {
+        try {
+          phase1Service = require('./services/phase1RecoveryAnalysis');
+        } catch (e3) {
+          return res.status(500).json({ 
+            ok: false,
+            error: 'Failed to load phase1RecoveryAnalysis service',
+            message: e3 instanceof Error ? e3.message : 'Unknown error'
+          });
+        }
+      }
+    }
+    
+    if (!phase1Service || !phase1Service.startPhase1Analysis) {
+      return res.status(500).json({ 
+        ok: false,
+        error: 'startPhase1Analysis function not found in service'
+      });
+    }
+    
+    const jobId = phase1Service.startPhase1Analysis();
+    console.log(`[Server] [Hard-wired] Started job ${jobId}`);
+    
+    // Return 202 Accepted with jobId (backward-compatible)
+    res.status(202).json({ 
+      ok: true,
+      jobId,
+      status: 'started',
+      message: 'Phase 1 analysis started in background. Poll /api/refactor-console/jobs/' + jobId + ' for status.'
+    });
+  } catch (error) {
+    console.error('[Server] [Hard-wired] Phase 1 analysis error:', error);
+    if (!res.headersSent) {
+      res.status(500).json({ 
+        ok: false,
+        error: 'Phase 1 analysis failed', 
+        message: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  }
+});
+
+// Refactor Console API
+if (refactorConsoleRouter && typeof refactorConsoleRouter.use === 'function') {
+  console.log('[Server] ✅ Mounting Refactor Console router at /api/refactor-console');
+  app.use('/api/refactor-console', refactorConsoleRouter);
+  
+  // Log registered routes for debugging
+  const routes: string[] = [];
+  refactorConsoleRouter.stack.forEach((middleware: any) => {
+    if (middleware.route) {
+      const methods = Object.keys(middleware.route.methods).map(m => m.toUpperCase()).join(', ');
+      routes.push(`${methods} ${middleware.route.path}`);
+    }
+  });
+  console.log('[Server] Refactor Console routes:', routes.join(', '));
+} else {
+  console.error('[Server] ❌ Refactor Console router is not a valid Express router');
+  console.error('[Server] Router type:', typeof refactorConsoleRouter);
+  if (refactorConsoleRouter) {
+    console.error('[Server] Router keys:', Object.keys(refactorConsoleRouter));
+  }
+}
+
+registerRouterMenuStudio(app);
+// --- 404 HANDLER ----------------------------------------------------
+app.use('/api/*', (req, res) => {
+  res.status(404).json({ error: 'Not found' });
+});
+
+// --- STATIC FRONTEND ------------------------------------------------
+// Serve /images/* from front-end/dist/images (production) or front-end/public/images (development)
+// Note: __dirname in dist/index.js is server/dist, so we need to go up to prod root, then into front-end
+const prodRoot = path.resolve(__dirname, '../..'); // From server/dist -> server -> prod root
+const distImagesPath = path.join(prodRoot, 'front-end/dist/images');
+const publicImagesPath = path.join(prodRoot, 'front-end/public/images');
+console.log(`[DEBUG] Checking images paths:`);
+console.log(`  distImagesPath: ${distImagesPath} (exists: ${fs.existsSync(distImagesPath)})`);
+console.log(`  publicImagesPath: ${publicImagesPath} (exists: ${fs.existsSync(publicImagesPath)})`);
+let imagesPath: string | null = null;
+if (fs.existsSync(distImagesPath)) {
+    imagesPath = distImagesPath;
+    console.log(`✅ [Server] Serving /images/* from: ${imagesPath} (dist)`);
+} else if (fs.existsSync(publicImagesPath)) {
+    imagesPath = publicImagesPath;
+    console.log(`✅ [Server] Serving /images/* from: ${imagesPath} (public)`);
+} else {
+    console.warn(`⚠️  [Server] Images directory not found in dist or public`);
+    console.warn(`   Checked: ${distImagesPath}`);
+    console.warn(`   Checked: ${publicImagesPath}`);
+}
+if (imagesPath) {
+    app.use('/images', express.static(imagesPath));
+    console.log(`✅ [Server] /images/* middleware mounted`);
+} else {
+    console.error(`❌ [Server] Failed to mount /images/* middleware - path not found`);
+}
+
+app.use('/uploads', express.static(path.resolve(__dirname, '../misc/public/uploads')));
+
+// Serve static assets with long cache (hashed filenames are immutable)
+// Vite produces hashed filenames like assets/index-abc123.js, so these can be cached forever
+app.use('/assets', express.static(path.resolve(__dirname, 'assets'), {
+  maxAge: '1y', // 1 year cache for hashed assets (immutable)
+  immutable: true, // Mark as immutable for better caching
+  etag: true,
+  lastModified: true
+}));
+
+// Serve dynamic addon components (development & production paths)
+const addonsPath = process.env.NODE_ENV === 'production' 
+  ? '/var/www/orthodoxmetrics/addons' 
+  : path.resolve(__dirname, '../misc/public/addons');
+app.use('/addons', express.static(addonsPath));
+
+// Explicit route for manifest.json to fix 403 errors
+// CRITICAL: Set no-cache for manifest.json to prevent PWA caching issues
+app.get('/manifest.json', (req, res) => {
+  const manifestPath = path.resolve(__dirname, '../front-end/dist/manifest.json');
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
+  res.sendFile(manifestPath);
+});
+
+// Explicit route for build.meta.json to fix 403 errors
+app.get('/build.meta.json', (req, res) => {
+  // Try multiple locations for build.meta.json
+  const locations = [
+    path.resolve(__dirname, '../front-end/dist/build.meta.json'),
+    path.resolve(__dirname, '../front-end/build.meta.json'),
+    path.resolve(__dirname, '../front-end/public/build.meta.json')
+  ];
+  
+  for (const buildMetaPath of locations) {
+    if (fs.existsSync(buildMetaPath)) {
+      res.setHeader('Content-Type', 'application/json');
+      res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+      res.setHeader('Pragma', 'no-cache');
+      res.setHeader('Expires', '0');
+      return res.sendFile(buildMetaPath);
+    }
+  }
+  
+  // If file doesn't exist in any location, return a default response
+  res.json({
+    buildTime: new Date().toISOString(),
+    version: "1.0.0",
+    environment: process.env.NODE_ENV || 'development'
+  });
+});
+
+// Explicit route for build-info.json (injected by build script)
+app.get('/build-info.json', (req, res) => {
+  const buildInfoPath = path.resolve(__dirname, '../front-end/dist/build-info.json');
+  
+  if (fs.existsSync(buildInfoPath)) {
+    res.setHeader('Content-Type', 'application/json');
+    // CRITICAL: No cache for build-info.json so it always shows latest build
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+    return res.sendFile(buildInfoPath);
+  }
+  
+  // Fallback if file doesn't exist
+  res.json({
+    gitSha: 'unknown',
+    buildTime: new Date().toISOString(),
+    buildTimestamp: Date.now(),
+    version: '1.0.0'
+  });
+});
+
+// Version-aware static file serving
+app.use(versionSwitcherMiddleware);
+app.use((req, res, next) => {
+  if (req.versionPath) {
+    express.static(req.versionPath)(req, res, next);
+  } else {
+    express.static(path.resolve(__dirname, '../front-end/dist'))(req, res, next);
+  }
+});
+
+// Catch-all handler: send back React's index.html file for any non-API routes
+app.get('*', versionSwitcherMiddleware, (req, res) => {
+  // Don't serve index.html for API routes
+  if (req.path.startsWith('/api/')) {
+    return res.status(404).json({ error: 'API endpoint not found' });
+  }
+  // Don't serve index.html for /images/* routes
+  // Note: In production, Nginx should serve /images/* directly.
+  // This check is a fallback - if we reach here, the static middleware didn't match,
+  // which means the file doesn't exist or there's a routing issue.
+  if (req.path.startsWith('/images/')) {
+    // Return 404 with proper image content-type hint
+    res.status(404).json({ error: 'Image not found', path: req.path });
+    return;
+  }
+
+  // CRITICAL: Set no-cache headers for index.html to ensure users always get latest asset references
+  // This prevents browsers from caching index.html which contains references to hashed JS/CSS files
+  if (req.path === '/' || req.path === '/index.html' || !req.path.includes('.')) {
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+    res.setHeader('Surrogate-Control', 'no-store');
+  }
+
+  // Serve version-specific index.html
+  const versionPath = req.versionPath || path.resolve(__dirname, '../front-end/dist');
+  const indexPath = path.join(versionPath, 'index.html');
+  res.sendFile(indexPath);
+});
+
+// --- EMAIL QUEUE PROCESSING ------------------------------------------
+const { notificationService } = require('./routes/notifications');
+const cron = require('node-cron');
+
+// Process email queue every 5 minutes
+cron.schedule('*/5 * * * *', async () => {
+  try {
+    const processedCount = await notificationService.processEmailQueue();
+    if (processedCount > 0) {
+      console.log(`Processed ${processedCount} emails from notification queue`);
+    }
+  } catch (error) {
+    console.error('Error processing email queue:', error);
+  }
+});
+
+console.log('Email queue processor started (runs every 5 minutes)');
+
+// Daily changelog at 11 PM
+cron.schedule('0 23 * * *', async () => {
+  try {
+    const omDaily = require('./routes/om-daily');
+    await omDaily.generateAndEmailChangelog();
+  } catch (err) {
+    console.error('[Changelog] Cron error:', err);
+  }
+});
+console.log('Daily changelog cron scheduled (11 PM)');
+
+// GitHub issue sync at 11:15 PM
+cron.schedule('15 23 * * *', async () => {
+  try {
+    const omDaily = require('./routes/om-daily');
+    await omDaily.fullSync();
+  } catch (err) {
+    console.error('[GitHub Sync] Cron error:', err);
+  }
+});
+console.log('GitHub issue sync cron scheduled (11:15 PM)');
+
+// --- WEBSOCKET INTEGRATION -----------------------------------------
+const websocketService = require('./services/websocketService');
+
+// Initialize JIT WebSocket
+if (jitTerminalRouter.setupJITWebSocket) {
+  const jitWebSocket = jitTerminalRouter.setupJITWebSocket(server);
+  console.log('🔌 JIT Terminal WebSocket initialized');
+}
+
+// Initialize OMAI Logger WebSocket
+const WS = require('ws');
+const omaiLoggerWss = new WS.Server({
+  server,
+  path: '/ws/omai-logger'
+});
+
+omaiLoggerWss.on('connection', (ws, req) => {
+  console.log('🔌 OMAI Logger WebSocket connected');
+  
+  // Store the WebSocket connection for broadcasting
+  if (omaiLoggerRouter.ws) {
+    omaiLoggerRouter.ws(ws);
+  }
+  
+  ws.on('error', (error) => {
+    console.error('❌ OMAI Logger WebSocket error:', error);
+  });
+  
+  ws.on('close', () => {
+    console.log('🔌 OMAI Logger WebSocket disconnected');
+  });
+});
+
+console.log('🔌 OMAI Logger WebSocket initialized on /ws/omai-logger');
+
+// --- BROADCAST NEW BUILD (triggers UpdateAvailableBanner on all connected clients) -----------
+app.post('/api/admin/broadcast-new-build', requireAuthForRoutes, requireAdminForRoutes, (req, res) => {
+  try {
+    const buildInfo = req.body || {};
+    websocketService.broadcastNewBuild(buildInfo);
+    res.json({ ok: true, message: 'New build notification broadcast to all connected clients' });
+  } catch (err) {
+    console.error('[broadcast-new-build] Error:', err);
+    res.status(500).json({ ok: false, message: 'Failed to broadcast' });
+  }
+});
+
+// --- GLOBAL ERROR HANDLER (MUST be after all routes, before server starts) -------------------
+const apiErrorHandler = require('./middleware/apiErrorHandler');
+
+// Register error handler for API routes
+app.use(apiErrorHandler);
+
+// Catch-all error handler for unhandled errors
+app.use((err, req, res, next) => {
+  // If headers already sent, delegate to default handler
+  if (res.headersSent) {
+    return next(err);
+  }
+  
+  // For API routes, use the API error handler
+  if (req.path && req.path.startsWith('/api/')) {
+    return apiErrorHandler(err, req, res, next);
+  }
+  
+  // For non-API routes, use default Express error handler
+  console.error('Unhandled error:', err);
+  res.status(err.status || 500).json({
+    error: err.message || 'Internal server error',
+    ...(process.env.NODE_ENV === 'development' && { stack: err.stack })
+  });
+});
+
+// --- START SERVER ---------------------------------------------------
+// Defensive logging: Log process info before attempting to bind
+const nodeEnv = process.env.NODE_ENV || 'development';
+const processId = process.pid;
+const instanceId = process.env.pm_id || process.env.INSTANCE_ID || 'unknown';
+const execMode = process.env.pm_exec_mode || 'standalone';
+
+console.log('═══════════════════════════════════════════════════════════');
+console.log('🚀 Starting OrthodoxMetrics Backend Server');
+console.log('═══════════════════════════════════════════════════════════');
+console.log(`📋 Process ID: ${processId}`);
+console.log(`🔢 Instance ID: ${instanceId}`);
+console.log(`⚙️  Execution Mode: ${execMode}`);
+console.log(`🌐 Environment: ${nodeEnv.toUpperCase()}`);
+console.log(`🔌 Attempting to bind: ${HOST}:${PORT}`);
+console.log('═══════════════════════════════════════════════════════════');
+
+// Error handler for server listen errors (EADDRINUSE, etc.)
+server.on('error', (error: NodeJS.ErrnoException) => {
+  if (error.code === 'EADDRINUSE') {
+    console.error('═══════════════════════════════════════════════════════════');
+    console.error('❌ FATAL ERROR: Port already in use (EADDRINUSE)');
+    console.error('═══════════════════════════════════════════════════════════');
+    console.error(`Port ${PORT} is already bound by another process.`);
+    console.error(`Process ID: ${processId}`);
+    console.error(`Instance ID: ${instanceId}`);
+    console.error(`Execution Mode: ${execMode}`);
+    console.error('');
+    console.error('🔍 Troubleshooting Steps:');
+    console.error('   1. Check for zombie processes:');
+    console.error(`      ss -lntp | grep :${PORT}`);
+    console.error(`      lsof -i :${PORT}`);
+    console.error('   2. Check PM2 status:');
+    console.error('      pm2 status orthodox-backend');
+    console.error('      pm2 describe orthodox-backend');
+    console.error('   3. If PM2 shows multiple instances, stop all:');
+    console.error('      pm2 stop orthodox-backend');
+    console.error('      pm2 delete orthodox-backend');
+    console.error('   4. Kill any zombie processes manually if needed:');
+    console.error(`      kill -9 <PID>  # Replace <PID> with process ID from lsof`);
+    console.error('   5. Restart cleanly:');
+    console.error('      pm2 start ecosystem.config.cjs --only orthodox-backend');
+    console.error('');
+    console.error('⚠️  Exiting to prevent crash loop...');
+    console.error('═══════════════════════════════════════════════════════════');
+    process.exit(1);
+  } else {
+    console.error('═══════════════════════════════════════════════════════════');
+    console.error('❌ FATAL ERROR: Server failed to start');
+    console.error('═══════════════════════════════════════════════════════════');
+    console.error(`Error: ${error.message}`);
+    console.error(`Code: ${error.code || 'UNKNOWN'}`);
+    console.error(`Process ID: ${processId}`);
+    console.error(`Stack: ${error.stack}`);
+    console.error('═══════════════════════════════════════════════════════════');
+    process.exit(1);
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log('═══════════════════════════════════════════════════════════');
+  console.log(`✅ Server successfully bound to ${HOST}:${PORT}`);
+  console.log(`📁 Entrypoint: dist/index.js (compiled from src/index.ts)`);
+  console.log(`🔍 Route health check: GET /api/admin/_routes`);
+  if (nodeEnv !== 'production') {
+    console.log('📋 Development mode: Enhanced logging and verbose output enabled');
+  } else {
+    console.log('🔧 Production mode: Optimized for performance and reduced logging');
+  }
+  
+  // Log critical route mounts
+  console.log('✅ Critical routes mounted:');
+  console.log('   - /api/admin/templates');
+  console.log('   - /api/admin/churches');
+  console.log('   - /api/admin/users');
+  
+  // Initialize WebSocket service after server starts
+  websocketService.initialize(server, sessionMiddleware);
+  console.log('🔌 WebSocket service initialized');
+  
+  // DISABLED: Backend log monitoring causes infinite feedback loop
+  // The logMonitor watches PM2 logs, but its own output gets logged by PM2,
+  // creating an infinite loop that floods the logs
+  // logMonitor.start('orthodox-backend');
+  // console.log('🔍 Backend log monitoring started for orthodox-backend');
+  console.log('═══════════════════════════════════════════════════════════');
+  
+  // ============================================================================
+  // STARTUP VERIFICATION - Test critical public endpoints
+  // ============================================================================
+  // Verify that health and maintenance status endpoints are accessible
+  // without authentication. This prevents silent regressions from breaking
+  // monitoring and uptime checks.
+  console.log('🏥 Running startup health check verification...');
+  
+  const http = require('http');
+  
+  // Test /api/system/health
+  const healthCheckOptions = {
+    hostname: HOST === '0.0.0.0' ? 'localhost' : HOST,
+    port: PORT,
+    path: '/api/system/health',
+    method: 'GET',
+    timeout: 5000
+  };
+  
+  const healthReq = http.request(healthCheckOptions, (healthRes) => {
+    let data = '';
+    healthRes.on('data', (chunk) => { data += chunk; });
+    healthRes.on('end', () => {
+      if (healthRes.statusCode === 200) {
+        console.log('✅ Health endpoint verification PASSED: /api/system/health returns 200');
+        try {
+          const json = JSON.parse(data);
+          console.log(`   Status: ${json.status}, Uptime: ${json.uptime}s`);
+        } catch (e) {
+          console.log('   Response received successfully');
+        }
+      } else {
+        console.error('❌ CRITICAL: Health endpoint verification FAILED!');
+        console.error(`   /api/system/health returned ${healthRes.statusCode} instead of 200`);
+        console.error('   This endpoint MUST be public for monitoring systems!');
+        console.error('   Check: server/src/api/systemStatus.js and auth middleware allowlist');
+      }
+    });
+  });
+  
+  healthReq.on('error', (err) => {
+    console.error('❌ Health endpoint verification ERROR:', err.message);
+  });
+  
+  healthReq.on('timeout', () => {
+    console.error('❌ Health endpoint verification TIMEOUT');
+    healthReq.destroy();
+  });
+  
+  healthReq.end();
+  
+  // Test /api/maintenance/status
+  const maintenanceCheckOptions = {
+    hostname: HOST === '0.0.0.0' ? 'localhost' : HOST,
+    port: PORT,
+    path: '/api/maintenance/status',
+    method: 'GET',
+    timeout: 5000
+  };
+  
+  const maintenanceReq = http.request(maintenanceCheckOptions, (maintenanceRes) => {
+    let data = '';
+    maintenanceRes.on('data', (chunk) => { data += chunk; });
+    maintenanceRes.on('end', () => {
+      if (maintenanceRes.statusCode === 200) {
+        console.log('✅ Maintenance endpoint verification PASSED: /api/maintenance/status returns 200');
+        try {
+          const json = JSON.parse(data);
+          console.log(`   Status: ${json.status}, Maintenance: ${json.maintenance}`);
+        } catch (e) {
+          console.log('   Response received successfully');
+        }
+      } else {
+        console.error('❌ CRITICAL: Maintenance endpoint verification FAILED!');
+        console.error(`   /api/maintenance/status returned ${maintenanceRes.statusCode} instead of 200`);
+        console.error('   This endpoint MUST be public for frontend polling!');
+        console.error('   Check: server/src/api/maintenance-public.js and auth middleware allowlist');
+      }
+    });
+  });
+  
+  maintenanceReq.on('error', (err) => {
+    console.error('❌ Maintenance endpoint verification ERROR:', err.message);
+  });
+  
+  maintenanceReq.on('timeout', () => {
+    console.error('❌ Maintenance endpoint verification TIMEOUT');
+    maintenanceReq.destroy();
+  });
+  
+  maintenanceReq.end();
+  
+  console.log('═══════════════════════════════════════════════════════════');
+  // ============================================================================
+});
+
+app.get('/api/auth/check', (req,res)=>{
+  const u = req.session && req.session.user;
+  if (u) return res.json({ authenticated: true, user: u });
+  res.status(401).json({ authenticated: false, message: 'Not authenticated' });
+});
+
+// Removed duplicate /api/user/profile route - already handled by userProfileRouter

--- a/server/src/utils/detectColumns.js
+++ b/server/src/utils/detectColumns.js
@@ -1,0 +1,62 @@
+/**
+ * Detect which date/clergy columns exist in each sacramental record table.
+ * Churches have different schemas (mdate vs marriage_date, burial_date vs funeral_date, etc.)
+ *
+ * Shared by: om-charts.js, dashboard-home.js
+ */
+
+async function detectColumns(pool) {
+  const getColNames = async (table) => {
+    try {
+      const [cols] = await pool.query(`SHOW COLUMNS FROM ${table}`);
+      return cols.map(c => c.Field);
+    } catch {
+      return [];
+    }
+  };
+
+  const [bCols, mCols, fCols] = await Promise.all([
+    getColNames('baptism_records'),
+    getColNames('marriage_records'),
+    getColNames('funeral_records'),
+  ]);
+
+  // Baptism date: reception_date > baptism_date
+  const baptismDate = bCols.includes('reception_date') ? 'reception_date'
+    : bCols.includes('baptism_date') ? 'baptism_date' : null;
+
+  // Birth date for age calc
+  const birthDate = bCols.includes('birth_date') ? 'birth_date' : null;
+
+  // Marriage date: mdate > marriage_date
+  const marriageDate = mCols.includes('mdate') ? 'mdate'
+    : mCols.includes('marriage_date') ? 'marriage_date' : null;
+
+  // Funeral/burial date: burial_date > funeral_date > deceased_date > death_date
+  const funeralDate = fCols.includes('burial_date') ? 'burial_date'
+    : fCols.includes('funeral_date') ? 'funeral_date'
+    : fCols.includes('deceased_date') ? 'deceased_date'
+    : fCols.includes('death_date') ? 'death_date' : null;
+
+  // Clergy columns
+  const baptismClergy = bCols.includes('clergy') ? 'clergy' : null;
+  const marriageClergy = mCols.includes('clergy') ? 'clergy' : null;
+  const funeralClergy = fCols.includes('clergy') ? 'clergy' : null;
+
+  // Name columns (for recent activity display)
+  const baptismName = bCols.includes('child_name') ? 'child_name'
+    : bCols.includes('name') ? 'name' : null;
+  const marriageName = mCols.includes('groom_name') ? 'groom_name'
+    : mCols.includes('name') ? 'name' : null;
+  const funeralName = fCols.includes('deceased_name') ? 'deceased_name'
+    : fCols.includes('name') ? 'name' : null;
+
+  return {
+    baptismDate, birthDate, marriageDate, funeralDate,
+    baptismClergy, marriageClergy, funeralClergy,
+    baptismName, marriageName, funeralName,
+    bCols, mCols, fCols
+  };
+}
+
+module.exports = { detectColumns };


### PR DESCRIPTION
## Summary
- **Church Dashboard**: Replace generic template dashboard with real sacramental data from tenant databases — count cards, monthly activity chart, type distribution donut, recent records list, year-over-year comparison, and data completeness gauge
- **Impersonation Banner Fix**: Move banner inside PageWrapper with spacer div so it no longer covers the navigation header
- **Backend API**: New `GET /api/churches/:churchId/dashboard` endpoint with shared `detectColumns` utility extracted from OM Charts

## Test plan
- [ ] Navigate to `/dashboards/modern` with a church selected — verify real record counts and charts
- [ ] Switch churches — dashboard refreshes with new church data
- [ ] No church selected — shows "Select a church" info alert
- [ ] Impersonate a user via "Login As" — red banner visible, nav header NOT covered
- [ ] Click "Return to Admin" — banner disappears, layout returns to normal
- [ ] Verify OM Charts still works (shared `detectColumns` refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)