### PR TITLE
feat: church registration token system and setup wizard enhancements

### DIFF
--- a/front-end/src/features/auth/authentication/auth1/Register.tsx
+++ b/front-end/src/features/auth/authentication/auth1/Register.tsx
@@ -1,0 +1,103 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Box, Grid, Typography, Stack } from '@mui/material';
+
+import PageContainer from '@/shared/ui/PageContainer';
+import img1 from '@/assets/images/backgrounds/login-bg.svg';
+import Logo from '@/layouts/full/shared/logo/Logo';
+
+import AuthRegister from '@/features/auth/authentication/authForms/AuthRegister';
+
+const Register = () => (
+  <PageContainer title="Register" description="this is Register page">
+    <Grid container spacing={0} justifyContent="center" sx={{ overflowX: 'hidden' }}>
+      <Grid
+        item
+        xs={12}
+        sm={12}
+        lg={7}
+        xl={8}
+        sx={{
+          position: 'relative',
+          '&:before': {
+            content: '""',
+            background: 'radial-gradient(#d2f1df, #d3d7fa, #bad8f4)',
+            backgroundSize: '400% 400%',
+            animation: 'gradient 15s ease infinite',
+            position: 'absolute',
+            height: '100%',
+            width: '100%',
+            opacity: '0.3',
+          },
+        }}>
+        <Box position="relative">
+          <Box px={3}>
+            <Logo />
+          </Box>
+          <Box
+            alignItems="center"
+            justifyContent="center"
+            height={'calc(100vh - 75px)'}
+            sx={{
+              display: {
+                xs: 'none',
+                lg: 'flex',
+              },
+            }}
+          >
+            <img
+              src={img1}
+              alt="bg"
+              style={{
+                width: '100%',
+                maxWidth: '500px',
+              }}
+            />
+          </Box>
+        </Box>
+      </Grid>
+      <Grid
+        item
+        xs={12}
+        sm={12}
+        lg={5}
+        xl={4}
+        display="flex"
+        justifyContent="center"
+        alignItems="center">
+        <Box p={4}>
+          <AuthRegister
+            title="Create Your Account"
+            subtext={
+              <Typography variant="subtitle1" color="textSecondary" mb={1}>
+                Register with your church's registration token
+              </Typography>
+            }
+            subtitle={
+              <Stack direction="row" spacing={1} mt={3}>
+                <Typography color="textSecondary" variant="h6" fontWeight="400">
+                  Already have an Account?
+                </Typography>
+                <Typography
+                  component={Link}
+                  to="/auth/login"
+                  fontWeight="500"
+                  sx={{
+                    textDecoration: 'none',
+                    color: 'primary.main',
+                  }}
+                >
+                  Sign In
+                </Typography>
+              </Stack>
+            }
+          />
+        </Box>
+      </Grid>
+    </Grid>
+  </PageContainer>
+);
+
+export default Register;

--- a/front-end/src/features/auth/authentication/auth2/Register2.tsx
+++ b/front-end/src/features/auth/authentication/auth2/Register2.tsx
@@ -1,0 +1,76 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import React from 'react';
+import { Box, Card, Grid, Typography, Stack } from '@mui/material';
+import { Link } from 'react-router-dom';
+import PageContainer from '@/shared/ui/PageContainer';
+import Logo from '@/layouts/full/shared/logo/Logo';
+
+import AuthRegister from '@/features/auth/authentication/authForms/AuthRegister';
+
+const Register2 = () => (
+  <PageContainer title="Register" description="Register for Orthodox Metrics">
+    <Box
+      sx={{
+        position: 'relative',
+        '&:before': {
+          content: '""',
+          background: 'radial-gradient(#d2f1df, #d3d7fa, #bad8f4)',
+          backgroundSize: '400% 400%',
+          animation: 'gradient 15s ease infinite',
+          position: 'absolute',
+          height: '100%',
+          width: '100%',
+          opacity: '0.3',
+        },
+      }}
+    >
+      <Grid container spacing={0} justifyContent="center" sx={{ minHeight: '100vh' }}>
+        <Grid
+          item
+          xs={12}
+          sm={12}
+          lg={6}
+          xl={5}
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          py={4}
+        >
+          <Card elevation={9} sx={{ p: 4, zIndex: 1, width: '100%', maxWidth: '520px' }}>
+            <Box display="flex" alignItems="center" justifyContent="center">
+              <Logo />
+            </Box>
+            <AuthRegister
+              subtext={
+                <Typography variant="subtitle1" textAlign="center" color="textSecondary" mb={1}>
+                  Register with your church's registration token
+                </Typography>
+              }
+              subtitle={
+                <Stack direction="row" spacing={1} mt={3} justifyContent="center">
+                  <Typography color="textSecondary" variant="h6" fontWeight="400">
+                    Already have an account?
+                  </Typography>
+                  <Typography
+                    component={Link}
+                    to="/auth/login"
+                    fontWeight="500"
+                    sx={{
+                      textDecoration: 'none',
+                      color: 'primary.main',
+                    }}
+                  >
+                    Sign In
+                  </Typography>
+                </Stack>
+              }
+            />
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  </PageContainer>
+);
+
+export default Register2;

--- a/front-end/src/features/auth/authentication/authForms/AuthRegister.tsx
+++ b/front-end/src/features/auth/authentication/authForms/AuthRegister.tsx
@@ -1,0 +1,305 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Stack,
+  Alert,
+  LinearProgress,
+  InputAdornment,
+  IconButton,
+  CircularProgress,
+} from '@mui/material';
+import { Link } from 'react-router-dom';
+import { IconEye, IconEyeOff, IconCheck, IconBuilding, IconKey } from '@tabler/icons-react';
+import CustomTextField from '@/components/forms/theme-elements/CustomTextField';
+import CustomFormLabel from '@/components/forms/theme-elements/CustomFormLabel';
+
+// Password strength calculator (matches AcceptInvite pattern)
+const getPasswordStrength = (password: string): { score: number; label: string; color: 'error' | 'warning' | 'info' | 'success' } => {
+  if (!password) return { score: 0, label: '', color: 'error' };
+  let score = 0;
+  if (password.length >= 8) score += 25;
+  if (password.length >= 12) score += 10;
+  if (/[a-z]/.test(password) && /[A-Z]/.test(password)) score += 25;
+  if (/\d/.test(password)) score += 20;
+  if (/[^a-zA-Z0-9]/.test(password)) score += 20;
+
+  if (score <= 25) return { score, label: 'Weak', color: 'error' };
+  if (score <= 50) return { score, label: 'Fair', color: 'warning' };
+  if (score <= 75) return { score, label: 'Good', color: 'info' };
+  return { score: Math.min(score, 100), label: 'Strong', color: 'success' };
+};
+
+interface AuthRegisterProps {
+  title?: React.ReactNode;
+  subtitle?: React.ReactNode;
+  subtext?: React.ReactNode;
+}
+
+const AuthRegister = ({ title, subtitle, subtext }: AuthRegisterProps) => {
+  const [churchName, setChurchName] = useState('');
+  const [registrationToken, setRegistrationToken] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const passwordStrength = getPasswordStrength(password);
+  const passwordsMatch = confirmPassword.length > 0 && password === confirmPassword;
+  const passwordsMismatch = confirmPassword.length > 0 && password !== confirmPassword;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!churchName.trim() || !registrationToken.trim() || !firstName.trim() || !lastName.trim() || !email.trim() || !password) {
+      setError('All fields are required.');
+      return;
+    }
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters.');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      const res = await fetch('/api/auth/church-register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          church_name: churchName.trim(),
+          registration_token: registrationToken.trim(),
+          first_name: firstName.trim(),
+          last_name: lastName.trim(),
+          email: email.trim(),
+          password,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok || !data.success) {
+        setError(data.message || 'Registration failed. Please try again.');
+        return;
+      }
+
+      setSuccess(true);
+    } catch {
+      setError('Network error. Please try again later.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <Box textAlign="center" py={3}>
+        <Box
+          sx={{
+            width: 64,
+            height: 64,
+            borderRadius: '50%',
+            bgcolor: 'success.light',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            mx: 'auto',
+            mb: 2,
+          }}
+        >
+          <IconCheck size={32} color="#2e7d32" />
+        </Box>
+        <Typography variant="h5" gutterBottom fontWeight={600}>
+          Registration Submitted
+        </Typography>
+        <Typography variant="body1" color="textSecondary" paragraph>
+          Your account has been created and is pending admin review. You will be able to sign in once
+          an administrator activates your account.
+        </Typography>
+        <Button component={Link} to="/auth/login" variant="contained" color="primary" sx={{ mt: 2 }}>
+          Return to Sign In
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      {title ? (
+        <Typography fontWeight="700" variant="h3" mb={1}>
+          {title}
+        </Typography>
+      ) : null}
+
+      {subtext}
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+          {error}
+        </Alert>
+      )}
+
+      <Box component="form" onSubmit={handleSubmit}>
+        <Stack spacing={0}>
+          <Box sx={{ bgcolor: 'action.hover', borderRadius: 1, p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" color="textSecondary" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+              <IconBuilding size={18} /> Church Verification
+            </Typography>
+            <CustomFormLabel htmlFor="churchName">Church Name</CustomFormLabel>
+            <CustomTextField
+              id="churchName"
+              placeholder="Enter your church's full name"
+              variant="outlined"
+              fullWidth
+              value={churchName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setChurchName(e.target.value)}
+              required
+            />
+            <CustomFormLabel htmlFor="registrationToken">Registration Token</CustomFormLabel>
+            <CustomTextField
+              id="registrationToken"
+              placeholder="Paste the token provided by your church"
+              variant="outlined"
+              fullWidth
+              value={registrationToken}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setRegistrationToken(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <IconKey size={18} />
+                  </InputAdornment>
+                ),
+              }}
+              required
+            />
+          </Box>
+
+          <Typography variant="subtitle2" color="textSecondary" sx={{ mb: 1 }}>
+            Personal Information
+          </Typography>
+          <Stack direction="row" spacing={2}>
+            <Box flex={1}>
+              <CustomFormLabel htmlFor="firstName">First Name</CustomFormLabel>
+              <CustomTextField
+                id="firstName"
+                variant="outlined"
+                fullWidth
+                value={firstName}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFirstName(e.target.value)}
+                required
+              />
+            </Box>
+            <Box flex={1}>
+              <CustomFormLabel htmlFor="lastName">Last Name</CustomFormLabel>
+              <CustomTextField
+                id="lastName"
+                variant="outlined"
+                fullWidth
+                value={lastName}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLastName(e.target.value)}
+                required
+              />
+            </Box>
+          </Stack>
+
+          <CustomFormLabel htmlFor="email">Email Address</CustomFormLabel>
+          <CustomTextField
+            id="email"
+            type="email"
+            placeholder="your.email@example.com"
+            variant="outlined"
+            fullWidth
+            value={email}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+            required
+          />
+
+          <CustomFormLabel htmlFor="password">Password</CustomFormLabel>
+          <CustomTextField
+            id="password"
+            type={showPassword ? 'text' : 'password'}
+            variant="outlined"
+            fullWidth
+            value={password}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={() => setShowPassword(!showPassword)} edge="end">
+                    {showPassword ? <IconEyeOff size={18} /> : <IconEye size={18} />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+            required
+          />
+          {password && (
+            <Box mt={0.5}>
+              <LinearProgress
+                variant="determinate"
+                value={passwordStrength.score}
+                color={passwordStrength.color}
+                sx={{ height: 6, borderRadius: 3 }}
+              />
+              <Typography variant="caption" color={`${passwordStrength.color}.main`} mt={0.5}>
+                {passwordStrength.label}
+              </Typography>
+            </Box>
+          )}
+
+          <CustomFormLabel htmlFor="confirmPassword">Confirm Password</CustomFormLabel>
+          <CustomTextField
+            id="confirmPassword"
+            type={showConfirmPassword ? 'text' : 'password'}
+            variant="outlined"
+            fullWidth
+            value={confirmPassword}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setConfirmPassword(e.target.value)}
+            error={passwordsMismatch}
+            helperText={passwordsMismatch ? 'Passwords do not match' : passwordsMatch ? 'Passwords match' : ''}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  {passwordsMatch && <IconCheck size={18} color="#2e7d32" style={{ marginRight: 4 }} />}
+                  <IconButton size="small" onClick={() => setShowConfirmPassword(!showConfirmPassword)} edge="end">
+                    {showConfirmPassword ? <IconEyeOff size={18} /> : <IconEye size={18} />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+            required
+          />
+        </Stack>
+
+        <Button
+          color="primary"
+          variant="contained"
+          size="large"
+          fullWidth
+          type="submit"
+          disabled={submitting || !churchName || !registrationToken || !firstName || !lastName || !email || !password || !confirmPassword}
+          sx={{ mt: 3 }}
+        >
+          {submitting ? <CircularProgress size={24} color="inherit" /> : 'Create Account'}
+        </Button>
+      </Box>
+      {subtitle}
+    </>
+  );
+};
+
+export default AuthRegister;

--- a/front-end/src/features/devel-tools/om-church-wizard/ChurchSetupWizard.tsx
+++ b/front-end/src/features/devel-tools/om-church-wizard/ChurchSetupWizard.tsx
@@ -1,0 +1,1728 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Stepper,
+  Step,
+  StepLabel,
+  StepContent,
+  StepConnector,
+  Button,
+  Typography,
+  Card,
+  CardContent,
+  Grid,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Switch,
+  FormControlLabel,
+  Chip,
+  IconButton,
+  Alert,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemSecondaryAction,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  CircularProgress,
+  Paper,
+  Stack,
+  Autocomplete,
+  FormGroup,
+  Checkbox,
+  Tabs,
+  Tab,
+  Tooltip,
+  Snackbar,
+} from '@mui/material';
+import { alpha, styled } from '@mui/material/styles';
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+  Save as SaveIcon,
+  Cancel as CancelIcon,
+  CheckCircle as CheckIcon,
+  Info as InfoIcon,
+  Warning as WarningIcon,
+  Church as ChurchIcon,
+  People as PeopleIcon,
+  Settings as SettingsIcon,
+  Web as WebIcon,
+  Storage as StorageIcon,
+  Person as PersonIcon,
+  ContentCopy as CopyIcon,
+  VpnKey as TokenIcon,
+  TableChart as TableIcon,
+  Dashboard as DashboardIcon,
+} from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
+import { useFormik } from 'formik';
+import * as Yup from 'yup';
+import { LiveTableBuilder } from '@/features/devel-tools/live-table-builder/components/LiveTableBuilder';
+import type { TableData } from '@/features/devel-tools/live-table-builder/types';
+
+// Types
+interface ChurchWizardData {
+  // Basic Info
+  name: string;
+  email: string;
+  phone: string;
+  address: string;
+  city: string;
+  state_province: string;
+  postal_code: string;
+  country: string;
+  website: string;
+  preferred_language: string;
+  timezone: string;
+  currency: string;
+  is_active: boolean;
+
+  // Template Selection
+  template_church_id: number | null;
+  selected_tables: string[];
+
+  // Custom Fields
+  custom_fields: CustomField[];
+
+  // User Management
+  initial_users: ChurchUser[];
+
+  // Landing Page
+  custom_landing_page: {
+    enabled: boolean;
+    title: string;
+    welcome_message: string;
+    primary_color: string;
+    logo_url: string;
+    default_app: 'liturgical_calendar' | 'church_records' | 'notes_app';
+  };
+
+  // Custom Table Builder data
+  custom_table_builder?: {
+    table_name: string;
+    data: TableData;
+  } | null;
+}
+
+interface CustomField {
+  id: string;
+  table_name: string;
+  field_name: string;
+  field_type: 'VARCHAR' | 'TEXT' | 'INT' | 'DATE' | 'BOOLEAN';
+  field_length?: number;
+  is_required: boolean;
+  default_value?: string;
+  description: string;
+}
+
+interface ChurchUser {
+  id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: 'admin' | 'manager' | 'user' | 'viewer';
+  permissions: string[];
+  send_invite: boolean;
+}
+
+interface TemplateChurch {
+  id: number;
+  name: string;
+  city: string;
+  country: string;
+  available_tables: string[];
+}
+
+// Step configuration with icons and descriptions
+const STEP_CONFIG = [
+  { label: 'Church Information', icon: <ChurchIcon />, description: 'Basic details about your church' },
+  { label: 'Template Selection', icon: <DashboardIcon />, description: 'Clone from an existing church or start fresh' },
+  { label: 'Record Tables', icon: <TableIcon />, description: 'Configure database tables and custom fields' },
+  { label: 'User Management', icon: <PeopleIcon />, description: 'Add initial users and set permissions' },
+  { label: 'Landing Page', icon: <WebIcon />, description: 'Customize the church landing page' },
+  { label: 'Review & Create', icon: <CheckIcon />, description: 'Review all settings before creating' },
+  { label: 'Registration Token', icon: <TokenIcon />, description: 'Share this token so members can register' },
+];
+
+const steps = STEP_CONFIG.map(s => s.label);
+
+const AVAILABLE_RECORD_TABLES = [
+  { key: 'baptism_records', label: 'Baptism Records', description: 'Track baptism ceremonies and certificates' },
+  { key: 'marriage_records', label: 'Marriage Records', description: 'Manage wedding ceremonies and certificates' },
+  { key: 'funeral_records', label: 'Funeral Records', description: 'Record funeral services and memorials' },
+  { key: 'clergy', label: 'Clergy Management', description: 'Manage priests, deacons, and church staff' },
+  { key: 'members', label: 'Church Members', description: 'Comprehensive membership database' },
+  { key: 'donations', label: 'Donations & Offerings', description: 'Track financial contributions' },
+  { key: 'calendar_events', label: 'Calendar Events', description: 'Liturgical and parish events' },
+  { key: 'confession_records', label: 'Confession Records', description: 'Private confession tracking (encrypted)' },
+  { key: 'communion_records', label: 'Communion Records', description: 'Holy Communion participation' },
+  { key: 'chrismation_records', label: 'Chrismation Records', description: 'Confirmation ceremonies' }
+];
+
+const FIELD_TYPES = [
+  { value: 'VARCHAR', label: 'Text (Short)', maxLength: 255 },
+  { value: 'TEXT', label: 'Text (Long)', maxLength: null },
+  { value: 'INT', label: 'Number', maxLength: null },
+  { value: 'DATE', label: 'Date', maxLength: null },
+  { value: 'BOOLEAN', label: 'Yes/No', maxLength: null }
+];
+
+const USER_ROLES = [
+  { value: 'church_admin', label: 'Church Administrator', description: 'Full access to all church functions' },
+  { value: 'priest', label: 'Priest', description: 'Full clergy privileges and record lifecycle authority' },
+  { value: 'deacon', label: 'Deacon', description: 'Partial clergy privileges' },
+  { value: 'editor', label: 'Editor', description: 'Add and edit records' },
+  { value: 'viewer', label: 'Viewer', description: 'View-only access' }
+];
+
+const AVAILABLE_PERMISSIONS = [
+  'view_records', 'create_records', 'edit_records', 'delete_records',
+  'view_reports', 'export_data', 'manage_users', 'view_analytics'
+];
+
+const DEFAULT_APP_OPTIONS = [
+  {
+    value: 'liturgical_calendar',
+    label: 'Liturgical Calendar',
+    description: 'Orthodox liturgical calendar with feast days and fasting periods'
+  },
+  {
+    value: 'church_records',
+    label: 'Church Records',
+    description: 'Manage baptism, marriage, and funeral records'
+  },
+  {
+    value: 'notes_app',
+    label: 'Notes App',
+    description: 'Personal notes and task management'
+  }
+];
+
+// Styled step connector for professional look
+const StyledStepConnector = styled(StepConnector)(({ theme }) => ({
+  '& .MuiStepConnector-line': {
+    borderColor: theme.palette.divider,
+    borderLeftWidth: 2,
+    minHeight: 20,
+  },
+}));
+
+const ChurchSetupWizard: React.FC = () => {
+  const navigate = useNavigate();
+  const { user, hasRole } = useAuth();
+  const [activeStep, setActiveStep] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [templateChurches, setTemplateChurches] = useState<TemplateChurch[]>([]);
+  const [selectedTemplate, setSelectedTemplate] = useState<TemplateChurch | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Dialog states
+  const [customFieldDialog, setCustomFieldDialog] = useState(false);
+  const [userDialog, setUserDialog] = useState(false);
+  const [editingField, setEditingField] = useState<CustomField | null>(null);
+  const [editingUser, setEditingUser] = useState<ChurchUser | null>(null);
+
+  // Completion state
+  const [wizardResult, setWizardResult] = useState<{
+    church_id: number;
+    db_name: string;
+    registration_token: string;
+    church_name: string;
+  } | null>(null);
+  const [tokenCopied, setTokenCopied] = useState(false);
+
+  // Toast state
+  const [toast, setToast] = useState<{ message: string; severity: 'success' | 'error' | 'warning' | 'info' } | null>(null);
+
+  // Validation schemas for each step
+  const validationSchemas = [
+    // Step 1: Basic Information
+    Yup.object({
+      name: Yup.string().required('Church name is required').min(3, 'Name must be at least 3 characters'),
+      email: Yup.string().email('Invalid email format').required('Email is required'),
+      phone: Yup.string().required('Phone number is required'),
+      city: Yup.string().required('City is required'),
+      country: Yup.string().required('Country is required'),
+      preferred_language: Yup.string().required('Language is required'),
+    }),
+  ];
+
+  // Formik setup
+  const formik = useFormik<ChurchWizardData>({
+    initialValues: {
+      name: '',
+      email: '',
+      phone: '',
+      address: '',
+      city: '',
+      state_province: '',
+      postal_code: '',
+      country: '',
+      website: '',
+      preferred_language: 'en',
+      timezone: 'UTC',
+      currency: 'USD',
+      is_active: true,
+      template_church_id: null,
+      selected_tables: ['baptism_records', 'marriage_records', 'funeral_records'],
+      custom_fields: [],
+      initial_users: [],
+      custom_landing_page: {
+        enabled: false,
+        title: '',
+        welcome_message: '',
+        primary_color: '#1976d2',
+        logo_url: '',
+        default_app: 'liturgical_calendar'
+      },
+      custom_table_builder: null,
+    },
+    validationSchema: validationSchemas[0],
+    onSubmit: async (values) => {
+      await handleFinalSubmit(values);
+    }
+  });
+
+  // Load template churches
+  useEffect(() => {
+    const fetchTemplateChurches = async () => {
+      try {
+        setLoading(true);
+        const response = await fetch('/api/admin/churches?preferred_language=en', {
+          credentials: 'include'
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          const templatesWithTables = await Promise.all(
+            data.churches.map(async (church: any) => {
+              try {
+                const tablesResponse = await fetch(`/api/admin/churches/${church.id}/tables`, {
+                  credentials: 'include'
+                });
+                const tablesData = await tablesResponse.json();
+                return {
+                  ...church,
+                  available_tables: tablesData.tables || []
+                };
+              } catch {
+                return {
+                  ...church,
+                  available_tables: []
+                };
+              }
+            })
+          );
+          setTemplateChurches(templatesWithTables);
+        }
+      } catch (error) {
+        console.error('Error fetching template churches:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTemplateChurches();
+  }, []);
+
+  // Handle template selection
+  const handleTemplateSelection = (templateId: number | null) => {
+    const template = templateChurches.find(t => t.id === templateId) || null;
+    setSelectedTemplate(template);
+    formik.setFieldValue('template_church_id', templateId);
+
+    if (template) {
+      formik.setFieldValue('selected_tables', template.available_tables);
+    }
+  };
+
+  // Handle adding custom field
+  const handleAddCustomField = (field: CustomField) => {
+    const currentFields = formik.values.custom_fields;
+    if (editingField) {
+      const updatedFields = currentFields.map(f => f.id === field.id ? field : f);
+      formik.setFieldValue('custom_fields', updatedFields);
+      setEditingField(null);
+    } else {
+      formik.setFieldValue('custom_fields', [...currentFields, { ...field, id: Date.now().toString() }]);
+    }
+    setCustomFieldDialog(false);
+  };
+
+  // Handle adding user
+  const handleAddUser = (user: ChurchUser) => {
+    const currentUsers = formik.values.initial_users;
+    if (editingUser) {
+      const updatedUsers = currentUsers.map(u => u.id === user.id ? user : u);
+      formik.setFieldValue('initial_users', updatedUsers);
+      setEditingUser(null);
+    } else {
+      formik.setFieldValue('initial_users', [...currentUsers, { ...user, id: Date.now().toString() }]);
+    }
+    setUserDialog(false);
+  };
+
+  // Handle step navigation
+  const handleNext = () => {
+    if (activeStep < steps.length - 1) {
+      setActiveStep(activeStep + 1);
+    }
+  };
+
+  const handleBack = () => {
+    setActiveStep(activeStep - 1);
+  };
+
+  // Copy token to clipboard
+  const handleCopyToken = async () => {
+    if (wizardResult?.registration_token) {
+      try {
+        await navigator.clipboard.writeText(wizardResult.registration_token);
+        setTokenCopied(true);
+        setTimeout(() => setTokenCopied(false), 2000);
+      } catch {
+        // Fallback
+        const textarea = document.createElement('textarea');
+        textarea.value = wizardResult.registration_token;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+        setTokenCopied(true);
+        setTimeout(() => setTokenCopied(false), 2000);
+      }
+    }
+  };
+
+  // Handle final submission
+  const handleFinalSubmit = async (values: ChurchWizardData) => {
+    try {
+      setIsSubmitting(true);
+
+      const response = await fetch('/api/admin/churches/wizard', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        body: JSON.stringify(values)
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        // Store result and advance to token step
+        setWizardResult({
+          church_id: result.church_id,
+          db_name: result.db_name,
+          registration_token: result.registration_token,
+          church_name: values.name,
+        });
+        setActiveStep(steps.length - 1); // Go to Registration Token step
+      } else {
+        const errorData = await response.json();
+
+        if (response.status === 400 && errorData.required) {
+          const missingFields = errorData.required.join(', ');
+          setToast({ message: `Please fill in all required fields: ${missingFields}`, severity: 'error' });
+        } else {
+          setToast({ message: errorData.message || 'Failed to create church', severity: 'error' });
+        }
+
+        throw new Error(errorData.message || 'Failed to create church');
+      }
+    } catch (error: any) {
+      console.error('Error creating church:', error);
+      if (!error.message?.includes('required fields')) {
+        setToast({ message: 'An unexpected error occurred. Please try again.', severity: 'error' });
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Handle table builder toast
+  const handleBuilderToast = useCallback((message: string, severity?: 'success' | 'error' | 'warning' | 'info') => {
+    setToast({ message, severity: severity || 'info' });
+  }, []);
+
+  // Render step content
+  const renderStepContent = (step: number) => {
+    switch (step) {
+      case 0:
+        return <BasicInformationStep formik={formik} />;
+      case 1:
+        return (
+          <TemplateSelectionStep
+            formik={formik}
+            templateChurches={templateChurches}
+            selectedTemplate={selectedTemplate}
+            onTemplateSelect={handleTemplateSelection}
+            loading={loading}
+          />
+        );
+      case 2:
+        return (
+          <RecordTablesStep
+            formik={formik}
+            selectedTemplate={selectedTemplate}
+            onAddCustomField={() => setCustomFieldDialog(true)}
+            onEditCustomField={(field) => {
+              setEditingField(field);
+              setCustomFieldDialog(true);
+            }}
+            onDeleteCustomField={(fieldId) => {
+              const updatedFields = formik.values.custom_fields.filter(f => f.id !== fieldId);
+              formik.setFieldValue('custom_fields', updatedFields);
+            }}
+            onToast={handleBuilderToast}
+          />
+        );
+      case 3:
+        return (
+          <UserManagementStep
+            formik={formik}
+            onAddUser={() => setUserDialog(true)}
+            onEditUser={(user) => {
+              setEditingUser(user);
+              setUserDialog(true);
+            }}
+            onDeleteUser={(userId) => {
+              const updatedUsers = formik.values.initial_users.filter(u => u.id !== userId);
+              formik.setFieldValue('initial_users', updatedUsers);
+            }}
+          />
+        );
+      case 4:
+        return <LandingPageStep formik={formik} />;
+      case 5:
+        return <ReviewStep formik={formik} selectedTemplate={selectedTemplate} />;
+      case 6:
+        return wizardResult ? (
+          <RegistrationTokenStep
+            result={wizardResult}
+            onCopyToken={handleCopyToken}
+            tokenCopied={tokenCopied}
+          />
+        ) : null;
+      default:
+        return null;
+    }
+  };
+
+  // Check if user has permission to create churches
+  if (!hasRole(['super_admin'])) {
+    return (
+      <Box p={3}>
+        <Alert severity="error">
+          You don't have permission to create churches. Please contact a system administrator.
+        </Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box p={3} maxWidth={1100} mx="auto">
+      <Card elevation={3}>
+        <CardContent sx={{ p: { xs: 2, md: 4 } }}>
+          {/* Header */}
+          <Box mb={4}>
+            <Stack direction="row" alignItems="center" spacing={2} mb={1}>
+              <Box
+                sx={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: 2,
+                  bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1),
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <ChurchIcon color="primary" fontSize="large" />
+              </Box>
+              <Box>
+                <Typography variant="h4" fontWeight={700}>
+                  Church Setup Wizard
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Step {activeStep + 1} of {steps.length} &mdash; {STEP_CONFIG[activeStep].description}
+                </Typography>
+              </Box>
+            </Stack>
+          </Box>
+
+          <Stepper
+            activeStep={activeStep}
+            orientation="vertical"
+            connector={<StyledStepConnector />}
+          >
+            {steps.map((label, index) => (
+              <Step key={label} completed={wizardResult ? index < steps.length - 1 : undefined}>
+                <StepLabel
+                  StepIconProps={{
+                    sx: {
+                      '&.Mui-active': { color: 'primary.main' },
+                      '&.Mui-completed': { color: 'success.main' },
+                    }
+                  }}
+                >
+                  <Stack direction="row" alignItems="center" spacing={1}>
+                    <Typography variant="subtitle1" fontWeight={activeStep === index ? 700 : 500}>
+                      {label}
+                    </Typography>
+                    {activeStep === index && (
+                      <Chip
+                        label="Current"
+                        size="small"
+                        color="primary"
+                        variant="outlined"
+                        sx={{ height: 20, fontSize: '0.7rem' }}
+                      />
+                    )}
+                  </Stack>
+                </StepLabel>
+                <StepContent>
+                  <Box my={2}>
+                    {renderStepContent(index)}
+                  </Box>
+
+                  {/* Navigation buttons - don't show on token step */}
+                  {index < steps.length - 1 && (
+                    <Box mt={3} display="flex" gap={1}>
+                      <Button
+                        disabled={activeStep === 0}
+                        onClick={handleBack}
+                        variant="outlined"
+                        size="small"
+                      >
+                        Back
+                      </Button>
+
+                      {activeStep === steps.length - 2 ? (
+                        <Button
+                          variant="contained"
+                          onClick={() => formik.handleSubmit()}
+                          disabled={isSubmitting}
+                          startIcon={isSubmitting ? <CircularProgress size={18} /> : <SaveIcon />}
+                        >
+                          {isSubmitting ? 'Creating Church...' : 'Create Church'}
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="contained"
+                          onClick={handleNext}
+                        >
+                          Continue
+                        </Button>
+                      )}
+                    </Box>
+                  )}
+
+                  {/* Token step - show finish button */}
+                  {index === steps.length - 1 && wizardResult && (
+                    <Box mt={3}>
+                      <Button
+                        variant="contained"
+                        color="success"
+                        onClick={() => navigate(`/apps/church-management/edit/${wizardResult.church_id}`, {
+                          state: {
+                            message: `Church "${wizardResult.church_name}" created successfully!`,
+                            severity: 'success'
+                          }
+                        })}
+                        startIcon={<CheckIcon />}
+                      >
+                        Go to Church Management
+                      </Button>
+                    </Box>
+                  )}
+                </StepContent>
+              </Step>
+            ))}
+          </Stepper>
+        </CardContent>
+      </Card>
+
+      {/* Custom Field Dialog */}
+      <CustomFieldDialog
+        open={customFieldDialog}
+        onClose={() => {
+          setCustomFieldDialog(false);
+          setEditingField(null);
+        }}
+        onSave={handleAddCustomField}
+        editingField={editingField}
+        existingTables={formik.values.selected_tables}
+      />
+
+      {/* User Dialog */}
+      <UserDialog
+        open={userDialog}
+        onClose={() => {
+          setUserDialog(false);
+          setEditingUser(null);
+        }}
+        onSave={handleAddUser}
+        editingUser={editingUser}
+      />
+
+      {/* Toast */}
+      <Snackbar
+        open={!!toast}
+        autoHideDuration={4000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert severity={toast.severity} onClose={() => setToast(null)} variant="filled">
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </Box>
+  );
+};
+
+// ============================================================================
+// Step Components
+// ============================================================================
+
+const BasicInformationStep: React.FC<{ formik: any }> = ({ formik }) => (
+  <Grid container spacing={3}>
+    <Grid item xs={12} md={6}>
+      <TextField
+        fullWidth
+        name="name"
+        label="Church Name"
+        value={formik.values.name}
+        onChange={formik.handleChange}
+        error={formik.touched.name && Boolean(formik.errors.name)}
+        helperText={formik.touched.name && formik.errors.name}
+        required
+      />
+    </Grid>
+    <Grid item xs={12} md={6}>
+      <TextField
+        fullWidth
+        name="email"
+        label="Admin Email"
+        type="email"
+        value={formik.values.email}
+        onChange={formik.handleChange}
+        error={formik.touched.email && Boolean(formik.errors.email)}
+        helperText={formik.touched.email && formik.errors.email}
+        required
+      />
+    </Grid>
+    <Grid item xs={12} md={6}>
+      <TextField
+        fullWidth
+        name="phone"
+        label="Phone Number"
+        value={formik.values.phone}
+        onChange={formik.handleChange}
+        error={formik.touched.phone && Boolean(formik.errors.phone)}
+        helperText={formik.touched.phone && formik.errors.phone}
+        required
+      />
+    </Grid>
+    <Grid item xs={12} md={6}>
+      <TextField
+        fullWidth
+        name="website"
+        label="Website URL"
+        value={formik.values.website}
+        onChange={formik.handleChange}
+      />
+    </Grid>
+    <Grid item xs={12}>
+      <TextField
+        fullWidth
+        name="address"
+        label="Address"
+        value={formik.values.address}
+        onChange={formik.handleChange}
+      />
+    </Grid>
+    <Grid item xs={12} md={4}>
+      <TextField
+        fullWidth
+        name="city"
+        label="City"
+        value={formik.values.city}
+        onChange={formik.handleChange}
+        error={formik.touched.city && Boolean(formik.errors.city)}
+        helperText={formik.touched.city && formik.errors.city}
+        required
+      />
+    </Grid>
+    <Grid item xs={12} md={4}>
+      <TextField
+        fullWidth
+        name="state_province"
+        label="State/Province"
+        value={formik.values.state_province}
+        onChange={formik.handleChange}
+      />
+    </Grid>
+    <Grid item xs={12} md={4}>
+      <TextField
+        fullWidth
+        name="postal_code"
+        label="Postal Code"
+        value={formik.values.postal_code}
+        onChange={formik.handleChange}
+      />
+    </Grid>
+    <Grid item xs={12} md={4}>
+      <FormControl fullWidth>
+        <InputLabel>Country</InputLabel>
+        <Select
+          name="country"
+          label="Country"
+          value={formik.values.country}
+          onChange={formik.handleChange}
+          error={formik.touched.country && Boolean(formik.errors.country)}
+        >
+          <MenuItem value="United States">United States</MenuItem>
+          <MenuItem value="Canada">Canada</MenuItem>
+          <MenuItem value="Greece">Greece</MenuItem>
+          <MenuItem value="Romania">Romania</MenuItem>
+          <MenuItem value="Russia">Russia</MenuItem>
+          <MenuItem value="Serbia">Serbia</MenuItem>
+          <MenuItem value="Bulgaria">Bulgaria</MenuItem>
+          <MenuItem value="Other">Other</MenuItem>
+        </Select>
+      </FormControl>
+    </Grid>
+    <Grid item xs={12} md={4}>
+      <FormControl fullWidth>
+        <InputLabel>Language</InputLabel>
+        <Select
+          name="preferred_language"
+          label="Language"
+          value={formik.values.preferred_language}
+          onChange={formik.handleChange}
+        >
+          <MenuItem value="en">English</MenuItem>
+          <MenuItem value="el">Greek</MenuItem>
+          <MenuItem value="ro">Romanian</MenuItem>
+          <MenuItem value="ru">Russian</MenuItem>
+          <MenuItem value="sr">Serbian</MenuItem>
+          <MenuItem value="bg">Bulgarian</MenuItem>
+        </Select>
+      </FormControl>
+    </Grid>
+    <Grid item xs={12} md={4}>
+      <FormControl fullWidth>
+        <InputLabel>Currency</InputLabel>
+        <Select
+          name="currency"
+          label="Currency"
+          value={formik.values.currency}
+          onChange={formik.handleChange}
+        >
+          <MenuItem value="USD">USD ($)</MenuItem>
+          <MenuItem value="CAD">CAD ($)</MenuItem>
+          <MenuItem value="EUR">EUR</MenuItem>
+          <MenuItem value="GBP">GBP</MenuItem>
+          <MenuItem value="RON">RON (lei)</MenuItem>
+          <MenuItem value="RUB">RUB</MenuItem>
+        </Select>
+      </FormControl>
+    </Grid>
+  </Grid>
+);
+
+const TemplateSelectionStep: React.FC<{
+  formik: any;
+  templateChurches: TemplateChurch[];
+  selectedTemplate: TemplateChurch | null;
+  onTemplateSelect: (templateId: number | null) => void;
+  loading: boolean;
+}> = ({ formik, templateChurches, selectedTemplate, onTemplateSelect, loading }) => (
+  <Box>
+    <Typography variant="body2" color="text.secondary" paragraph>
+      Select an existing church to use as a template. This will copy its table structure and settings.
+    </Typography>
+
+    {loading ? (
+      <Box display="flex" justifyContent="center" py={4}>
+        <CircularProgress />
+        <Typography ml={2}>Loading template churches...</Typography>
+      </Box>
+    ) : (
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Paper
+            variant="outlined"
+            sx={{
+              p: 2,
+              mb: 1,
+              cursor: 'pointer',
+              borderColor: formik.values.template_church_id === null ? 'primary.main' : 'divider',
+              borderWidth: formik.values.template_church_id === null ? 2 : 1,
+              bgcolor: formik.values.template_church_id === null ? (theme: any) => alpha(theme.palette.primary.main, 0.04) : 'transparent',
+            }}
+            onClick={() => onTemplateSelect(null)}
+          >
+            <FormControlLabel
+              control={<Checkbox checked={formik.values.template_church_id === null} onChange={() => onTemplateSelect(null)} />}
+              label={
+                <Box>
+                  <Typography variant="subtitle1" fontWeight={600}>Start from Scratch</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Create a new church with default table structures
+                  </Typography>
+                </Box>
+              }
+            />
+          </Paper>
+        </Grid>
+
+        {templateChurches.map((church) => (
+          <Grid item xs={12} md={6} key={church.id}>
+            <Paper
+              variant="outlined"
+              sx={{
+                p: 2,
+                cursor: 'pointer',
+                borderWidth: selectedTemplate?.id === church.id ? 2 : 1,
+                borderColor: selectedTemplate?.id === church.id ? 'primary.main' : 'divider',
+                bgcolor: selectedTemplate?.id === church.id ? (theme: any) => alpha(theme.palette.primary.main, 0.04) : 'transparent',
+                transition: 'all 0.2s',
+                '&:hover': { borderColor: 'primary.light' },
+              }}
+              onClick={() => onTemplateSelect(church.id)}
+            >
+              <FormControlLabel
+                control={<Checkbox checked={selectedTemplate?.id === church.id} onChange={() => onTemplateSelect(church.id)} />}
+                label={
+                  <Box>
+                    <Typography variant="subtitle1" fontWeight={600}>{church.name}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {church.city}, {church.country}
+                    </Typography>
+                    <Chip label={`${church.available_tables.length} tables`} size="small" sx={{ mt: 0.5 }} />
+                  </Box>
+                }
+              />
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    )}
+  </Box>
+);
+
+const RecordTablesStep: React.FC<{
+  formik: any;
+  selectedTemplate: TemplateChurch | null;
+  onAddCustomField: () => void;
+  onEditCustomField: (field: CustomField) => void;
+  onDeleteCustomField: (fieldId: string) => void;
+  onToast: (message: string, severity?: 'success' | 'error' | 'warning' | 'info') => void;
+}> = ({ formik, selectedTemplate, onAddCustomField, onEditCustomField, onDeleteCustomField, onToast }) => {
+  const [tabValue, setTabValue] = useState(0);
+
+  return (
+    <Box>
+      <Tabs value={tabValue} onChange={(_, v) => setTabValue(v)} sx={{ mb: 3 }}>
+        <Tab label="Standard Tables" icon={<StorageIcon />} iconPosition="start" />
+        <Tab label="Custom Table Builder" icon={<TableIcon />} iconPosition="start" />
+      </Tabs>
+
+      {tabValue === 0 && (
+        <>
+          <Typography variant="body2" color="text.secondary" paragraph>
+            Choose which record tables to create in the church database.
+          </Typography>
+
+          <Grid container spacing={2}>
+            {AVAILABLE_RECORD_TABLES.map((table) => (
+              <Grid item xs={12} md={6} key={table.key}>
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    p: 2,
+                    borderColor: formik.values.selected_tables.includes(table.key) ? 'primary.main' : 'divider',
+                    borderWidth: formik.values.selected_tables.includes(table.key) ? 2 : 1,
+                    bgcolor: formik.values.selected_tables.includes(table.key) ? (theme: any) => alpha(theme.palette.primary.main, 0.04) : 'transparent',
+                    transition: 'all 0.2s',
+                  }}
+                >
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={formik.values.selected_tables.includes(table.key)}
+                        onChange={(e) => {
+                          const currentTables = formik.values.selected_tables;
+                          if (e.target.checked) {
+                            formik.setFieldValue('selected_tables', [...currentTables, table.key]);
+                          } else {
+                            formik.setFieldValue('selected_tables', currentTables.filter((t: string) => t !== table.key));
+                          }
+                        }}
+                      />
+                    }
+                    label={
+                      <Box>
+                        <Typography variant="subtitle2" fontWeight={600}>{table.label}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {table.description}
+                        </Typography>
+                      </Box>
+                    }
+                  />
+                </Paper>
+              </Grid>
+            ))}
+          </Grid>
+
+          <Divider sx={{ my: 3 }} />
+
+          <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+            <Typography variant="subtitle1" fontWeight={600}>Custom Fields</Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<AddIcon />}
+              onClick={onAddCustomField}
+            >
+              Add Custom Field
+            </Button>
+          </Box>
+
+          {formik.values.custom_fields.length === 0 ? (
+            <Alert severity="info" variant="outlined">
+              No custom fields added. You can extend any table with additional columns.
+            </Alert>
+          ) : (
+            <List dense>
+              {formik.values.custom_fields.map((field: CustomField) => (
+                <ListItem key={field.id} divider>
+                  <ListItemText
+                    primary={`${field.field_name} (${field.field_type})`}
+                    secondary={`Table: ${field.table_name} - ${field.description}`}
+                  />
+                  <ListItemSecondaryAction>
+                    <IconButton size="small" onClick={() => onEditCustomField(field)}>
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" onClick={() => onDeleteCustomField(field.id)} color="error">
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </ListItemSecondaryAction>
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </>
+      )}
+
+      {tabValue === 1 && (
+        <Box>
+          <Typography variant="body2" color="text.secondary" paragraph>
+            Use the interactive table builder to design a custom record table. Define columns and optionally pre-populate rows.
+          </Typography>
+
+          <TextField
+            fullWidth
+            label="Custom Table Name"
+            placeholder="e.g., special_services"
+            value={formik.values.custom_table_builder?.table_name || ''}
+            onChange={(e) => {
+              const sanitized = e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, '_');
+              formik.setFieldValue('custom_table_builder', {
+                ...formik.values.custom_table_builder,
+                table_name: sanitized,
+                data: formik.values.custom_table_builder?.data || { columns: [], rows: [] },
+              });
+            }}
+            helperText="Use lowercase letters, numbers, and underscores only"
+            sx={{ mb: 2 }}
+          />
+
+          <Paper variant="outlined" sx={{ p: 2, minHeight: 300 }}>
+            <LiveTableBuilder
+              data={formik.values.custom_table_builder?.data || { columns: [{ id: 'col_0', label: 'Column A' }], rows: [{ id: 'row_0', cells: { col_0: '' } }] }}
+              onDataChange={(data: TableData) => {
+                formik.setFieldValue('custom_table_builder', {
+                  ...formik.values.custom_table_builder,
+                  table_name: formik.values.custom_table_builder?.table_name || '',
+                  data,
+                });
+              }}
+              onToast={onToast}
+            />
+          </Paper>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const UserManagementStep: React.FC<{
+  formik: any;
+  onAddUser: () => void;
+  onEditUser: (user: ChurchUser) => void;
+  onDeleteUser: (userId: string) => void;
+}> = ({ formik, onAddUser, onEditUser, onDeleteUser }) => (
+  <Box>
+    <Typography variant="body2" color="text.secondary" paragraph>
+      Add users who will have access to the new church's records. They will receive email invitations.
+    </Typography>
+
+    <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+      <Typography variant="subtitle1" fontWeight={600}>
+        Users ({formik.values.initial_users.length})
+      </Typography>
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<AddIcon />}
+        onClick={onAddUser}
+      >
+        Add User
+      </Button>
+    </Box>
+
+    {formik.values.initial_users.length === 0 ? (
+      <Alert severity="info" variant="outlined">
+        No users added yet. Users can also be added after church creation, or they can self-register using the church's registration token.
+      </Alert>
+    ) : (
+      <List dense>
+        {formik.values.initial_users.map((user: ChurchUser) => (
+          <ListItem key={user.id} divider>
+            <ListItemText
+              primary={`${user.first_name} ${user.last_name}`}
+              secondary={`${user.email} - ${user.role.toUpperCase()}`}
+            />
+            <ListItemSecondaryAction>
+              <Chip
+                label={user.send_invite ? 'Invite' : 'No invite'}
+                color={user.send_invite ? 'success' : 'default'}
+                size="small"
+                variant="outlined"
+                sx={{ mr: 1 }}
+              />
+              <IconButton size="small" onClick={() => onEditUser(user)}>
+                <EditIcon fontSize="small" />
+              </IconButton>
+              <IconButton size="small" onClick={() => onDeleteUser(user.id)} color="error">
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </ListItemSecondaryAction>
+          </ListItem>
+        ))}
+      </List>
+    )}
+  </Box>
+);
+
+const LandingPageStep: React.FC<{ formik: any }> = ({ formik }) => (
+  <Box>
+    <Typography variant="body2" color="text.secondary" paragraph>
+      Configure a custom landing page for church members.
+    </Typography>
+
+    <FormControlLabel
+      control={
+        <Switch
+          checked={formik.values.custom_landing_page.enabled}
+          onChange={(e) =>
+            formik.setFieldValue('custom_landing_page.enabled', e.target.checked)
+          }
+        />
+      }
+      label="Enable Custom Landing Page"
+      sx={{ mb: 3 }}
+    />
+
+    {formik.values.custom_landing_page.enabled && (
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            label="Landing Page Title"
+            value={formik.values.custom_landing_page.title}
+            onChange={(e) =>
+              formik.setFieldValue('custom_landing_page.title', e.target.value)
+            }
+            placeholder="Welcome to Our Church"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            label="Primary Color"
+            type="color"
+            value={formik.values.custom_landing_page.primary_color}
+            onChange={(e) =>
+              formik.setFieldValue('custom_landing_page.primary_color', e.target.value)
+            }
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            fullWidth
+            multiline
+            rows={3}
+            label="Welcome Message"
+            value={formik.values.custom_landing_page.welcome_message}
+            onChange={(e) =>
+              formik.setFieldValue('custom_landing_page.welcome_message', e.target.value)
+            }
+            placeholder="Enter a welcome message for members..."
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            fullWidth
+            label="Logo URL"
+            value={formik.values.custom_landing_page.logo_url}
+            onChange={(e) =>
+              formik.setFieldValue('custom_landing_page.logo_url', e.target.value)
+            }
+            placeholder="https://example.com/logo.png"
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <FormControl fullWidth>
+            <InputLabel>Default Application</InputLabel>
+            <Select
+              value={formik.values.custom_landing_page.default_app}
+              onChange={(e) =>
+                formik.setFieldValue('custom_landing_page.default_app', e.target.value)
+              }
+              label="Default Application"
+            >
+              {DEFAULT_APP_OPTIONS.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+      </Grid>
+    )}
+  </Box>
+);
+
+const ReviewStep: React.FC<{
+  formik: any;
+  selectedTemplate: TemplateChurch | null;
+}> = ({ formik, selectedTemplate }) => (
+  <Box>
+    <Typography variant="body2" color="text.secondary" paragraph>
+      Please review all settings before creating the church.
+    </Typography>
+
+    <Grid container spacing={2}>
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ p: 2, bgcolor: (theme) => alpha(theme.palette.primary.main, 0.03) }}>
+          <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+            <ChurchIcon fontSize="small" color="primary" />
+            <Typography variant="subtitle2" fontWeight={700}>Church Information</Typography>
+          </Stack>
+          <Typography variant="body2"><strong>Name:</strong> {formik.values.name}</Typography>
+          <Typography variant="body2"><strong>Email:</strong> {formik.values.email}</Typography>
+          <Typography variant="body2"><strong>Location:</strong> {formik.values.city}, {formik.values.country}</Typography>
+          <Typography variant="body2"><strong>Language:</strong> {formik.values.preferred_language}</Typography>
+        </Paper>
+      </Grid>
+
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ p: 2, bgcolor: (theme) => alpha(theme.palette.info.main, 0.03) }}>
+          <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+            <StorageIcon fontSize="small" color="info" />
+            <Typography variant="subtitle2" fontWeight={700}>Database Setup</Typography>
+          </Stack>
+          <Typography variant="body2">
+            <strong>Template:</strong> {selectedTemplate ? selectedTemplate.name : 'Default'}
+          </Typography>
+          <Typography variant="body2">
+            <strong>Tables:</strong> {formik.values.selected_tables.length} selected
+          </Typography>
+          <Typography variant="body2">
+            <strong>Custom Fields:</strong> {formik.values.custom_fields.length}
+          </Typography>
+          {formik.values.custom_table_builder?.table_name && (
+            <Typography variant="body2">
+              <strong>Custom Table:</strong> {formik.values.custom_table_builder.table_name}
+            </Typography>
+          )}
+        </Paper>
+      </Grid>
+
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ p: 2, bgcolor: (theme) => alpha(theme.palette.success.main, 0.03) }}>
+          <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+            <PeopleIcon fontSize="small" color="success" />
+            <Typography variant="subtitle2" fontWeight={700}>Users</Typography>
+          </Stack>
+          <Typography variant="body2">
+            <strong>Initial Users:</strong> {formik.values.initial_users.length}
+          </Typography>
+          {formik.values.initial_users.slice(0, 3).map((user: ChurchUser) => (
+            <Typography key={user.id} variant="body2">
+              &bull; {user.first_name} {user.last_name} ({user.role})
+            </Typography>
+          ))}
+          {formik.values.initial_users.length > 3 && (
+            <Typography variant="body2" color="text.secondary">
+              ... and {formik.values.initial_users.length - 3} more
+            </Typography>
+          )}
+        </Paper>
+      </Grid>
+
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ p: 2, bgcolor: (theme) => alpha(theme.palette.warning.main, 0.03) }}>
+          <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+            <WebIcon fontSize="small" color="warning" />
+            <Typography variant="subtitle2" fontWeight={700}>Landing Page</Typography>
+          </Stack>
+          <Typography variant="body2">
+            <strong>Enabled:</strong> {formik.values.custom_landing_page.enabled ? 'Yes' : 'No'}
+          </Typography>
+          {formik.values.custom_landing_page.enabled && (
+            <>
+              <Typography variant="body2">
+                <strong>Title:</strong> {formik.values.custom_landing_page.title || 'Not set'}
+              </Typography>
+              <Typography variant="body2">
+                <strong>Default App:</strong> {
+                  DEFAULT_APP_OPTIONS.find(option =>
+                    option.value === formik.values.custom_landing_page.default_app
+                  )?.label || 'Not set'
+                }
+              </Typography>
+            </>
+          )}
+        </Paper>
+      </Grid>
+    </Grid>
+
+    <Alert severity="info" variant="outlined" sx={{ mt: 3 }}>
+      A unique <strong>registration token</strong> will be generated after creation. Share it with church members so they can self-register.
+    </Alert>
+  </Box>
+);
+
+// ============================================================================
+// Registration Token Step (Post-Creation)
+// ============================================================================
+
+const RegistrationTokenStep: React.FC<{
+  result: {
+    church_id: number;
+    db_name: string;
+    registration_token: string;
+    church_name: string;
+  };
+  onCopyToken: () => void;
+  tokenCopied: boolean;
+}> = ({ result, onCopyToken, tokenCopied }) => (
+  <Box>
+    <Alert severity="success" sx={{ mb: 3 }}>
+      <Typography variant="subtitle1" fontWeight={700}>
+        Church created successfully!
+      </Typography>
+      <Typography variant="body2">
+        "{result.church_name}" has been set up with database <code>{result.db_name}</code>.
+      </Typography>
+    </Alert>
+
+    <Paper
+      elevation={2}
+      sx={{
+        p: 3,
+        mb: 3,
+        border: '2px solid',
+        borderColor: 'primary.main',
+        borderRadius: 2,
+        bgcolor: (theme) => alpha(theme.palette.primary.main, 0.04),
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={1} mb={2}>
+        <TokenIcon color="primary" />
+        <Typography variant="h6" fontWeight={700}>
+          Registration Token
+        </Typography>
+      </Stack>
+
+      <Typography variant="body2" color="text.secondary" paragraph>
+        Share this token with church members. They can use it along with the church name to register at:
+      </Typography>
+
+      <Paper
+        variant="outlined"
+        sx={{ p: 1.5, mb: 2, bgcolor: 'grey.50', borderRadius: 1 }}
+      >
+        <Typography variant="body2" color="primary.main" fontWeight={500} sx={{ fontFamily: 'monospace' }}>
+          {window.location.origin}/auth/register
+        </Typography>
+      </Paper>
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          p: 2,
+          bgcolor: 'grey.900',
+          borderRadius: 1,
+          mb: 2,
+        }}
+      >
+        <Typography
+          variant="body2"
+          sx={{
+            fontFamily: 'monospace',
+            color: '#4caf50',
+            wordBreak: 'break-all',
+            flex: 1,
+            fontSize: '0.85rem',
+          }}
+        >
+          {result.registration_token}
+        </Typography>
+        <Tooltip title={tokenCopied ? 'Copied!' : 'Copy to clipboard'}>
+          <IconButton
+            onClick={onCopyToken}
+            size="small"
+            sx={{ color: tokenCopied ? 'success.main' : 'grey.400' }}
+          >
+            {tokenCopied ? <CheckIcon /> : <CopyIcon />}
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      <Alert severity="warning" variant="outlined">
+        <Typography variant="body2">
+          <strong>Important:</strong> Save this token securely. Users who register with this token will have their accounts locked by default until a super admin reviews and assigns them a role.
+        </Typography>
+      </Alert>
+    </Paper>
+
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Typography variant="subtitle2" gutterBottom fontWeight={600}>
+        Registration Details
+      </Typography>
+      <Typography variant="body2">
+        <strong>Church Name:</strong> {result.church_name}
+      </Typography>
+      <Typography variant="body2">
+        <strong>Church ID:</strong> {result.church_id}
+      </Typography>
+      <Typography variant="body2">
+        <strong>Database:</strong> {result.db_name}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+        Members will need both the <strong>church name</strong> (exactly as shown above) and the <strong>registration token</strong> to create their accounts.
+      </Typography>
+    </Paper>
+  </Box>
+);
+
+// ============================================================================
+// Dialog Components
+// ============================================================================
+
+const CustomFieldDialog: React.FC<{
+  open: boolean;
+  onClose: () => void;
+  onSave: (field: CustomField) => void;
+  editingField: CustomField | null;
+  existingTables: string[];
+}> = ({ open, onClose, onSave, editingField, existingTables }) => {
+  const [fieldData, setFieldData] = useState<Partial<CustomField>>({
+    table_name: '',
+    field_name: '',
+    field_type: 'VARCHAR',
+    is_required: false,
+    description: ''
+  });
+
+  useEffect(() => {
+    if (editingField) {
+      setFieldData(editingField);
+    } else {
+      setFieldData({
+        table_name: '',
+        field_name: '',
+        field_type: 'VARCHAR',
+        is_required: false,
+        description: ''
+      });
+    }
+  }, [editingField, open]);
+
+  const handleSave = () => {
+    if (fieldData.table_name && fieldData.field_name && fieldData.field_type) {
+      onSave({
+        ...fieldData,
+        id: editingField?.id || Date.now().toString()
+      } as CustomField);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        {editingField ? 'Edit Custom Field' : 'Add Custom Field'}
+      </DialogTitle>
+      <DialogContent>
+        <Grid container spacing={2} sx={{ mt: 1 }}>
+          <Grid item xs={12} md={6}>
+            <FormControl fullWidth>
+              <InputLabel>Table</InputLabel>
+              <Select
+                label="Table"
+                value={fieldData.table_name || ''}
+                onChange={(e) => setFieldData({ ...fieldData, table_name: e.target.value })}
+              >
+                {existingTables.map((table) => (
+                  <MenuItem key={table} value={table}>
+                    {AVAILABLE_RECORD_TABLES.find(t => t.key === table)?.label || table}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="Field Name"
+              value={fieldData.field_name || ''}
+              onChange={(e) => setFieldData({ ...fieldData, field_name: e.target.value })}
+              placeholder="e.g., sponsor_name"
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <FormControl fullWidth>
+              <InputLabel>Field Type</InputLabel>
+              <Select
+                label="Field Type"
+                value={fieldData.field_type || 'VARCHAR'}
+                onChange={(e) => setFieldData({ ...fieldData, field_type: e.target.value as any })}
+              >
+                {FIELD_TYPES.map((type) => (
+                  <MenuItem key={type.value} value={type.value}>
+                    {type.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            {fieldData.field_type === 'VARCHAR' && (
+              <TextField
+                fullWidth
+                type="number"
+                label="Max Length"
+                value={fieldData.field_length || 255}
+                onChange={(e) => setFieldData({ ...fieldData, field_length: parseInt(e.target.value) })}
+              />
+            )}
+          </Grid>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              multiline
+              rows={2}
+              label="Description"
+              value={fieldData.description || ''}
+              onChange={(e) => setFieldData({ ...fieldData, description: e.target.value })}
+              placeholder="Describe what this field is for..."
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={fieldData.is_required || false}
+                  onChange={(e) => setFieldData({ ...fieldData, is_required: e.target.checked })}
+                />
+              }
+              label="Required Field"
+            />
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={!fieldData.table_name || !fieldData.field_name || !fieldData.field_type}
+        >
+          {editingField ? 'Update' : 'Add'} Field
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const UserDialog: React.FC<{
+  open: boolean;
+  onClose: () => void;
+  onSave: (user: ChurchUser) => void;
+  editingUser: ChurchUser | null;
+}> = ({ open, onClose, onSave, editingUser }) => {
+  const [userData, setUserData] = useState<Partial<ChurchUser>>({
+    email: '',
+    first_name: '',
+    last_name: '',
+    role: 'user',
+    permissions: [],
+    send_invite: true
+  });
+
+  useEffect(() => {
+    if (editingUser) {
+      setUserData(editingUser);
+    } else {
+      setUserData({
+        email: '',
+        first_name: '',
+        last_name: '',
+        role: 'user',
+        permissions: [],
+        send_invite: true
+      });
+    }
+  }, [editingUser, open]);
+
+  const handleSave = () => {
+    if (userData.email && userData.first_name && userData.last_name) {
+      onSave({
+        ...userData,
+        id: editingUser?.id || Date.now().toString()
+      } as ChurchUser);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        {editingUser ? 'Edit User' : 'Add User'}
+      </DialogTitle>
+      <DialogContent>
+        <Grid container spacing={2} sx={{ mt: 1 }}>
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="First Name"
+              value={userData.first_name || ''}
+              onChange={(e) => setUserData({ ...userData, first_name: e.target.value })}
+              required
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label="Last Name"
+              value={userData.last_name || ''}
+              onChange={(e) => setUserData({ ...userData, last_name: e.target.value })}
+              required
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              type="email"
+              label="Email Address"
+              value={userData.email || ''}
+              onChange={(e) => setUserData({ ...userData, email: e.target.value })}
+              required
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <FormControl fullWidth>
+              <InputLabel>Role</InputLabel>
+              <Select
+                label="Role"
+                value={userData.role || 'user'}
+                onChange={(e) => setUserData({ ...userData, role: e.target.value as any })}
+              >
+                {USER_ROLES.map((role) => (
+                  <MenuItem key={role.value} value={role.value}>
+                    {role.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={userData.send_invite || false}
+                  onChange={(e) => setUserData({ ...userData, send_invite: e.target.checked })}
+                />
+              }
+              label="Send Email Invitation"
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <Typography variant="subtitle2" gutterBottom>
+              Permissions
+            </Typography>
+            <FormGroup row>
+              {AVAILABLE_PERMISSIONS.map((permission) => (
+                <FormControlLabel
+                  key={permission}
+                  control={
+                    <Checkbox
+                      checked={userData.permissions?.includes(permission) || false}
+                      onChange={(e) => {
+                        const currentPermissions = userData.permissions || [];
+                        if (e.target.checked) {
+                          setUserData({
+                            ...userData,
+                            permissions: [...currentPermissions, permission]
+                          });
+                        } else {
+                          setUserData({
+                            ...userData,
+                            permissions: currentPermissions.filter(p => p !== permission)
+                          });
+                        }
+                      }}
+                    />
+                  }
+                  label={permission.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase())}
+                />
+              ))}
+            </FormGroup>
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={!userData.email || !userData.first_name || !userData.last_name}
+        >
+          {editingUser ? 'Update' : 'Add'} User
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ChurchSetupWizard;

--- a/server/database/migrations/2026-02-21_church_registration_tokens.sql
+++ b/server/database/migrations/2026-02-21_church_registration_tokens.sql
@@ -1,0 +1,15 @@
+-- Church Registration Tokens
+-- Allows church-level registration tokens for self-service user registration
+-- Users who register via token are locked by default until admin review
+
+CREATE TABLE IF NOT EXISTS church_registration_tokens (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  church_id INT NOT NULL,
+  token VARCHAR(64) NOT NULL UNIQUE,
+  is_active TINYINT(1) DEFAULT 1,
+  created_by INT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (church_id) REFERENCES churches(id) ON DELETE CASCADE,
+  INDEX idx_crt_token (token),
+  INDEX idx_crt_church_id (church_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/server/src/api/admin.js
+++ b/server/src/api/admin.js
@@ -1,0 +1,1791 @@
+const { getAppPool } = require('../config/db-compat');
+// server/routes/admin.js
+const express = require('express');
+const { pool: promisePool } = require('../config/db-compat');
+const bcrypt = require('bcrypt');
+const {
+    canManageUser,
+    canPerformDestructiveOperation,
+    canChangeRole,
+    isRootSuperAdmin,
+    logUnauthorizedAttempt,
+    ROOT_SUPERADMIN_EMAIL
+} = require('../middleware/userAuthorization');
+const { requireRole } = require('../middleware/auth');
+
+const router = express.Router();
+
+// Mount admin menu management routes
+const menusRouter = require('../routes/admin/menus');
+router.use('/menus', menusRouter);
+
+// Use centralized auth middleware (supports both session and JWT fallback)
+const requireAdmin = requireRole(['admin', 'super_admin']);
+const requireSuperAdmin = requireRole(['super_admin']);
+
+// Middleware to check if user can create/edit users with specific roles
+const requireRolePermission = async (req, res, next) => {
+    const userRole = req.session?.user?.role || req.user?.role;
+    const targetRole = req.body.role;
+
+    if (!userRole) {
+        return res.status(401).json({
+            success: false,
+            message: 'Authentication required'
+        });
+    }
+
+    // Super admin can create/edit any role except super_admin
+    if (userRole === 'super_admin') {
+        if (targetRole === 'super_admin') {
+            return res.status(403).json({
+                success: false,
+                message: 'Cannot create or modify super_admin users'
+            });
+        }
+        return next();
+    }
+
+    // Regular admin can only create/edit non-admin roles
+    if (userRole === 'admin') {
+        if (targetRole === 'admin' || targetRole === 'super_admin') {
+            return res.status(403).json({
+                success: false,
+                message: 'Cannot create or modify admin or super_admin users'
+            });
+        }
+        return next();
+    }
+
+    return res.status(403).json({
+        success: false,
+        message: 'Insufficient privileges'
+    });
+};
+
+// Debug middleware for admin routes
+router.use((req, res, next) => {
+    console.log(`🔧 Admin route: ${req.method} ${req.path} - Original URL: ${req.originalUrl}`);
+    next();
+});
+
+// GET /admin/users - Get all users
+router.get('/users', requireAdmin, async (req, res) => {
+    try {
+        const { search, role, church_id, is_active } = req.query;
+        
+        let query = `
+            SELECT 
+                u.id,
+                u.email,
+                u.first_name,
+                u.last_name,
+                u.role,
+                u.church_id,
+                c.name as church_name,
+                u.is_active,
+                u.email_verified,
+                u.preferred_language,
+                u.timezone,
+                u.phone,
+                u.created_at,
+                u.updated_at,
+                u.last_login
+            FROM orthodoxmetrics_db.users u
+            LEFT JOIN orthodoxmetrics_db.churches c ON u.church_id = c.id
+            WHERE 1=1
+        `;
+        const params = [];
+
+        // Search filter (email, first_name, last_name)
+        if (search) {
+            query += ` AND (u.email LIKE ? OR u.first_name LIKE ? OR u.last_name LIKE ?)`;
+            const searchTerm = `%${search}%`;
+            params.push(searchTerm, searchTerm, searchTerm);
+        }
+
+        // Role filter
+        if (role && role !== 'all') {
+            query += ` AND u.role = ?`;
+            params.push(role);
+        }
+
+        // Church filter
+        if (church_id && church_id !== 'all') {
+            query += ` AND u.church_id = ?`;
+            params.push(parseInt(church_id));
+        }
+
+        // Active status filter
+        if (is_active !== undefined && is_active !== 'all') {
+            query += ` AND u.is_active = ?`;
+            params.push(is_active === 'true' ? 1 : 0);
+        }
+
+        query += ` ORDER BY u.created_at DESC`;
+
+        const [rows] = await getAppPool().query(query, params);
+
+        // Remove password_hash from results (shouldn't be in SELECT, but ensure it's not returned)
+        const users = rows.map(user => {
+            const { password_hash, ...safeUser } = user;
+            return safeUser;
+        });
+
+        res.json({
+            success: true,
+            users: users,
+            count: users.length
+        });
+    } catch (err) {
+        console.error('Error fetching users:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Server error while fetching users',
+            error: err.message
+        });
+    }
+});
+
+// POST /admin/users - Create new user
+router.post('/users', requireAdmin, requireRolePermission, async (req, res) => {
+    try {
+        const { email, first_name, last_name, role, church_id, phone, preferred_language, password } = req.body;
+        const currentUser = req.user || req.session?.user;
+
+        // Validate required fields
+        if (!email || !first_name || !last_name || !role) {
+            return res.status(400).json({
+                success: false,
+                message: 'Email, first name, last name, and role are required'
+            });
+        }
+
+        // Check if email already exists
+        const [existingUsers] = await getAppPool().query(
+            'SELECT id FROM orthodoxmetrics_db.users WHERE email = ?',
+            [email]
+        );
+
+        if (existingUsers.length > 0) {
+            return res.status(400).json({
+                success: false,
+                message: 'User with this email already exists'
+            });
+        }
+
+        // Generate password if not provided
+        let tempPassword = null;
+        let passwordHash;
+        
+        if (password) {
+            const saltRounds = 12;
+            passwordHash = await bcrypt.hash(password, saltRounds);
+        } else {
+            // Generate secure temporary password
+            tempPassword = Math.random().toString(36).slice(-12) + Math.random().toString(36).slice(-12);
+            const saltRounds = 12;
+            passwordHash = await bcrypt.hash(tempPassword, saltRounds);
+        }
+
+        // Insert user
+        const [result] = await getAppPool().query(`
+            INSERT INTO orthodoxmetrics_db.users (
+                email, first_name, last_name, role, church_id, phone, 
+                preferred_language, password_hash, is_active, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, NOW(), NOW())
+        `, [
+            email,
+            first_name,
+            last_name,
+            role,
+            church_id || null,
+            phone || null,
+            preferred_language || 'en',
+            passwordHash
+        ]);
+
+        const userId = result.insertId;
+
+        console.log(`✅ User created: ${email} (${role}) by ${currentUser.email} (role: ${currentUser.role})`);
+
+        // Get created user (without password_hash)
+        const [userRows] = await getAppPool().query(`
+            SELECT 
+                id, email, first_name, last_name, role, church_id, phone,
+                preferred_language, is_active, email_verified, created_at, updated_at, last_login
+            FROM orthodoxmetrics_db.users 
+            WHERE id = ?
+        `, [userId]);
+
+        res.json({
+            success: true,
+            message: 'User created successfully',
+            user: userRows[0],
+            tempPassword: tempPassword // Only returned if auto-generated
+        });
+    } catch (err) {
+        console.error('Error creating user:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Server error while creating user',
+            error: err.message
+        });
+    }
+});
+
+// PUT /admin/users/:id - Update user
+router.put('/users/:id', requireAdmin, async (req, res) => {
+    try {
+        const userId = parseInt(req.params.id);
+        const { email, first_name, last_name, role, church_id, preferred_language, is_active } = req.body;
+        const currentUser = req.user || req.session?.user;
+
+        // Don't allow updating self's role to lower privilege
+        if (userId === currentUser.id && role && role !== currentUser.role) {
+            return res.status(400).json({
+                success: false,
+                message: 'You cannot change your own role'
+            });
+        }
+
+        // Get target user
+        const [userRows] = await getAppPool().query(
+            'SELECT id, email, role, first_name, last_name FROM orthodoxmetrics_db.users WHERE id = ?',
+            [userId]
+        );
+
+        if (userRows.length === 0) {
+            return res.status(404).json({
+                success: false,
+                message: 'User not found'
+            });
+        }
+
+        const targetUser = userRows[0];
+
+        // Check if current user can manage target user
+        if (!canManageUser(currentUser, targetUser)) {
+            logUnauthorizedAttempt(currentUser, targetUser, 'UPDATE_USER');
+            return res.status(403).json({
+                success: false,
+                message: 'You do not have permission to update this user',
+                code: 'UPDATE_DENIED'
+            });
+        }
+
+        // Check role assignment permission if role is being changed
+        if (role && role !== targetUser.role) {
+            if (!canChangeRole(currentUser, targetUser, role)) {
+                logUnauthorizedAttempt(currentUser, targetUser, 'CHANGE_ROLE');
+                return res.status(403).json({
+                    success: false,
+                    message: 'You do not have permission to assign this role',
+                    code: 'ROLE_ASSIGNMENT_DENIED'
+                });
+            }
+
+            // Prevent assigning super_admin unless current user is super_admin
+            if (role === 'super_admin' && currentUser.role !== 'super_admin') {
+                return res.status(403).json({
+                    success: false,
+                    message: 'Only super_admin can assign super_admin role'
+                });
+            }
+        }
+
+        // Build update query dynamically
+        const updates = [];
+        const values = [];
+
+        if (email !== undefined) {
+            // Check if email is already taken by another user
+            const [emailCheck] = await getAppPool().query(
+                'SELECT id FROM orthodoxmetrics_db.users WHERE email = ? AND id != ?',
+                [email, userId]
+            );
+            if (emailCheck.length > 0) {
+                return res.status(400).json({
+                    success: false,
+                    message: 'Email is already in use by another user'
+                });
+            }
+            updates.push('email = ?');
+            values.push(email);
+        }
+
+        if (first_name !== undefined) {
+            updates.push('first_name = ?');
+            values.push(first_name);
+        }
+
+        if (last_name !== undefined) {
+            updates.push('last_name = ?');
+            values.push(last_name);
+        }
+
+        if (role !== undefined) {
+            updates.push('role = ?');
+            values.push(role);
+        }
+
+        if (church_id !== undefined) {
+            updates.push('church_id = ?');
+            values.push(church_id || null);
+        }
+
+        if (preferred_language !== undefined) {
+            updates.push('preferred_language = ?');
+            values.push(preferred_language);
+        }
+
+        if (is_active !== undefined) {
+            // Don't allow deactivating self
+            if (userId === currentUser.id && !is_active) {
+                return res.status(400).json({
+                    success: false,
+                    message: 'You cannot deactivate your own account'
+                });
+            }
+
+            // Check permission for deactivation
+            if (!is_active && !canPerformDestructiveOperation(currentUser, targetUser)) {
+                logUnauthorizedAttempt(currentUser, targetUser, 'DEACTIVATE_USER');
+                return res.status(403).json({
+                    success: false,
+                    message: 'You do not have permission to deactivate this user',
+                    code: 'DEACTIVATION_DENIED'
+                });
+            }
+
+            updates.push('is_active = ?');
+            values.push(is_active ? 1 : 0);
+        }
+
+        if (updates.length === 0) {
+            return res.status(400).json({
+                success: false,
+                message: 'No fields to update'
+            });
+        }
+
+        updates.push('updated_at = CURRENT_TIMESTAMP');
+        values.push(userId);
+
+        await getAppPool().query(
+            `UPDATE orthodoxmetrics_db.users SET ${updates.join(', ')} WHERE id = ?`,
+            values
+        );
+
+        console.log(`✅ User updated: ${targetUser.email} by ${currentUser.email} (role: ${currentUser.role})`);
+
+        // Get updated user (without password_hash)
+        const [updatedRows] = await getAppPool().query(`
+            SELECT 
+                id, email, first_name, last_name, role, church_id, phone,
+                preferred_language, is_active, email_verified, created_at, updated_at, last_login
+            FROM orthodoxmetrics_db.users 
+            WHERE id = ?
+        `, [userId]);
+
+        res.json({
+            success: true,
+            message: 'User updated successfully',
+            user: updatedRows[0]
+        });
+    } catch (err) {
+        console.error('Error updating user:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Server error while updating user',
+            error: err.message
+        });
+    }
+});
+
+// DELETE /admin/users/:id - Delete user
+router.delete('/users/:id', requireAdmin, async (req, res) => {
+    try {
+        const userId = parseInt(req.params.id);
+        const currentUser = req.user || req.session?.user;
+
+        // Don't allow deleting self
+        if (userId === currentUser.id) {
+            return res.status(400).json({
+                success: false,
+                message: 'You cannot delete your own account'
+            });
+        }
+
+        // Get target user
+        const [userRows] = await getAppPool().query(
+            'SELECT id, email, role, first_name, last_name FROM orthodoxmetrics_db.users WHERE id = ?',
+            [userId]
+        );
+
+        if (userRows.length === 0) {
+            return res.status(404).json({
+                success: false,
+                message: 'User not found'
+            });
+        }
+
+        const targetUser = userRows[0];
+
+        // Check if current user can perform destructive operation
+        if (!canPerformDestructiveOperation(currentUser, targetUser)) {
+            logUnauthorizedAttempt(currentUser, targetUser, 'DELETE_USER');
+            return res.status(403).json({
+                success: false,
+                message: 'You do not have permission to delete this user',
+                code: 'DELETE_DENIED'
+            });
+        }
+
+        // Super admin can delete anyone except super_admin
+        // Regular admin can only delete non-admin users
+        if (currentUser.role === 'super_admin') {
+            if (targetUser.role === 'super_admin') {
+                return res.status(403).json({
+                    success: false,
+                    message: 'Cannot delete super_admin users'
+                });
+            }
+        } else if (currentUser.role === 'admin') {
+            if (targetUser.role === 'admin' || targetUser.role === 'super_admin') {
+                return res.status(403).json({
+                    success: false,
+                    message: 'Cannot delete admin or super_admin users'
+                });
+            }
+        }
+
+        // Delete user
+        await getAppPool().query(
+            'DELETE FROM orthodoxmetrics_db.users WHERE id = ?',
+            [userId]
+        );
+
+        console.log(`✅ User deleted: ${targetUser.email} by ${currentUser.email} (role: ${currentUser.role})`);
+
+        res.json({
+            success: true,
+            message: 'User deleted successfully'
+        });
+    } catch (err) {
+        console.error('Error deleting user:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Server error while deleting user',
+            error: err.message
+        });
+    }
+});
+
+// PUT /admin/users/:id/toggle-status - Toggle user active status (alias for frontend compatibility)
+router.put('/users/:id/toggle-status', requireAdmin, async (req, res) => {
+    try {
+        const userId = parseInt(req.params.id);
+        const currentUser = req.user || req.session?.user;
+
+        // Get current user status
+        const [userRows] = await getAppPool().query(
+            'SELECT id, email, role, first_name, last_name, is_active FROM orthodoxmetrics_db.users WHERE id = ?',
+            [userId]
+        );
+
+        if (userRows.length === 0) {
+            return res.status(404).json({
+                success: false,
+                message: 'User not found'
+            });
+        }
+
+        const targetUser = userRows[0];
+        const newStatus = !targetUser.is_active; // Toggle status
+
+        // Don't allow deactivating self
+        if (userId === currentUser.id && !newStatus) {
+            return res.status(400).json({
+                success: false,
+                message: 'You cannot deactivate your own account'
+            });
+        }
+
+        // Check permissions
+        if (!newStatus && !canPerformDestructiveOperation(currentUser, targetUser)) {
+            logUnauthorizedAttempt(currentUser, targetUser, 'DEACTIVATE_USER');
+            return res.status(403).json({
+                success: false,
+                message: 'You do not have permission to deactivate this user',
+                code: 'DEACTIVATION_DENIED'
+            });
+        }
+
+        if (newStatus && !canManageUser(currentUser, targetUser)) {
+            logUnauthorizedAttempt(currentUser, targetUser, 'ACTIVATE_USER');
+            return res.status(403).json({
+                success: false,
+                message: 'You do not have permission to activate this user',
+                code: 'ACTIVATION_DENIED'
+            });
+        }
+
+        // Update status
+        await getAppPool().query(
+            'UPDATE orthodoxmetrics_db.users SET is_active = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+            [newStatus ? 1 : 0, userId]
+        );
+
+        console.log(`✅ User status toggled: ${targetUser.email} -> ${newStatus ? 'active' : 'inactive'} by ${currentUser.email} (role: ${currentUser.role})`);
+
+        res.json({
+            success: true,
+            message: `User ${newStatus ? 'activated' : 'deactivated'} successfully`
+        });
+    } catch (err) {
+        console.error('Error toggling user status:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Server error while toggling user status',
+            error: err.message
+        });
+    }
+});
+
+// GET /api/admin/churches - Get all churches (for admin panel / ChurchHeader.tsx)
+router.get('/churches', requireAdmin, async (req, res) => {
+    try {
+        const [churches] = await getAppPool().query(
+            `SELECT id, name, church_name, is_active 
+             FROM churches 
+             WHERE is_active = 1 
+             ORDER BY name ASC`
+        );
+        
+        res.json({
+            success: true,
+            churches: churches
+        });
+    } catch (err) {
+        console.error('❌ Error fetching church list:', err);
+        res.status(500).json({ success: false, message: 'Internal server error' });
+    }
+});
+
+// GET /api/admin/churches/:id - Get individual church by ID (admin only)
+router.get('/churches/:id', requireAdmin, async (req, res) => {
+    try {
+        const churchId = parseInt(req.params.id);
+        console.log('🔍 Admin request for church ID:', churchId, 'from:', req.user?.email);
+
+        if (isNaN(churchId)) {
+            return res.status(400).json({
+                success: false,
+                message: 'Invalid church ID format'
+            });
+        }
+
+        const [churchResult] = await getAppPool().query(
+            `SELECT 
+                id, name, email, phone, address, city, state_province, postal_code, 
+                country, website, preferred_language, timezone, currency, tax_id,
+                description_multilang, settings, is_active, database_name,
+                has_baptism_records, has_marriage_records, has_funeral_records, 
+                setup_complete, created_at, updated_at
+            FROM churches 
+            WHERE id = ? AND is_active = 1`,
+            [churchId]
+        );
+
+        if (churchResult.length === 0) {
+            console.log('❌ Church not found with ID:', churchId);
+            return res.status(404).json({
+                success: false,
+                message: 'Church not found'
+            });
+        }
+
+        const church = churchResult[0];
+        console.log('✅ Church found for editing:', church.name);
+
+        res.json({
+            success: true,
+            ...church, // Return the church data directly for compatibility with frontend
+            church_id: church.id, // Add church_id for frontend compatibility
+            // Add backward compatibility aliases
+            admin_email: church.email,
+            church_name: church.name,
+            language_preference: church.preferred_language || 'en'
+        });
+    } catch (error) {
+        console.error('❌ Error fetching church for admin:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Failed to fetch church',
+            error: error.message
+        });
+    }
+});
+
+// POST /admin/churches - Create new church (super_admin only)
+
+// POST /admin/churches/wizard - Create church via comprehensive wizard (super_admin only)
+router.post('/churches/wizard', requireSuperAdmin, async (req, res) => {
+    try {
+        console.log('🧙‍♂️ Church Setup Wizard request:', req.body);
+        
+        const {
+            // Basic church info
+            name, email, phone, address, city, state_province, postal_code, country,
+            website, preferred_language = 'en', timezone = 'UTC', currency = 'USD', is_active = true,
+            
+            // Template selection
+            template_church_id = null,
+            selected_tables = [],
+            
+            // Custom fields
+            custom_fields = [],
+            
+            // Initial users
+            initial_users = [],
+            
+            // Landing page configuration
+            custom_landing_page = { enabled: false }
+        } = req.body;
+
+        // Validate required fields
+        if (!name || !email) {
+            return res.status(400).json({
+                success: false,
+                message: 'Church name and email are required'
+            });
+        }
+
+        // Check for existing church with same name or email
+        const [existingChurches] = await getAppPool().query(
+            'SELECT id, name, email FROM churches WHERE name = ? OR email = ?',
+            [name, email]
+        );
+
+        if (existingChurches.length > 0) {
+            console.log('🚫 Duplicate church found:', existingChurches);
+            return res.status(400).json({
+                success: false,
+                message: 'Church with this name or email already exists',
+                existing: existingChurches[0]
+            });
+        }
+
+        // Always use record_template1 as the template database
+        const templateDatabaseName = 'record_template1';
+        console.log('🎯 Using template database:', templateDatabaseName);
+
+        // Generate secure random password for database user
+        const generateSecurePassword = () => {
+            const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
+            let result = '';
+            for (let i = 0; i < 16; i++) {
+                result += chars.charAt(Math.floor(Math.random() * chars.length));
+            }
+            return result;
+        };
+
+        // Step 1: Insert church record and get the church_id
+        const [result] = await getAppPool().query(`
+            INSERT INTO churches (
+                name, email, phone, address, city, state_province, postal_code, 
+                country, website, preferred_language, timezone, currency, is_active,
+                setup_complete, created_at, updated_at,
+                church_name, admin_email, language_preference
+            ) 
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ?, ?, ?)
+        `, [
+            name, email, phone, address, city, state_province, postal_code,
+            country, website, preferred_language, timezone, currency, is_active ? 1 : 0,
+            false, // Will be set to true after full setup
+            name, email, preferred_language
+        ]);
+
+        const church_id = result.insertId;
+        console.log('✅ Church created in orthodoxmetrics_db with ID:', church_id);
+
+        // Step 2: Generate database credentials using new format
+        const dbName = `om_church_${church_id}`;
+        const dbUser = `church_${church_id}`;
+        const dbPassword = generateSecurePassword();
+        
+        console.log(`🔧 Creating database: ${dbName} with user: ${dbUser}`);
+
+        // Step 3: Create database and dedicated user
+        try {
+            console.log('🔄 Creating church-specific database and user...');
+            
+            // Create the database
+            await getAppPool().query(`CREATE DATABASE IF NOT EXISTS \`${dbName}\``);
+            console.log(`✅ Database created: ${dbName}`);
+            
+            // Create dedicated database user
+            await getAppPool().query(`CREATE USER IF NOT EXISTS '${dbUser}'@'localhost' IDENTIFIED BY '${dbPassword}'`);
+            console.log(`✅ Database user created: ${dbUser}`);
+            
+            // Grant full privileges to the user for their database
+            await getAppPool().query(`GRANT ALL PRIVILEGES ON \`${dbName}\`.* TO '${dbUser}'@'localhost'`);
+            await getAppPool().query(`FLUSH PRIVILEGES`);
+            console.log(`✅ Privileges granted to ${dbUser} for ${dbName}`);
+            
+            // Switch to the new database for table creation
+            await getAppPool().query(`USE \`${dbName}\``);
+            
+            // Create church_info table with the church_id
+            await getAppPool().query(`
+                CREATE TABLE IF NOT EXISTS church_info (
+                    id INT PRIMARY KEY AUTO_INCREMENT,
+                    church_id INT NOT NULL DEFAULT ${church_id},
+                    name VARCHAR(255) NOT NULL DEFAULT '${name}',
+                    email VARCHAR(255) NOT NULL DEFAULT '${email}',
+                    phone VARCHAR(50),
+                    address TEXT,
+                    city VARCHAR(100),
+                    state_province VARCHAR(100),
+                    country VARCHAR(100),
+                    preferred_language VARCHAR(10) DEFAULT '${preferred_language}',
+                    timezone VARCHAR(50) DEFAULT '${timezone}',
+                    currency VARCHAR(10) DEFAULT '${currency}',
+                    is_active BOOLEAN DEFAULT TRUE,
+                    custom_landing_page JSON,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    UNIQUE KEY uk_church_id (church_id)
+                )
+            `);
+
+            // Insert church info with landing page configuration
+            await getAppPool().query(`
+                INSERT INTO church_info (
+                    church_id, name, email, phone, address, city, state_province, 
+                    country, preferred_language, timezone, currency, is_active, custom_landing_page
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `, [
+                church_id, name, email, phone, address, city, state_province,
+                country, preferred_language, timezone, currency, is_active ? 1 : 0,
+                JSON.stringify(custom_landing_page)
+            ]);
+
+            // Clone structure from record_template1 database
+            console.log('🎯 Cloning structure from template database:', templateDatabaseName);
+            
+            try {
+                // Map selected modules to actual table names
+                const tableNameMapping = {
+                    'baptism': ['baptism_records', 'baptism_history'],
+                    'marriage': ['marriage_records', 'marriage_history'], 
+                    'funeral': ['funeral_records', 'funeral_history']
+                };
+                
+                const tablesToClone = [];
+                for (const module of selected_tables) {
+                    if (tableNameMapping[module]) {
+                        tablesToClone.push(...tableNameMapping[module]);
+                    }
+                }
+                
+                // Clone table structures for selected tables from record_template1
+                const [templateTables] = await getAppPool().query(`
+                    SELECT TABLE_NAME 
+                    FROM information_schema.TABLES 
+                    WHERE TABLE_SCHEMA = ? 
+                    AND TABLE_NAME NOT IN ('church_info', 'church_settings')
+                    AND TABLE_NAME IN (${tablesToClone.map(() => '?').join(',')})
+                `, [templateDatabaseName, ...tablesToClone]);
+
+                // Disable foreign key checks to avoid constraint issues during cloning
+                await getAppPool().query('SET FOREIGN_KEY_CHECKS = 0');
+
+                for (const table of templateTables) {
+                    const tableName = table.TABLE_NAME;
+                    console.log(`📋 Cloning table structure: ${tableName} from ${templateDatabaseName}`);
+                    
+                    try {
+                        // Get CREATE TABLE statement from template
+                        const [createTableResult] = await getAppPool().query(`SHOW CREATE TABLE \`${templateDatabaseName}\`.\`${tableName}\``);
+                        let createStatement = createTableResult[0]['Create Table'];
+                        
+                        // Replace table name and execute in new database
+                        createStatement = createStatement.replace(`CREATE TABLE \`${tableName}\``, `CREATE TABLE IF NOT EXISTS \`${dbName}\`.\`${tableName}\``);
+                        await getAppPool().query(createStatement);
+                        console.log(`✅ Cloned table: ${tableName}`);
+                    } catch (tableError) {
+                        console.warn(`⚠️ Failed to clone table ${tableName}:`, tableError.message);
+                    }
+                }
+                
+                // Re-enable foreign key checks
+                await getAppPool().query('SET FOREIGN_KEY_CHECKS = 1');
+                
+                console.log('✅ Template structure cloned successfully');
+            } catch (templateError) {
+                console.warn('⚠️ Template cloning failed (non-critical):', templateError.message);
+                // Make sure to re-enable foreign key checks even if there's an error
+                try {
+                    await getAppPool().query('SET FOREIGN_KEY_CHECKS = 1');
+                } catch (fkError) {
+                    console.warn('⚠️ Failed to re-enable foreign key checks:', fkError.message);
+                }
+            }
+
+            // Create all selected record tables
+            console.log('📋 Creating wizard selected record tables:', selected_tables);
+            
+            const tableDefinitions = {
+                'baptism_records': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.baptism_records (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        first_name VARCHAR(255) NOT NULL,
+                        middle_name VARCHAR(255),
+                        last_name VARCHAR(255) NOT NULL,
+                        birth_date DATE,
+                        baptism_date DATE NOT NULL,
+                        birth_place VARCHAR(255),
+                        baptism_place VARCHAR(255),
+                        father_name VARCHAR(255),
+                        mother_name VARCHAR(255),
+                        godfather_name VARCHAR(255),
+                        godmother_name VARCHAR(255),
+                        godparents VARCHAR(500),
+                        priest_name VARCHAR(255),
+                        sponsors VARCHAR(500),
+                        parents VARCHAR(500),
+                        clergy VARCHAR(255),
+                        certificate_number VARCHAR(100),
+                        book_number VARCHAR(100),
+                        page_number VARCHAR(100),
+                        entry_number VARCHAR(100),
+                        notes TEXT,
+                        created_by INT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_baptism_church_id (church_id),
+                        INDEX idx_baptism_names (first_name, last_name),
+                        INDEX idx_baptism_date (baptism_date)
+                    )
+                `,
+                'marriage_records': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.marriage_records (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        groom_first_name VARCHAR(255) NOT NULL,
+                        groom_middle_name VARCHAR(255),
+                        groom_last_name VARCHAR(255) NOT NULL,
+                        bride_first_name VARCHAR(255) NOT NULL,
+                        bride_middle_name VARCHAR(255),
+                        bride_last_name VARCHAR(255) NOT NULL,
+                        marriage_date DATE NOT NULL,
+                        marriage_place VARCHAR(255),
+                        groom_father VARCHAR(255),
+                        groom_mother VARCHAR(255),
+                        bride_father VARCHAR(255),
+                        bride_mother VARCHAR(255),
+                        priest_name VARCHAR(255),
+                        best_man VARCHAR(255),
+                        maid_of_honor VARCHAR(255),
+                        witness1 VARCHAR(255),
+                        witness2 VARCHAR(255),
+                        certificate_number VARCHAR(100),
+                        book_number VARCHAR(100),
+                        page_number VARCHAR(100),
+                        entry_number VARCHAR(100),
+                        notes TEXT,
+                        created_by INT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_marriage_church_id (church_id),
+                        INDEX idx_marriage_groom (groom_first_name, groom_last_name),
+                        INDEX idx_marriage_bride (bride_first_name, bride_last_name),
+                        INDEX idx_marriage_date (marriage_date)
+                    )
+                `,
+                'funeral_records': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.funeral_records (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        first_name VARCHAR(255) NOT NULL,
+                        middle_name VARCHAR(255),
+                        last_name VARCHAR(255) NOT NULL,
+                        birth_date DATE,
+                        death_date DATE,
+                        funeral_date DATE NOT NULL,
+                        birth_place VARCHAR(255),
+                        death_place VARCHAR(255),
+                        funeral_place VARCHAR(255),
+                        father_name VARCHAR(255),
+                        mother_name VARCHAR(255),
+                        spouse_name VARCHAR(255),
+                        priest_name VARCHAR(255),
+                        cause_of_death VARCHAR(255),
+                        cemetery VARCHAR(255),
+                        plot_number VARCHAR(100),
+                        certificate_number VARCHAR(100),
+                        book_number VARCHAR(100),
+                        page_number VARCHAR(100),
+                        entry_number VARCHAR(100),
+                        notes TEXT,
+                        created_by INT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_funeral_church_id (church_id),
+                        INDEX idx_funeral_names (first_name, last_name),
+                        INDEX idx_funeral_date (funeral_date)
+                    )
+                `,
+                'clergy': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.clergy (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        first_name VARCHAR(255) NOT NULL,
+                        last_name VARCHAR(255) NOT NULL,
+                        title VARCHAR(100),
+                        position VARCHAR(100),
+                        ordination_date DATE,
+                        start_date DATE,
+                        end_date DATE,
+                        email VARCHAR(255),
+                        phone VARCHAR(50),
+                        is_active BOOLEAN DEFAULT TRUE,
+                        notes TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_clergy_church_id (church_id),
+                        INDEX idx_clergy_names (first_name, last_name)
+                    )
+                `,
+                'members': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.members (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        first_name VARCHAR(255) NOT NULL,
+                        last_name VARCHAR(255) NOT NULL,
+                        email VARCHAR(255),
+                        phone VARCHAR(50),
+                        address TEXT,
+                        city VARCHAR(100),
+                        state_province VARCHAR(100),
+                        postal_code VARCHAR(20),
+                        country VARCHAR(100),
+                        birth_date DATE,
+                        baptism_date DATE,
+                        membership_date DATE,
+                        membership_status VARCHAR(50) DEFAULT 'active',
+                        notes TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_members_church_id (church_id),
+                        INDEX idx_members_names (first_name, last_name),
+                        INDEX idx_members_email (email)
+                    )
+                `,
+                'donations': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.donations (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        donor_name VARCHAR(255),
+                        amount DECIMAL(10,2) NOT NULL,
+                        currency VARCHAR(10) DEFAULT '${currency}',
+                        donation_date DATE NOT NULL,
+                        category VARCHAR(100),
+                        method VARCHAR(50),
+                        reference_number VARCHAR(100),
+                        notes TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_donations_church_id (church_id),
+                        INDEX idx_donations_date (donation_date),
+                        INDEX idx_donations_amount (amount)
+                    )
+                `,
+                'calendar_events': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.calendar_events (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        title VARCHAR(255) NOT NULL,
+                        description TEXT,
+                        event_date DATE NOT NULL,
+                        start_time TIME,
+                        end_time TIME,
+                        event_type VARCHAR(100),
+                        location VARCHAR(255),
+                        is_recurring BOOLEAN DEFAULT FALSE,
+                        recurrence_pattern VARCHAR(100),
+                        created_by INT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_events_church_id (church_id),
+                        INDEX idx_events_date (event_date),
+                        INDEX idx_events_type (event_type)
+                    )
+                `,
+                'confession_records': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.confession_records (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        person_name VARCHAR(255),
+                        confession_date DATE NOT NULL,
+                        priest_name VARCHAR(255),
+                        notes TEXT,
+                        is_confidential BOOLEAN DEFAULT TRUE,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_confession_church_id (church_id),
+                        INDEX idx_confession_date (confession_date)
+                    )
+                `,
+                'communion_records': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.communion_records (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        person_name VARCHAR(255),
+                        communion_date DATE NOT NULL,
+                        service_type VARCHAR(100),
+                        priest_name VARCHAR(255),
+                        notes TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_communion_church_id (church_id),
+                        INDEX idx_communion_date (communion_date)
+                    )
+                `,
+                'chrismation_records': `
+                    CREATE TABLE IF NOT EXISTS \`${dbName}\`.chrismation_records (
+                        id INT PRIMARY KEY AUTO_INCREMENT,
+                        church_id INT NOT NULL DEFAULT ${church_id},
+                        first_name VARCHAR(255) NOT NULL,
+                        last_name VARCHAR(255) NOT NULL,
+                        chrismation_date DATE NOT NULL,
+                        baptism_date DATE,
+                        sponsor_name VARCHAR(255),
+                        priest_name VARCHAR(255),
+                        confirmation_name VARCHAR(255),
+                        certificate_number VARCHAR(100),
+                        notes TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        INDEX idx_chrismation_church_id (church_id),
+                        INDEX idx_chrismation_names (first_name, last_name),
+                        INDEX idx_chrismation_date (chrismation_date)
+                    )
+                `
+            };
+
+            // Create selected tables
+            for (const tableName of selected_tables) {
+                if (tableDefinitions[tableName]) {
+                    await getAppPool().query(tableDefinitions[tableName]);
+                    console.log(`✅ Created table: ${tableName}`);
+                }
+            }
+
+            // Add custom fields to selected tables
+            if (custom_fields && custom_fields.length > 0) {
+                console.log('🔧 Adding custom fields:', custom_fields);
+                
+                for (const field of custom_fields) {
+                    try {
+                        let fieldDefinition = `${field.field_name} ${field.field_type}`;
+                        
+                        if (field.field_type === 'VARCHAR' && field.field_length) {
+                            fieldDefinition += `(${field.field_length})`;
+                        }
+                        
+                        if (field.is_required) {
+                            fieldDefinition += ' NOT NULL';
+                        }
+                        
+                        if (field.default_value) {
+                            fieldDefinition += ` DEFAULT '${field.default_value}'`;
+                        }
+
+                        await getAppPool().query(`
+                            ALTER TABLE \`${dbName}\`.\`${field.table_name}\` 
+                            ADD COLUMN ${fieldDefinition}
+                        `);
+                        
+                        console.log(`✅ Added custom field: ${field.field_name} to ${field.table_name}`);
+                    } catch (fieldError) {
+                        console.warn(`⚠️ Failed to add custom field ${field.field_name}:`, fieldError.message);
+                    }
+                }
+            }
+
+                        // NOTE: Users are stored in orthodoxmetrics_db, not in individual church databases
+            // Church databases are for records only. User management is handled centrally.
+                        // Use the church_users junction table in orthodoxmetrics_db to assign users to churches.
+
+                        // Add initial users to orthodoxmetrics_db (not church database)
+            if (initial_users && initial_users.length > 0) {
+                                console.log('👥 Adding initial users to orthodoxmetrics_db:', initial_users.length);
+                
+                for (const user of initial_users) {
+                    try {
+                        // Check if user already exists in orthodoxmetrics_db
+                        const [existingUsers] = await getAppPool().query(
+                            'SELECT id FROM orthodoxmetrics_db.users WHERE email = ?',
+                            [user.email]
+                        );
+
+                        let userId;
+                        if (existingUsers.length > 0) {
+                            userId = existingUsers[0].id;
+                            console.log(`👤 User ${user.email} already exists, using existing user`);
+                        } else {
+                            // Create new user in orthodoxmetrics_db
+                            const tempPassword = Math.random().toString(36).slice(-12);
+                            const bcrypt = require('bcrypt');
+                            const hashedPassword = await bcrypt.hash(tempPassword, 10);
+
+                            // Get role_id for the user role
+                            const [roleResult] = await getAppPool().query(
+                                'SELECT id FROM orthodoxmetrics_db.roles WHERE name = ?',
+                                [user.role]
+                            );
+                            
+                            if (roleResult.length === 0) {
+                                throw new Error(`Role '${user.role}' not found`);
+                            }
+                            
+                            const role_id = roleResult[0].id;
+                            const full_name = `${user.first_name} ${user.last_name}`;
+
+                            const [result] = await getAppPool().query(`
+                                INSERT INTO orthodoxmetrics_db.users (
+                                    email, full_name, role_id, church_id, 
+                                    password_hash, is_active, created_at, updated_at
+                                ) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())
+                            `, [
+                                user.email, full_name, role_id, church_id,
+                                hashedPassword, true
+                            ]);
+                            
+                            userId = result.insertId;
+                            console.log(`✅ Created user: ${user.first_name} ${user.last_name} (${user.role}) with temp password: ${tempPassword}`);
+                        }
+
+                        // Assign user to church via church_users junction table
+                        await getAppPool().query(
+                            'INSERT INTO church_users (church_id, user_id, role) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE role = VALUES(role)',
+                            [church_id, userId, user.role]
+                        );
+                        
+                        // TODO: Send invitation email if user.send_invite is true
+                        if (user.send_invite) {
+                            console.log(`📧 TODO: Send invitation email to ${user.email}`);
+                        }
+                    } catch (userError) {
+                        console.warn(`⚠️ Failed to add user ${user.email}:`, userError.message);
+                    }
+                }
+            }
+
+            // Create church settings table for landing page and other configurations
+            await getAppPool().query(`
+                CREATE TABLE IF NOT EXISTS \`${dbName}\`.church_settings (
+                    id INT PRIMARY KEY AUTO_INCREMENT,
+                    church_id INT NOT NULL DEFAULT ${church_id},
+                    setting_key VARCHAR(255) NOT NULL,
+                    setting_value JSON,
+                    description TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    UNIQUE KEY uk_church_setting (church_id, setting_key),
+                    INDEX idx_settings_church_id (church_id)
+                )
+            `);
+
+            // Store landing page configuration in settings
+            if (custom_landing_page && custom_landing_page.enabled) {
+                await getAppPool().query(`
+                    INSERT INTO \`${dbName}\`.church_settings (
+                        church_id, setting_key, setting_value, description
+                    ) VALUES (?, 'custom_landing_page', ?, 'Custom landing page configuration with default app')
+                `, [church_id, JSON.stringify(custom_landing_page)]);
+                console.log('✅ Stored custom landing page configuration with default app');
+            }
+
+            // Step 4: Store database credentials in the main churches table
+            await getAppPool().query('USE orthodoxmetrics_db');
+            await getAppPool().query(`
+                UPDATE churches 
+                SET database_name = ?, db_user = ?, db_password = ?, setup_complete = 1 
+                WHERE id = ?
+            `, [dbName, dbUser, dbPassword, church_id]);
+            console.log('✅ Database credentials stored in churches table');
+
+            // Step 5: Generate registration token for the new church
+            const crypto = require('crypto');
+            const registrationToken = crypto.randomBytes(32).toString('hex');
+            const currentUser = req.user || req.session?.user;
+            await getAppPool().query(
+                'INSERT INTO church_registration_tokens (church_id, token, created_by) VALUES (?, ?, ?)',
+                [church_id, registrationToken, currentUser?.id || 0]
+            );
+            console.log('✅ Registration token generated for church:', registrationToken.substring(0, 8) + '...');
+
+            console.log('🎉 Church Setup Wizard completed successfully!');
+
+        } catch (dbError) {
+            console.error('❌ Database setup failed:', dbError);
+            
+            // Rollback: delete the church record and database if setup failed
+            try {
+                await getAppPool().query('USE orthodoxmetrics_db');
+                await getAppPool().query('DELETE FROM churches WHERE id = ?', [church_id]);
+                await getAppPool().query(`DROP DATABASE IF EXISTS \`${dbName}\``);
+                await getAppPool().query(`DROP USER IF EXISTS '${dbUser}'@'localhost'`);
+                console.log('🔄 Rolled back church record and database due to setup failure');
+            } catch (rollbackError) {
+                console.error('❌ Rollback failed:', rollbackError);
+            }
+            
+            throw new Error(`Database setup failed: ${dbError.message}`);
+        }
+
+        // Fetch the created church with all details
+        const [newChurch] = await getAppPool().query(`
+            SELECT * FROM churches WHERE id = ?
+        `, [church_id]);
+
+        res.json({
+            success: true,
+            message: `Church "${name}" created successfully with dedicated database`,
+            church_id: church_id,
+            db_name: dbName,
+            db_user: dbUser,
+            church: newChurch[0],
+            registration_token: registrationToken,
+            wizard_summary: {
+                template_used: templateDatabaseName,
+                tables_created: selected_tables.length,
+                custom_fields_added: custom_fields.length,
+                initial_users_added: initial_users.length,
+                landing_page_configured: custom_landing_page.enabled,
+                church_id: church_id,
+                dbName: dbName
+            }
+        });
+
+    } catch (error) {
+        console.error('❌ Church wizard creation failed:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Failed to create church via wizard',
+            error: error.message
+        });
+    }
+});
+
+// PUT /admin/churches/:id - Update church (admin for own, super_admin for any)
+router.put('/churches/:id', requireAdmin, async (req, res) => {
+    try {
+        const churchId = parseInt(req.params.id);
+        const currentUser = req.user || req.session?.user;
+
+        console.log(`🔧 Updating church ${churchId} by user ${currentUser?.email}`);
+
+        if (isNaN(churchId)) {
+            return res.status(400).json({
+                success: false,
+                message: 'Invalid church ID format'
+            });
+        }
+
+        // Check if church exists
+        const [existingChurch] = await getAppPool().query(
+            'SELECT id, name FROM churches WHERE id = ?',
+            [churchId]
+        );
+
+        if (existingChurch.length === 0) {
+            return res.status(404).json({
+                success: false,
+                message: 'Church not found'
+            });
+        }
+
+        // Extract updatable fields from request body
+        const {
+            name, email, phone, address, city, state_province, postal_code,
+            country, website, preferred_language, timezone, currency, tax_id,
+            description_multilang, settings, is_active, database_name,
+            has_baptism_records, has_marriage_records, has_funeral_records,
+            setup_complete
+            // Note: template_church_id, default_landing_page, enable_ag_grid, ag_grid_record_types, 
+            // enable_multilingual, enable_notifications, public_calendar removed - columns don't exist in DB
+        } = req.body;
+
+        // Build update query dynamically
+        const updates = [];
+        const values = [];
+
+        if (name !== undefined) { updates.push('name = ?'); values.push(name); }
+        if (email !== undefined) { updates.push('email = ?'); values.push(email); }
+        if (phone !== undefined) { updates.push('phone = ?'); values.push(phone || null); }
+        if (address !== undefined) { updates.push('address = ?'); values.push(address || null); }
+        if (city !== undefined) { updates.push('city = ?'); values.push(city || null); }
+        if (state_province !== undefined) { updates.push('state_province = ?'); values.push(state_province || null); }
+        if (postal_code !== undefined) { updates.push('postal_code = ?'); values.push(postal_code || null); }
+        if (country !== undefined) { updates.push('country = ?'); values.push(country || null); }
+        if (website !== undefined) { updates.push('website = ?'); values.push(website || null); }
+        if (preferred_language !== undefined) { updates.push('preferred_language = ?'); values.push(preferred_language); }
+        if (timezone !== undefined) { updates.push('timezone = ?'); values.push(timezone); }
+        if (currency !== undefined) { updates.push('currency = ?'); values.push(currency || null); }
+        if (tax_id !== undefined) { updates.push('tax_id = ?'); values.push(tax_id || null); }
+        if (description_multilang !== undefined) { updates.push('description_multilang = ?'); values.push(description_multilang || null); }
+        if (settings !== undefined) { updates.push('settings = ?'); values.push(typeof settings === 'string' ? settings : JSON.stringify(settings || {})); }
+        if (is_active !== undefined) { updates.push('is_active = ?'); values.push(is_active ? 1 : 0); }
+        if (database_name !== undefined) { updates.push('database_name = ?'); values.push(database_name || null); }
+        if (has_baptism_records !== undefined) { updates.push('has_baptism_records = ?'); values.push(has_baptism_records ? 1 : 0); }
+        if (has_marriage_records !== undefined) { updates.push('has_marriage_records = ?'); values.push(has_marriage_records ? 1 : 0); }
+        if (has_funeral_records !== undefined) { updates.push('has_funeral_records = ?'); values.push(has_funeral_records ? 1 : 0); }
+        if (setup_complete !== undefined) { updates.push('setup_complete = ?'); values.push(setup_complete ? 1 : 0); }
+        // Removed: template_church_id, default_landing_page, enable_ag_grid, ag_grid_record_types, 
+        // enable_multilingual, enable_notifications, public_calendar (these columns don't exist in the churches table)
+
+        if (updates.length === 0) {
+            return res.status(400).json({
+                success: false,
+                message: 'No fields to update'
+            });
+        }
+
+        updates.push('updated_at = CURRENT_TIMESTAMP');
+        values.push(churchId);
+
+        await getAppPool().query(
+            `UPDATE churches SET ${updates.join(', ')} WHERE id = ?`,
+            values
+        );
+
+        console.log(`✅ Church ${churchId} updated successfully by ${currentUser?.email}`);
+
+        // Fetch and return updated church
+        const [updatedChurch] = await getAppPool().query(
+            `SELECT
+                id, name, email, phone, address, city, state_province, postal_code,
+                country, website, preferred_language, timezone, currency, tax_id,
+                description_multilang, settings, is_active, database_name,
+                has_baptism_records, has_marriage_records, has_funeral_records,
+                setup_complete, created_at, updated_at
+            FROM churches WHERE id = ?`,
+            [churchId]
+        );
+
+        res.json({
+            success: true,
+            message: 'Church updated successfully',
+            church: updatedChurch[0]
+        });
+
+    } catch (error) {
+        console.error('❌ Error updating church:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Failed to update church',
+            error: error.message
+        });
+    }
+});
+
+// DELETE /admin/churches/:id - Delete church (super_admin only)
+router.delete('/churches/:id', requireSuperAdmin, async (req, res) => {
+    try {
+        const churchId = parseInt(req.params.id);
+
+        // Check if there are users assigned to this church
+        const [userRows] = await getAppPool().query(
+            'SELECT COUNT(*) as user_count FROM orthodoxmetrics_db.users WHERE church_id = ?',
+            [churchId]
+        );
+
+        if (userRows[0].user_count > 0) {
+            return res.status(400).json({
+                success: false,
+                message: 'Cannot delete church with assigned users. Please reassign users first.'
+            });
+        }
+
+        // Get church info before deletion
+        const [churchRows] = await getAppPool().query(
+            'SELECT name FROM churches WHERE id = ?',
+            [churchId]
+        );
+
+        if (churchRows.length === 0) {
+            return res.status(404).json({
+                success: false,
+                message: 'Church not found'
+            });
+        }
+
+        // Delete church
+        await getAppPool().query('DELETE FROM churches WHERE id = ?', [churchId]);
+
+        console.log(`✅ Church deleted successfully: ${churchRows[0].name} by admin ${req.user?.email}`);
+
+        res.json({
+            success: true,
+            message: 'Church deleted successfully'
+        });
+
+    } catch (err) {
+        console.error('Error deleting church:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Server error while deleting church'
+        });
+    }
+});
+
+// GET /admin/church/:id - Get individual church data for admin panel
+
+// POST /admin/users/:id/reset-password - Reset user password
+router.post('/users/:id/reset-password', requireAdmin, async (req, res) => {
+    try {
+        const userId = parseInt(req.params.id);
+
+        // Don't allow reset of current user's password
+        if (userId === (req.user?.id || req.session?.user?.id)) {
+            return res.status(400).json({
+                success: false,
+                message: 'You cannot reset your own password'
+            });
+        }
+
+        // Get user info and check permissions
+        const [userRows] = await getAppPool().query(
+            'SELECT email, role FROM orthodoxmetrics_db.users WHERE id = ?',
+            [userId]
+        );
+
+        if (userRows.length === 0) {
+            return res.status(404).json({
+                success: false,
+                message: 'User not found'
+            });
+        }
+
+        const targetUserRole = userRows[0].role;
+        const currentUserRole = req.user?.role || req.session?.user?.role;
+
+        // Super admin can reset any role except super_admin
+        if (currentUserRole === 'super_admin') {
+            if (targetUserRole === 'super_admin') {
+                return res.status(403).json({
+                    success: false,
+                    message: 'Cannot reset super_admin passwords'
+                });
+            }
+        }
+
+        // Regular admin cannot reset admin or super_admin passwords
+        if (currentUserRole === 'admin') {
+            if (targetUserRole === 'admin' || targetUserRole === 'super_admin') {
+                return res.status(403).json({
+                    success: false,
+                    message: 'Cannot reset admin or super_admin passwords'
+                });
+            }
+        }
+
+        // Generate new temporary password
+        const tempPassword = Math.random().toString(36).slice(-12) + Math.random().toString(36).slice(-12);
+
+        // Hash the password
+        const saltRounds = 12;
+        const passwordHash = await bcrypt.hash(tempPassword, saltRounds);
+
+        // Update user password
+        await getAppPool().query(
+            'UPDATE orthodoxmetrics_db.users SET password_hash = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+            [passwordHash, userId]
+        );
+
+        console.log(`✅ Password reset for user: ${userRows[0].email} by admin ${req.user?.email}`);
+        console.log(`🔐 New temporary password for ${userRows[0].email}: ${tempPassword}`);
+
+        // TODO: Send password via secure email instead of returning in response
+        res.json({
+            success: true,
+            message: 'Password reset successfully. New password has been logged securely for admin retrieval.'
+        });
+
+    } catch (err) {
+        console.error('Error resetting password:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Server error while resetting password'
+        });
+    }
+});
+
+// PATCH /admin/users/:id/reset-password - Reset user password with custom password
+router.patch('/users/:id/reset-password', requireAdmin, async (req, res) => {
+    try {
+        const userId = parseInt(req.params.id);
+        const { new_password } = req.body;
+        const currentUser = req.user || req.session?.user;
+
+
+
+        // Don't allow reset of current user's password
+        if (userId === currentUser.id) {
+            return res.status(400).json({
+                success: false,
+                message: 'You cannot reset your own password'
+            });
+        }
+
+        // Get target user information
+        const [userRows] = await getAppPool().query(
+            'SELECT id, email, role, first_name, last_name FROM orthodoxmetrics_db.users WHERE id = ?',
+            [userId]
+        );
+
+        if (userRows.length === 0) {
+            return res.status(404).json({
+                success: false,
+                message: 'User not found'
+            });
+        }
+
+        const targetUser = userRows[0];
+
+        // Check if current user can manage the target user
+        if (!canManageUser(currentUser, targetUser)) {
+            logUnauthorizedAttempt(currentUser, targetUser, 'RESET_PASSWORD');
+            return res.status(403).json({
+                success: false,
+                message: 'You do not have permission to reset this user\'s password',
+                code: 'PASSWORD_RESET_DENIED'
+            });
+        }
+
+        // Validate provided password
+        if (!new_password || typeof new_password !== 'string') {
+            return res.status(400).json({
+                success: false,
+                message: 'Password is required'
+            });
+        }
+
+        if (new_password.length < 8) {
+            return res.status(400).json({
+                success: false,
+                message: 'Password must be at least 8 characters long'
+            });
+        }
+
+        // Hash the password
+        const saltRounds = 12;
+        const passwordHash = await bcrypt.hash(new_password, saltRounds);
+
+        // Update user password
+        await getAppPool().query(
+            'UPDATE orthodoxmetrics_db.users SET password_hash = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+            [passwordHash, userId]
+        );
+
+        console.log(`✅ Password reset for user: ${targetUser.email} by ${currentUser.email} (role: ${currentUser.role})`);
+
+
+        res.json({
+            success: true,
+            message: 'Password reset successfully'
+        });
+
+    } catch (err) {
+        console.error('Error resetting password:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Server error while resetting password'
+        });
+    }
+});
+
+// PATCH /admin/users/:id/status - Update user status
+router.patch('/users/:id/status', requireAdmin, async (req, res) => {
+    try {
+        const userId = parseInt(req.params.id);
+        const { is_active } = req.body;
+        const currentUser = req.user || req.session?.user;
+
+        // Don't allow deactivation of the current user
+        if (userId === currentUser.id && !is_active) {
+            return res.status(400).json({
+                success: false,
+                message: 'You cannot deactivate your own account'
+            });
+        }
+
+        // Get target user information
+        const [userRows] = await getAppPool().query(
+            'SELECT id, email, role, first_name, last_name FROM orthodoxmetrics_db.users WHERE id = ?',
+            [userId]
+        );
+
+        if (userRows.length === 0) {
+            return res.status(404).json({
+                success: false,
+                message: 'User not found'
+            });
+        }
+
+        const targetUser = userRows[0];
+
+        // Check if current user can perform destructive operations (deactivating is considered destructive)
+        if (!is_active && !canPerformDestructiveOperation(currentUser, targetUser)) {
+            logUnauthorizedAttempt(currentUser, targetUser, 'DEACTIVATE_USER');
+            return res.status(403).json({
+                success: false,
+                message: 'You do not have permission to deactivate this user',
+                code: 'DEACTIVATION_DENIED'
+            });
+        }
+
+        // Check if current user can manage the target user (for activation)
+        if (is_active && !canManageUser(currentUser, targetUser)) {
+            logUnauthorizedAttempt(currentUser, targetUser, 'ACTIVATE_USER');
+            return res.status(403).json({
+                success: false,
+                message: 'You do not have permission to activate this user',
+                code: 'ACTIVATION_DENIED'
+            });
+        }
+
+        // Update user status
+        await getAppPool().query(
+            'UPDATE orthodoxmetrics_db.users SET is_active = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+            [is_active ? 1 : 0, userId]
+        );
+
+        console.log(`✅ User status updated: ${targetUser.email} -> ${is_active ? 'active' : 'inactive'} by ${currentUser.email} (role: ${currentUser.role})`);
+
+        res.json({
+            success: true,
+            message: `User ${is_active ? 'activated' : 'deactivated'} successfully`
+        });
+
+    } catch (err) {
+        console.error('Error updating user status:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Server error while updating user status'
+        });
+    }
+});
+
+/*
+// Test endpoint to verify query works (disabled for production)
+router.get('/test-users', requireAdmin, async (req, res) => {
+    try {
+        console.log('🔍 Testing admin users query...');
+        
+        // Test the exact query that was working
+        const [rows] = await getAppPool().query(`
+            SELECT 
+                u.id,
+                u.email,
+                u.first_name,
+                u.last_name,
+                u.role,
+                u.church_id,
+                c.name as church_name,
+                u.is_active,
+                u.email_verified,
+                u.preferred_language,
+                u.timezone,
+                u.landing_page,
+                u.created_at,
+                u.updated_at,
+                u.last_login
+            FROM orthodoxmetrics_db.users u
+            LEFT JOIN churches c ON u.church_id = c.id
+            ORDER BY u.created_at DESC
+        `);
+
+        console.log('✅ Test query successful, returned', rows.length, 'users');
+        
+        res.json({
+            success: true,
+            count: rows.length,
+            users: rows
+        });
+    } catch (err) {
+        console.error('❌ Test query error:', err.message);
+        console.error('❌ Full error:', err);
+        res.status(500).json({
+            success: false,
+            message: 'Test query failed',
+            error: err.message
+        });
+    }
+});
+*/
+
+// GET /admin/churches/:id/tables - Get available tables for a church (for template selection)
+
+// GET /admin/churches/:id/users - Get church users
+
+// GET /admin/churches/:id/record-counts - Get record counts for church
+
+// GET /admin/churches/:id/database-info - Get database information
+
+// POST /admin/churches/:id/users/:userId/reset-password - Reset user password
+
+// POST /admin/churches/:id/users/:userId/lock - Lock user account
+
+// POST /admin/churches/:id/users/:userId/unlock - Unlock user account
+
+// POST /admin/churches/:id/users - Add new user to church
+
+// PUT /admin/churches/:id/users/:userId - Update church user
+
+// POST /admin/churches/:id/test-connection - Test database connection
+
+// GET /api/admin/roles - Get all system roles
+router.get('/roles', requireAdmin, async (req, res) => {
+    try {
+        const [roles] = await promisePool.query(`
+            SELECT id, name, description, is_system
+            FROM orthodoxmetrics_db.roles
+            WHERE is_system = 1
+            ORDER BY 
+                CASE name
+                    WHEN 'super_admin' THEN 1
+                    WHEN 'admin' THEN 2
+                    WHEN 'church_admin' THEN 3
+                    WHEN 'priest' THEN 4
+                    WHEN 'deacon' THEN 5
+                    WHEN 'cantor' THEN 6
+                    WHEN 'editor' THEN 7
+                    WHEN 'member' THEN 8
+                    WHEN 'viewer' THEN 9
+                    WHEN 'guest' THEN 10
+                    ELSE 99
+                END,
+                name ASC
+        `);
+        
+        res.json({
+            success: true,
+            roles: roles
+        });
+    } catch (error) {
+        console.error('Error fetching roles:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Failed to fetch roles'
+        });
+    }
+});
+
+module.exports = router;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -282,6 +282,7 @@ const sessionsRouter = require('./routes/admin/sessions');
 const usersRouter = require('./routes/admin/users');
 const adminInvitesRouter = require('./routes/admin/invites');
 const inviteRegisterRouter = require('./routes/invite-register');
+const churchRegisterRouter = require('./routes/church-register');
 const activityLogsRouter = require('./routes/admin/activity-logs');
 // Import new modular admin route files (extracted from monolithic admin.js)
 const churchUsersRouter = require('./routes/admin/church-users');
@@ -587,6 +588,9 @@ app.get('/__debug/session', (req, res) => {
 // Public routes first (no authentication required)
 app.use('/api/invite', inviteRegisterRouter); // Public invite validation + registration
 console.log('✅ [Server] Mounted /api/invite route (public invite registration)');
+app.use('/api/auth', churchRegisterRouter); // Public church token registration
+app.use('/api', churchRegisterRouter); // Admin token management endpoints
+console.log('✅ [Server] Mounted church registration token routes');
 app.use('/api/churches', churchesRouter);
 // Mount churches router at /api/my to handle /api/my/churches
 app.use('/api/my', churchesRouter);

--- a/server/src/routes/church-register.js
+++ b/server/src/routes/church-register.js
@@ -1,0 +1,213 @@
+// server/src/routes/church-register.js — Church token-based self-registration
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const crypto = require('crypto');
+const router = express.Router();
+const { getAppPool } = require('../config/db');
+
+// POST /api/auth/church-register — Public self-registration with church token
+router.post('/church-register', async (req, res) => {
+  try {
+    const { church_name, registration_token, first_name, last_name, email, password } = req.body;
+
+    // Validate required fields
+    if (!church_name || !registration_token || !first_name || !last_name || !email || !password) {
+      return res.status(400).json({
+        success: false,
+        message: 'All fields are required: church name, registration token, first name, last name, email, and password.'
+      });
+    }
+
+    if (password.length < 8) {
+      return res.status(400).json({
+        success: false,
+        message: 'Password must be at least 8 characters long.'
+      });
+    }
+
+    // Basic email format check
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Please enter a valid email address.'
+      });
+    }
+
+    const pool = getAppPool();
+
+    // Look up token and verify church name matches
+    const [tokenRows] = await pool.query(
+      `SELECT crt.id, crt.church_id, crt.token, c.name AS church_name
+       FROM church_registration_tokens crt
+       JOIN churches c ON crt.church_id = c.id
+       WHERE crt.token = ? AND crt.is_active = 1`,
+      [registration_token]
+    );
+
+    if (tokenRows.length === 0) {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid registration token. Please check with your church administrator.'
+      });
+    }
+
+    const tokenRecord = tokenRows[0];
+
+    // Verify church name matches (case-insensitive)
+    if (tokenRecord.church_name.toLowerCase().trim() !== church_name.toLowerCase().trim()) {
+      return res.status(400).json({
+        success: false,
+        message: 'The church name does not match the registration token. Please verify both fields.'
+      });
+    }
+
+    // Check if email is already registered
+    const [existingUsers] = await pool.query(
+      'SELECT id FROM users WHERE email = ?',
+      [email.toLowerCase().trim()]
+    );
+
+    if (existingUsers.length > 0) {
+      return res.status(409).json({
+        success: false,
+        message: 'An account with this email already exists. Please sign in or use a different email.'
+      });
+    }
+
+    // Hash password
+    const password_hash = await bcrypt.hash(password, 10);
+    const full_name = `${first_name.trim()} ${last_name.trim()}`;
+
+    // Create user — locked by default, pending admin review
+    const [result] = await pool.query(
+      `INSERT INTO users (
+        email, password_hash, first_name, last_name, full_name,
+        role, church_id, is_active, is_locked, locked_at, lockout_reason,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, 'viewer', ?, 1, 1, NOW(), 'Pending admin review - registered via church token', NOW(), NOW())`,
+      [
+        email.toLowerCase().trim(),
+        password_hash,
+        first_name.trim(),
+        last_name.trim(),
+        full_name,
+        tokenRecord.church_id
+      ]
+    );
+
+    console.log(`✅ Church token registration: ${email} registered for church ${tokenRecord.church_name} (ID: ${tokenRecord.church_id}), user ID: ${result.insertId} — account locked pending review`);
+
+    res.json({
+      success: true,
+      message: 'Your account has been created successfully. It is currently pending admin review. You will be able to sign in once an administrator activates your account.'
+    });
+  } catch (error) {
+    console.error('❌ Church token registration failed:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Registration failed. Please try again later.'
+    });
+  }
+});
+
+// --- Admin endpoints for managing registration tokens ---
+
+// GET /api/admin/churches/:churchId/registration-token
+router.get('/admin/churches/:churchId/registration-token', async (req, res) => {
+  try {
+    const churchId = parseInt(req.params.churchId);
+    if (isNaN(churchId)) {
+      return res.status(400).json({ success: false, message: 'Invalid church ID' });
+    }
+
+    const pool = getAppPool();
+    const [rows] = await pool.query(
+      `SELECT crt.id, crt.token, crt.is_active, crt.created_at, c.name AS church_name
+       FROM church_registration_tokens crt
+       JOIN churches c ON crt.church_id = c.id
+       WHERE crt.church_id = ? AND crt.is_active = 1
+       ORDER BY crt.created_at DESC LIMIT 1`,
+      [churchId]
+    );
+
+    if (rows.length === 0) {
+      return res.json({ success: true, token: null, message: 'No active registration token for this church.' });
+    }
+
+    res.json({ success: true, token: rows[0] });
+  } catch (error) {
+    console.error('❌ Failed to get registration token:', error);
+    res.status(500).json({ success: false, message: 'Failed to retrieve registration token.' });
+  }
+});
+
+// POST /api/admin/churches/:churchId/registration-token — Generate new token
+router.post('/admin/churches/:churchId/registration-token', async (req, res) => {
+  try {
+    const churchId = parseInt(req.params.churchId);
+    const currentUser = req.user || req.session?.user;
+
+    if (isNaN(churchId)) {
+      return res.status(400).json({ success: false, message: 'Invalid church ID' });
+    }
+
+    const pool = getAppPool();
+
+    // Verify church exists
+    const [churches] = await pool.query('SELECT id, name FROM churches WHERE id = ?', [churchId]);
+    if (churches.length === 0) {
+      return res.status(404).json({ success: false, message: 'Church not found.' });
+    }
+
+    // Deactivate any existing tokens for this church
+    await pool.query(
+      'UPDATE church_registration_tokens SET is_active = 0 WHERE church_id = ?',
+      [churchId]
+    );
+
+    // Generate new token
+    const token = crypto.randomBytes(32).toString('hex');
+    await pool.query(
+      'INSERT INTO church_registration_tokens (church_id, token, created_by) VALUES (?, ?, ?)',
+      [churchId, token, currentUser?.id || 0]
+    );
+
+    console.log(`✅ Registration token generated for church ${churches[0].name} (ID: ${churchId})`);
+
+    res.json({
+      success: true,
+      token: token,
+      church_name: churches[0].name,
+      message: `Registration token generated for ${churches[0].name}.`
+    });
+  } catch (error) {
+    console.error('❌ Failed to generate registration token:', error);
+    res.status(500).json({ success: false, message: 'Failed to generate registration token.' });
+  }
+});
+
+// DELETE /api/admin/churches/:churchId/registration-token — Deactivate token
+router.delete('/admin/churches/:churchId/registration-token', async (req, res) => {
+  try {
+    const churchId = parseInt(req.params.churchId);
+    if (isNaN(churchId)) {
+      return res.status(400).json({ success: false, message: 'Invalid church ID' });
+    }
+
+    const pool = getAppPool();
+    await pool.query(
+      'UPDATE church_registration_tokens SET is_active = 0 WHERE church_id = ?',
+      [churchId]
+    );
+
+    console.log(`🔒 Registration token deactivated for church ID: ${churchId}`);
+
+    res.json({ success: true, message: 'Registration token has been deactivated.' });
+  } catch (error) {
+    console.error('❌ Failed to deactivate registration token:', error);
+    res.status(500).json({ success: false, message: 'Failed to deactivate registration token.' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- Adds church-scoped registration token system for self-service user onboarding
- When a church is created via the Setup Wizard, a unique 64-char token is auto-generated
- Users register at `/auth/register` with church name + token; accounts are locked by default until super_admin review
- Church Setup Wizard enhanced with professional UI, 7-step flow, Live Table Builder integration, and registration token completion step
- New `church_registration_tokens` table, public registration endpoint, and admin token CRUD endpoints

## Key Changes
- **Backend**: New `church-register.js` route with `POST /api/auth/church-register` (public) and admin token management endpoints
- **Backend**: Wizard endpoint in `admin.js` now generates registration token on church creation
- **Frontend**: `AuthRegister.tsx` rewritten with church verification section, password strength indicator, and pending-review success state
- **Frontend**: `ChurchSetupWizard.tsx` upgraded with styled stepper, step progress, Live Table Builder tab, and token completion step
- **Database**: `church_registration_tokens` table with church_id FK, active flag, and unique token index

## Test plan
- [ ] Create a new church via the Setup Wizard — verify token is generated and displayed on final step
- [ ] Copy the token and register a new account at `/auth/register` with correct church name + token
- [ ] Verify the new user account is created with `is_locked=1` in the database
- [ ] Verify invalid tokens and mismatched church names are rejected
- [ ] Unlock the user via admin panel and confirm they can log in
- [ ] Test the Live Table Builder tab in Step 3 of the wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)