### PR TITLE
chore: migrate Batch 5 admin panel files from fetch() to apiClient

### DIFF
--- a/front-end/src/features/admin/admin/BigBookCustomComponentViewer.tsx
+++ b/front-end/src/features/admin/admin/BigBookCustomComponentViewer.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, Suspense, Component } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Typography,
@@ -96,14 +97,7 @@ const BigBookCustomComponentViewer: React.FC<BigBookCustomComponentViewerProps> 
 
     try {
       // Load the custom component registry
-      const response = await fetch('/api/bigbook/custom-components-registry', {
-        credentials: 'include'
-      });
-      if (!response.ok) {
-        throw new Error('Failed to load custom components registry');
-      }
-
-      const registry: CustomComponentRegistry = await response.json();
+      const registry = await apiClient.get<CustomComponentRegistry>('/bigbook/custom-components-registry');
       const component = registry.components[componentName];
 
       if (!component) {

--- a/front-end/src/features/admin/admin/BigBookDynamicRoute.tsx
+++ b/front-end/src/features/admin/admin/BigBookDynamicRoute.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, Suspense } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -113,14 +114,7 @@ const BigBookDynamicRoute: React.FC = () => {
       console.log(`🔍 Loading Big Book component: ${compId}`);
       
       // Load the custom components registry
-      const response = await fetch('/api/bigbook/custom-components-registry', {
-        credentials: 'include'
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to load registry: HTTP ${response.status}`);
-      }
-
-      const registry: CustomComponentRegistry = await response.json();
+      const registry = await apiClient.get<CustomComponentRegistry>('/bigbook/custom-components-registry');
       console.log('📋 Registry loaded:', registry);
 
       // Find the component in the registry

--- a/front-end/src/features/admin/admin/BigBookSettings.tsx
+++ b/front-end/src/features/admin/admin/BigBookSettings.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 import React, { useState } from 'react';
 import {
   Box,
@@ -169,19 +170,10 @@ const BigBookSettings: React.FC<BigBookSettingsProps> = ({
     setProcessingResult(null);
 
     try {
-      const response = await fetch('/api/bigbook/process-all', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          useSecureStorage: settings.useSecureStorage,
-          retryOnFailure: settings.retryOnMountFailure,
-        }),
+      const result = await apiClient.post<any>('/bigbook/process-all', {
+        useSecureStorage: settings.useSecureStorage,
+        retryOnFailure: settings.retryOnMountFailure,
       });
-
-      const result = await response.json();
       setProcessingResult(result);
       setProcessingProgress(100);
 
@@ -204,15 +196,7 @@ const BigBookSettings: React.FC<BigBookSettingsProps> = ({
     setMountTestResult(null);
 
     try {
-      const response = await fetch('/api/bigbook/test-secure-mount', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      const result = await response.json();
+      const result = await apiClient.post<any>('/bigbook/test-secure-mount');
       setMountTestResult(result.testResult);
 
     } catch (error) {

--- a/front-end/src/features/admin/admin/ChurchAdminList.tsx
+++ b/front-end/src/features/admin/admin/ChurchAdminList.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useNavigate } from 'react-router-dom';
 import {
     Box,
@@ -57,15 +58,7 @@ const ChurchAdminList: React.FC = () => {
             setLoading(true);
             setError(null);
             
-            const response = await fetch('/api/admin/churches', {
-                credentials: 'include'
-            });
-            
-            if (!response.ok) {
-                throw new Error('Failed to fetch churches');
-            }
-            
-            const result = await response.json();
+            const result = await apiClient.get<any>('/admin/churches');
             
             if (result.success) {
                 setChurches(result.churches || []);

--- a/front-end/src/features/admin/admin/ChurchAdminPanelWorking.tsx
+++ b/front-end/src/features/admin/admin/ChurchAdminPanelWorking.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
     Box,
@@ -35,28 +36,21 @@ const ChurchAdminPanelWorking: React.FC = () => {
             setLoading(true);
             setError(null);
             
-            const response = await fetch(`/api/admin/church/${churchId}/overview`, {
-                credentials: 'include'
-            });
+            const data = await apiClient.get<any>(`/admin/church/${churchId}/overview`);
             
-            if (response.ok) {
-                const data = await response.json();
-                if (data.metadata) {
-                    // Map the API response to our interface
-                    const churchInfo: ChurchData = {
-                        id: data.metadata.id,
-                        name: data.metadata.name,
-                        email: data.metadata.email || data.info?.email || '',
-                        databaseName: data.metadata.database_name,
-                        isActive: data.metadata.is_active,
-                        totalOcrJobs: (data.counts?.baptisms || 0) + (data.counts?.marriages || 0) + (data.counts?.funerals || 0)
-                    };
-                    setChurchData(churchInfo);
-                } else {
-                    throw new Error('Invalid response format');
-                }
+            if (data.metadata) {
+                // Map the API response to our interface
+                const churchInfo: ChurchData = {
+                    id: data.metadata.id,
+                    name: data.metadata.name,
+                    email: data.metadata.email || data.info?.email || '',
+                    databaseName: data.metadata.database_name,
+                    isActive: data.metadata.is_active,
+                    totalOcrJobs: (data.counts?.baptisms || 0) + (data.counts?.marriages || 0) + (data.counts?.funerals || 0)
+                };
+                setChurchData(churchInfo);
             } else {
-                throw new Error(`HTTP ${response.status}: Failed to load church data`);
+                throw new Error('Invalid response format');
             }
         } catch (err) {
             setError(err instanceof Error ? err.message : 'An error occurred');

--- a/front-end/src/features/admin/admin/EncryptedStoragePanel.tsx
+++ b/front-end/src/features/admin/admin/EncryptedStoragePanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Card,
   CardContent,
@@ -65,8 +66,7 @@ const EncryptedStoragePanel: React.FC = () => {
     setError('');
     
     try {
-      const response = await fetch('/api/bigbook/storage/status');
-      const result = await response.json();
+      const result = await apiClient.get<any>('/bigbook/storage/status');
       
       if (result.success) {
         setStatus(result.status);
@@ -87,8 +87,7 @@ const EncryptedStoragePanel: React.FC = () => {
     setError('');
     
     try {
-      const response = await fetch('/api/bigbook/storage/files');
-      const result = await response.json();
+      const result = await apiClient.get<any>('/bigbook/storage/files');
       
       if (result.success) {
         setFiles(result.files);
@@ -107,8 +106,7 @@ const EncryptedStoragePanel: React.FC = () => {
     setError('');
     
     try {
-      const response = await fetch('/api/bigbook/storage/mount', { method: 'POST' });
-      const result = await response.json();
+      const result = await apiClient.post<any>('/bigbook/storage/mount');
       
       if (result.success) {
         await loadStatus();
@@ -128,8 +126,7 @@ const EncryptedStoragePanel: React.FC = () => {
     setError('');
     
     try {
-      const response = await fetch('/api/bigbook/storage/unmount', { method: 'POST' });
-      const result = await response.json();
+      const result = await apiClient.post<any>('/bigbook/storage/unmount');
       
       if (result.success) {
         await loadStatus();
@@ -153,8 +150,7 @@ const EncryptedStoragePanel: React.FC = () => {
     setError('');
     
     try {
-      const response = await fetch('/api/bigbook/storage/rotate-key', { method: 'POST' });
-      const result = await response.json();
+      const result = await apiClient.post<any>('/bigbook/storage/rotate-key');
       
       if (result.success) {
         await loadStatus();

--- a/front-end/src/features/admin/admin/MenuManagement.tsx
+++ b/front-end/src/features/admin/admin/MenuManagement.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Box,
     Card,
@@ -80,15 +81,7 @@ const MenuManagement: React.FC = () => {
             setLoading(true);
             setError(null);
 
-            const response = await fetch('/api/menu-management/permissions', {
-                credentials: 'include'
-            });
-
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-
-            const data = await response.json();
+            const data = await apiClient.get<any>('/menu-management/permissions');
 
             if (data.success) {
                 setMenuItems(data.menuPermissions);
@@ -155,22 +148,9 @@ const MenuManagement: React.FC = () => {
             setError(null);
             setSuccess(null);
 
-            const response = await fetch('/api/menu-management/permissions', {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                credentials: 'include',
-                body: JSON.stringify({
-                    updates: pendingChanges
-                })
+            const data = await apiClient.put<any>('/menu-management/permissions', {
+                updates: pendingChanges
             });
-
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-
-            const data = await response.json();
 
             if (data.success) {
                 setSuccess(`Successfully updated ${data.updatedCount} menu permissions`);

--- a/front-end/src/features/admin/admin/MenuPermissions.tsx
+++ b/front-end/src/features/admin/admin/MenuPermissions.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Box,
     Card,
@@ -106,15 +107,7 @@ const MenuPermissionsManagement: React.FC = () => {
     const loadMenuPermissions = async () => {
         try {
             setLoading(true);
-            const response = await fetch('/api/menu-permissions', {
-                credentials: 'include'
-            });
-
-            if (!response.ok) {
-                throw new Error('Failed to load menu permissions');
-            }
-
-            const data = await response.json();
+            const data = await apiClient.get<any>('/menu-permissions');
             if (data.success) {
                 setMenuData({
                     menuItems: data.menuItems,
@@ -133,20 +126,7 @@ const MenuPermissionsManagement: React.FC = () => {
     // Update menu permissions for a specific menu item
     const updateMenuPermissions = async (menuId: number, allowedRoles: string[]) => {
         try {
-            const response = await fetch(`/api/menu-permissions/${menuId}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                credentials: 'include',
-                body: JSON.stringify({ allowedRoles })
-            });
-
-            if (!response.ok) {
-                throw new Error('Failed to update menu permissions');
-            }
-
-            const data = await response.json();
+            const data = await apiClient.put<any>(`/menu-permissions/${menuId}`, { allowedRoles });
             if (data.success) {
                 setSuccess('Menu permissions updated successfully');
                 loadMenuPermissions(); // Reload data
@@ -176,20 +156,7 @@ const MenuPermissionsManagement: React.FC = () => {
     // Create new menu item
     const handleCreateMenuItem = async () => {
         try {
-            const response = await fetch('/api/menu-permissions/menu-item', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                credentials: 'include',
-                body: JSON.stringify(newMenuItem)
-            });
-
-            if (!response.ok) {
-                throw new Error('Failed to create menu item');
-            }
-
-            const data = await response.json();
+            const data = await apiClient.post<any>('/menu-permissions/menu-item', newMenuItem);
             if (data.success) {
                 setSuccess('Menu item created successfully');
                 setCreateDialogOpen(false);

--- a/front-end/src/features/admin/admin/OMAIDiscoveryPanel.tsx
+++ b/front-end/src/features/admin/admin/OMAIDiscoveryPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Card,
   CardContent,
@@ -134,8 +135,7 @@ const OMAIDiscoveryPanel: React.FC = () => {
 
   const loadStatus = async () => {
     try {
-      const response = await fetch('/api/bigbook/omai/status');
-      const data = await response.json();
+      const data = await apiClient.get<any>('/bigbook/omai/status');
       if (data.success) {
         setStatus(data.status);
       }
@@ -146,8 +146,7 @@ const OMAIDiscoveryPanel: React.FC = () => {
 
   const loadSummary = async () => {
     try {
-      const response = await fetch('/api/bigbook/omai/summary');
-      const data = await response.json();
+      const data = await apiClient.get<any>('/bigbook/omai/summary');
       if (data.success && data.summary) {
         setSummary(data.summary);
       }
@@ -158,8 +157,7 @@ const OMAIDiscoveryPanel: React.FC = () => {
 
   const loadIndex = async () => {
     try {
-      const response = await fetch('/api/bigbook/omai/index');
-      const data = await response.json();
+      const data = await apiClient.get<any>('/bigbook/omai/index');
       if (data.success && data.index) {
         setIndex(data.index);
       }
@@ -171,10 +169,7 @@ const OMAIDiscoveryPanel: React.FC = () => {
   const initializeOMAI = async () => {
     setLoading(true);
     try {
-      const response = await fetch('/api/bigbook/omai/initialize', {
-        method: 'POST'
-      });
-      const data = await response.json();
+      const data = await apiClient.post<any>('/bigbook/omai/initialize');
       if (data.success) {
         await loadStatus();
       }
@@ -188,10 +183,7 @@ const OMAIDiscoveryPanel: React.FC = () => {
   const startDiscovery = async () => {
     setDiscovering(true);
     try {
-      const response = await fetch('/api/bigbook/omai/discover', {
-        method: 'POST'
-      });
-      const data = await response.json();
+      const data = await apiClient.post<any>('/bigbook/omai/discover');
       if (data.success) {
         // Poll for completion
         const pollInterval = setInterval(async () => {
@@ -215,8 +207,7 @@ const OMAIDiscoveryPanel: React.FC = () => {
   const loadCategoryFiles = async (category: string) => {
     try {
       const encodedCategory = category.toLowerCase().replace(/[^a-z0-9]/g, '_');
-      const response = await fetch(`/api/bigbook/omai/category/${encodedCategory}`);
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/bigbook/omai/category/${encodedCategory}`);
       if (data.success) {
         setCategoryFiles(data.files);
         setSelectedCategory(category);
@@ -228,13 +219,10 @@ const OMAIDiscoveryPanel: React.FC = () => {
 
   const loadFileDetails = async (fileId: string) => {
     try {
-      const [metadataResponse, contentResponse] = await Promise.all([
-        fetch(`/api/bigbook/omai/file/${fileId}`),
-        fetch(`/api/bigbook/omai/file/${fileId}/content`)
+      const [metadataData, contentData] = await Promise.all([
+        apiClient.get<any>(`/bigbook/omai/file/${fileId}`),
+        apiClient.get<any>(`/bigbook/omai/file/${fileId}/content`)
       ]);
-
-      const metadataData = await metadataResponse.json();
-      const contentData = await contentResponse.json();
 
       if (metadataData.success && contentData.success) {
         setSelectedFile(metadataData.file);
@@ -248,12 +236,7 @@ const OMAIDiscoveryPanel: React.FC = () => {
 
   const scheduleDiscovery = async () => {
     try {
-      const response = await fetch('/api/bigbook/omai/schedule', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ intervalHours: scheduleHours })
-      });
-      const data = await response.json();
+      const data = await apiClient.post<any>('/bigbook/omai/schedule', { intervalHours: scheduleHours });
       if (data.success) {
         setScheduleDialogOpen(false);
         await loadStatus();
@@ -265,8 +248,7 @@ const OMAIDiscoveryPanel: React.FC = () => {
 
   const loadLearningStatus = async () => {
     try {
-      const response = await fetch('/api/omai/learning-status');
-      const data = await response.json();
+      const data = await apiClient.get<any>('/omai/learning-status');
       if (data.success) {
         setLearningStatus(data);
       }
@@ -278,13 +260,8 @@ const OMAIDiscoveryPanel: React.FC = () => {
   const refreshLearning = async () => {
     setLearningLoading(true);
     try {
-      const response = await fetch('/api/omai/learn-now', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ forceRefresh: true })
-      });
-      const data = await response.json();
-      
+      const data = await apiClient.post<any>('/omai/learn-now', { forceRefresh: true });
+
       if (data.success) {
         setLearningDialogOpen(true);
         await loadLearningStatus();

--- a/front-end/src/features/admin/admin/OMAIDiscoveryPanelMobile.tsx
+++ b/front-end/src/features/admin/admin/OMAIDiscoveryPanelMobile.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Stack,
@@ -173,8 +174,7 @@ const OMAIDiscoveryPanelMobile: React.FC = () => {
   const loadLearningStatus = async () => {
     setStatusLoading(true);
     try {
-      const response = await fetch('/api/omai/learning-status');
-      const data = await response.json();
+      const data = await apiClient.get<any>('/omai/learning-status');
       setLearningStatus(data);
     } catch (error) {
       console.error('Failed to load learning status:', error);
@@ -186,11 +186,8 @@ const OMAIDiscoveryPanelMobile: React.FC = () => {
   const loadMemoryPreview = async () => {
     setMemoryLoading(true);
     try {
-      const response = await fetch('/api/omai/memory-preview');
-      if (response.ok) {
-        const data = await response.json();
-        setMemoryPreview(data);
-      }
+      const data = await apiClient.get<any>('/omai/memory-preview');
+      setMemoryPreview(data);
     } catch (error) {
       console.error('Failed to load memory preview:', error);
     } finally {
@@ -200,11 +197,8 @@ const OMAIDiscoveryPanelMobile: React.FC = () => {
 
   const loadAgents = async () => {
     try {
-      const response = await fetch('/api/omai/agents');
-      if (response.ok) {
-        const data = await response.json();
-        setAgents(data.agents || []);
-      }
+      const data = await apiClient.get<any>('/omai/agents');
+      setAgents(data.agents || []);
     } catch (error) {
       console.error('Failed to load agents:', error);
     }
@@ -223,13 +217,7 @@ const OMAIDiscoveryPanelMobile: React.FC = () => {
     }, 200);
 
     try {
-      const response = await fetch('/api/omai/learn-now', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ forceRefresh: true })
-      });
-      
-      const data = await response.json();
+      const data = await apiClient.post<any>('/omai/learn-now', { forceRefresh: true });
       clearInterval(progressInterval);
       setProgress(prev => ({ ...prev, learning: 100 }));
       
@@ -269,17 +257,11 @@ const OMAIDiscoveryPanelMobile: React.FC = () => {
     }, 300);
 
     try {
-      const response = await fetch('/api/omai/agents/run-command', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          agentId: selectedAgent,
-          command: autofixCommand,
-          context: 'mobile-interface'
-        })
+      const data = await apiClient.post<any>('/omai/agents/run-command', {
+        agentId: selectedAgent,
+        command: autofixCommand,
+        context: 'mobile-interface'
       });
-
-      const data = await response.json();
       clearInterval(progressInterval);
       setProgress(prev => ({ ...prev, autofix: 100 }));
 
@@ -314,12 +296,7 @@ const OMAIDiscoveryPanelMobile: React.FC = () => {
     formData.append('source', 'mobile-upload');
 
     try {
-      const response = await fetch('/api/omai/upload-knowledge', {
-        method: 'POST',
-        body: formData
-      });
-
-      const data = await response.json();
+      const data = await apiClient.post<any>('/omai/upload-knowledge', formData);
       if (data.success) {
         setUploadResult(`File uploaded successfully: ${data.processed} entries processed`);
         setUploadDialogOpen(true);

--- a/front-end/src/features/admin/admin/ScriptRunner.tsx
+++ b/front-end/src/features/admin/admin/ScriptRunner.tsx
@@ -3,6 +3,7 @@
 // Allows super_admin and admin users to execute pre-approved server scripts
 
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Paper,
   Typography,
@@ -84,19 +85,7 @@ const ScriptRunner: React.FC = () => {
     setError('');
     
     try {
-      const response = await fetch('/api/scripts', {
-        method: 'GET',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || `HTTP ${response.status}`);
-      }
+      const data = await apiClient.get<any>('/scripts');
 
       if (data.success) {
         setScripts(data.scripts || []);
@@ -119,17 +108,9 @@ const ScriptRunner: React.FC = () => {
     setIsLoadingLogs(true);
     
     try {
-      const response = await fetch('/api/script-logs?limit=20', {
-        method: 'GET',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
+      const data = await apiClient.get<any>('/script-logs?limit=20');
 
-      const data = await response.json();
-
-      if (response.ok && data.success) {
+      if (data.success) {
         setLogs(data.logs || []);
         console.log('📜 Loaded execution logs:', data.logs);
       }
@@ -153,23 +134,10 @@ const ScriptRunner: React.FC = () => {
     try {
       console.log(`🚀 Executing script: ${selectedScript}`);
       
-      const response = await fetch('/api/run-script', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          scriptName: selectedScript,
-          args: []
-        }),
+      const data = await apiClient.post<any>('/run-script', {
+        scriptName: selectedScript,
+        args: []
       });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || `HTTP ${response.status}: ${data.message || 'Script execution failed'}`);
-      }
 
       setResult(data);
       console.log('✅ Script execution completed:', data);

--- a/front-end/src/features/admin/admin/TSXComponentInstallWizard.tsx
+++ b/front-end/src/features/admin/admin/TSXComponentInstallWizard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Dialog,
   DialogTitle,
@@ -124,31 +125,10 @@ const TSXComponentInstallWizard: React.FC<TSXComponentInstallWizardProps> = ({
     try {
       const content = await file.text();
       
-      const response = await fetch('/api/bigbook/parse-tsx-component', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          fileName: file.name,
-          content: content
-        })
+      const result = await apiClient.post<any>('/bigbook/parse-tsx-component', {
+        fileName: file.name,
+        content: content
       });
-
-      // Check for authentication errors first
-      if (response.status === 401 || response.status === 403) {
-        onConsoleMessage('error', `🔐 Authentication required: Please log in as super_admin or editor to use Big Book auto-install`);
-        return;
-      }
-
-      // Check for other HTTP errors
-      if (!response.ok) {
-        onConsoleMessage('error', `❌ Server error: HTTP ${response.status} - ${response.statusText}`);
-        return;
-      }
-
-      const result = await response.json();
       
       if (result.success) {
         setComponentInfo(result.componentInfo);
@@ -184,26 +164,17 @@ const TSXComponentInstallWizard: React.FC<TSXComponentInstallWizardProps> = ({
     try {
       // Choose installation endpoint based on Big Book auto-install option
       const endpoint = installOptions.bigBookAutoInstall 
-        ? '/api/bigbook/install-bigbook-component'
-        : '/api/bigbook/install-tsx-component';
+        ? '/bigbook/install-bigbook-component'
+        : '/bigbook/install-tsx-component';
       
       onConsoleMessage('info', installOptions.bigBookAutoInstall 
         ? '📚 Installing as Big Book custom component with auto-menu integration...'
         : '🧩 Installing as standard TSX component...');
 
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          componentInfo,
-          installOptions
-        })
+      const result = await apiClient.post<any>(endpoint, {
+        componentInfo,
+        installOptions
       });
-
-      const result = await response.json();
       
       if (result.success) {
         setInstallationResult(result);
@@ -246,21 +217,10 @@ const TSXComponentInstallWizard: React.FC<TSXComponentInstallWizardProps> = ({
     try {
       // Choose removal endpoint based on installation type
       const endpoint = installOptions.bigBookAutoInstall 
-        ? '/api/bigbook/remove-bigbook-component'
-        : '/api/bigbook/remove-tsx-component';
+        ? '/bigbook/remove-bigbook-component'
+        : '/bigbook/remove-tsx-component';
       
-      const response = await fetch(endpoint, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          installationResult
-        })
-      });
-
-      const result = await response.json();
+      const result = await apiClient.delete<any>(endpoint);
       
       if (result.success) {
         onConsoleMessage('success', `✅ Component removed successfully`);

--- a/front-end/src/features/admin/admin/tools/OMSiteSurvey.tsx
+++ b/front-end/src/features/admin/admin/tools/OMSiteSurvey.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Typography,
@@ -132,24 +133,13 @@ const OMSiteSurvey: React.FC = () => {
         console.log(`🔄 Executing: ${step.name}`);
         
         try {
-          const response = await fetch(step.endpoint, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            credentials: 'include'
-          });
+          const result = await apiClient.post<any>(step.endpoint.replace('/api', ''));
           
-          if (response.ok) {
-            const result = await response.json();
-            if (result.success) {
-              step.setter(result);
-              console.log(`✅ ${step.name} completed`);
-            } else {
-              console.error(`❌ ${step.name} failed:`, result.error);
-            }
+          if (result.success) {
+            step.setter(result);
+            console.log(`✅ ${step.name} completed`);
           } else {
-            console.error(`❌ ${step.name} failed with status:`, response.status);
+            console.error(`❌ ${step.name} failed:`, result.error);
           }
         } catch (stepError) {
           console.error(`❌ ${step.name} error:`, stepError);

--- a/front-end/src/features/admin/components/NotificationManagement.tsx
+++ b/front-end/src/features/admin/components/NotificationManagement.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Box,
     Typography,
@@ -140,13 +141,8 @@ const NotificationManagement: React.FC = () => {
 
     const fetchSystemRoles = async () => {
         try {
-            const response = await fetch('/api/admin/roles', {
-                credentials: 'include'
-            });
-            if (response.ok) {
-                const data = await response.json();
-                setSystemRoles(data.roles || []);
-            }
+            const data = await apiClient.get<any>('/admin/roles');
+            setSystemRoles(data.roles || []);
         } catch (err) {
             console.error('Failed to load system roles:', err);
         }
@@ -155,13 +151,8 @@ const NotificationManagement: React.FC = () => {
     const fetchNotificationTypes = async () => {
         try {
             setLoading(true);
-            const response = await fetch('/api/admin/notifications/types', {
-                credentials: 'include'
-            });
-            if (response.ok) {
-                const data = await response.json();
-                setNotificationTypes(data.types || []);
-            }
+            const data = await apiClient.get<any>('/admin/notifications/types');
+            setNotificationTypes(data.types || []);
         } catch (err) {
             setError('Failed to load notification types');
         } finally {
@@ -171,13 +162,8 @@ const NotificationManagement: React.FC = () => {
 
     const fetchNotificationQueue = async () => {
         try {
-            const response = await fetch('/api/admin/notifications/queue', {
-                credentials: 'include'
-            });
-            if (response.ok) {
-                const data = await response.json();
-                setCustomNotifications(data.queue || []);
-            }
+            const data = await apiClient.get<any>('/admin/notifications/queue');
+            setCustomNotifications(data.queue || []);
         } catch (err) {
             console.error('Failed to load notification queue:', err);
         }
@@ -185,23 +171,13 @@ const NotificationManagement: React.FC = () => {
 
     const handleToggleNotificationType = async (typeId: number, enabled: boolean) => {
         try {
-            const response = await fetch(`/api/admin/notifications/types/${typeId}/toggle`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                credentials: 'include',
-                body: JSON.stringify({ enabled })
-            });
-
-            if (response.ok) {
-                setNotificationTypes(prev =>
-                    prev.map(type =>
-                        type.id === typeId ? { ...type, default_enabled: enabled } : type
-                    )
-                );
-                setSuccess(`Notification type ${enabled ? 'enabled' : 'disabled'} system-wide`);
-            } else {
-                throw new Error('Failed to update notification type');
-            }
+            await apiClient.put<any>(`/admin/notifications/types/${typeId}/toggle`, { enabled });
+            setNotificationTypes(prev =>
+                prev.map(type =>
+                    type.id === typeId ? { ...type, default_enabled: enabled } : type
+                )
+            );
+            setSuccess(`Notification type ${enabled ? 'enabled' : 'disabled'} system-wide`);
         } catch (err) {
             setError('Failed to update notification type');
         }
@@ -210,32 +186,21 @@ const NotificationManagement: React.FC = () => {
     const handleCreateCustomNotification = async () => {
         try {
             setLoading(true);
-            const response = await fetch('/api/admin/notifications/custom', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                credentials: 'include',
-                body: JSON.stringify(newNotification)
+            const data = await apiClient.post<any>('/admin/notifications/custom', newNotification);
+            setSuccess(`Custom notification ${newNotification.is_draft ? 'saved as draft' : 'scheduled'} successfully`);
+            setCreateDialogOpen(false);
+            setNewNotification({
+                title: '',
+                message: '',
+                priority: 'normal',
+                scheduled_at: null,
+                target_audience: 'all',
+                icon: '📢',
+                action_url: '',
+                action_text: '',
+                is_draft: false
             });
-
-            if (response.ok) {
-                const data = await response.json();
-                setSuccess(`Custom notification ${newNotification.is_draft ? 'saved as draft' : 'scheduled'} successfully`);
-                setCreateDialogOpen(false);
-                setNewNotification({
-                    title: '',
-                    message: '',
-                    priority: 'normal',
-                    scheduled_at: null,
-                    target_audience: 'all',
-                    icon: '📢',
-                    action_url: '',
-                    action_text: '',
-                    is_draft: false
-                });
-                fetchNotificationQueue();
-            } else {
-                throw new Error('Failed to create notification');
-            }
+            fetchNotificationQueue();
         } catch (err) {
             setError('Failed to create custom notification');
         } finally {

--- a/front-end/src/features/admin/components/SessionPulse.tsx
+++ b/front-end/src/features/admin/components/SessionPulse.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Paper,
@@ -66,23 +67,7 @@ const SessionPulse: React.FC<SessionPulseProps> = ({
 
   const fetchStats = useCallback(async () => {
     try {
-      const response = await fetch('/api/admin/session-stats', {
-        credentials: 'include'
-      });
-
-      if (response.status === 401) {
-        // Session expired - stop polling to prevent 401 spam
-        stopPolling();
-        setError('Session expired');
-        setLoading(false);
-        return;
-      }
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      const data = await response.json();
+      const data = await apiClient.get<any>('/admin/session-stats');
       if (data.success) {
         setStats(data.stats);
         setError(null);

--- a/front-end/src/features/admin/control-panel/PendingMembersPage.tsx
+++ b/front-end/src/features/admin/control-panel/PendingMembersPage.tsx
@@ -3,6 +3,7 @@
  * These users have is_locked=1 with lockout_reason "Pending admin review"
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
 import Breadcrumb from '@/layouts/full/shared/breadcrumb/Breadcrumb';
 import PageContainer from '@/shared/ui/PageContainer';
 import {
@@ -78,9 +79,7 @@ const PendingMembersPage: React.FC = () => {
     setLoading(true);
     setError('');
     try {
-      const res = await fetch('/api/admin/users?status=locked&limit=100', { credentials: 'include' });
-      if (!res.ok) throw new Error('Failed to fetch users');
-      const data = await res.json();
+      const data = await apiClient.get<any>('/admin/users?status=locked&limit=100');
       const pendingUsers = (data.users || []).filter(
         (u: PendingUser) => u.is_locked && u.lockout_reason?.toLowerCase().includes('pending')
       );
@@ -97,12 +96,7 @@ const PendingMembersPage: React.FC = () => {
   const handleApprove = async (userId: number, email: string) => {
     setActionLoading(userId);
     try {
-      const res = await fetch(`/api/admin/users/${userId}/unlock`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      if (!res.ok) throw new Error('Failed to unlock user');
+      await apiClient.post<any>(`/admin/users/${userId}/unlock`);
       setSnack({ open: true, message: `${email} approved and unlocked`, severity: 'success' });
       setUsers(prev => prev.filter(u => u.id !== userId));
     } catch (err: any) {
@@ -117,13 +111,9 @@ const PendingMembersPage: React.FC = () => {
     setActionLoading(rejectDialog.userId);
     try {
       // Keep the user locked but update the reason to indicate rejection
-      const res = await fetch(`/api/admin/users/${rejectDialog.userId}/lockout`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reason: `Registration rejected: ${rejectReason || 'Not approved by admin'}` }),
-      });
-      if (!res.ok) {
+      try {
+        await apiClient.post<any>(`/admin/users/${rejectDialog.userId}/lockout`, { reason: `Registration rejected: ${rejectReason || 'Not approved by admin'}` });
+      } catch {
         // User is already locked, so manually update the reason
         // The lockout endpoint returns 400 for already-locked users, so just remove from list
       }

--- a/front-end/src/features/admin/headlines/HeadlineSourcePicker.tsx
+++ b/front-end/src/features/admin/headlines/HeadlineSourcePicker.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Card,
@@ -106,16 +107,13 @@ const HeadlineSourcePicker: React.FC = () => {
       setLoading(true);
       
       // Load sources
-      const sourcesResponse = await fetch('/api/headlines/sources/manage');
-      const sourcesData = await sourcesResponse.json();
+      const sourcesData = await apiClient.get<any>('/headlines/sources/manage');
       
       // Load categories
-      const categoriesResponse = await fetch('/api/headlines/categories');
-      const categoriesData = await categoriesResponse.json();
+      const categoriesData = await apiClient.get<any>('/headlines/categories');
       
       // Load config
-      const configResponse = await fetch('/api/headlines/config');
-      const configData = await configResponse.json();
+      const configData = await apiClient.get<any>('/headlines/config');
       
       if (sourcesData.success) setSources(sourcesData.sources);
       if (categoriesData.success) setCategories(categoriesData.categories);
@@ -166,10 +164,7 @@ const HeadlineSourcePicker: React.FC = () => {
   const testSource = async (sourceId: string) => {
     try {
       setTesting(sourceId);
-      const response = await fetch(`/api/headlines/sources/${sourceId}/test`, {
-        method: 'POST'
-      });
-      const data = await response.json();
+      const data = await apiClient.post<any>(`/headlines/sources/${sourceId}/test`);
       
       if (data.success) {
         setMessage({ 
@@ -205,13 +200,7 @@ const HeadlineSourcePicker: React.FC = () => {
         return;
       }
 
-      const response = await fetch('/api/headlines/sources', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(newSource)
-      });
-      
-      const data = await response.json();
+      const data = await apiClient.post<any>('/headlines/sources', newSource);
       
       if (data.success) {
         setSources(prev => [...prev, data.source]);
@@ -231,27 +220,13 @@ const HeadlineSourcePicker: React.FC = () => {
       setSaving(true);
       
       // Save sources
-      const sourcesResponse = await fetch('/api/headlines/sources/bulk-update', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sources })
-      });
+      await apiClient.put<any>('/headlines/sources/bulk-update', { sources });
       
       // Save categories
-      const categoriesResponse = await fetch('/api/headlines/categories/bulk-update', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ categories })
-      });
+      await apiClient.put<any>('/headlines/categories/bulk-update', { categories });
       
       // Save config
-      const configResponse = await fetch('/api/headlines/config', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ config })
-      });
-      
-      const configData = await configResponse.json();
+      const configData = await apiClient.put<any>('/headlines/config', { config });
       
       if (configData.success) {
         setMessage({ type: 'success', text: 'Configuration saved successfully' });

--- a/front-end/src/features/admin/om-daily/hooks/useOMDailyItems.ts
+++ b/front-end/src/features/admin/om-daily/hooks/useOMDailyItems.ts
@@ -4,6 +4,7 @@
  */
 
 import { useCallback, useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import type { DailyItem } from '../omDailyTypes';
 
 interface UseOMDailyItemsOptions {
@@ -35,11 +36,8 @@ export function useOMDailyItems(_opts?: UseOMDailyItemsOptions) {
       if (params?.search) qs.set('search', params.search);
       qs.set('sort', params?.sort || 'priority');
 
-      const resp = await fetch(`/api/omai-daily/items?${qs}`, { credentials: 'include' });
-      if (resp.ok) {
-        const data = await resp.json();
-        setItems(data.items || []);
-      }
+      const data = await apiClient.get<any>(`/omai-daily/items?${qs}`);
+      setItems(data.items || []);
     } catch {} finally {
       setLoading(false);
     }
@@ -47,57 +45,30 @@ export function useOMDailyItems(_opts?: UseOMDailyItemsOptions) {
 
   const fetchCategories = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/categories', { credentials: 'include' });
-      if (resp.ok) {
-        const data = await resp.json();
-        setCategories(data.categories || []);
-      }
+      const data = await apiClient.get<any>('/omai-daily/categories');
+      setCategories(data.categories || []);
     } catch {}
   }, []);
 
   const saveItem = useCallback(async (form: Record<string, any>, editId?: number) => {
-    const url = editId ? `/api/omai-daily/items/${editId}` : '/api/omai-daily/items';
-    const method = editId ? 'PUT' : 'POST';
-    const resp = await fetch(url, {
-      method, credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(form),
-    });
-    if (!resp.ok) throw new Error('Failed to save');
-    return resp.json();
+    const url = editId ? `/omai-daily/items/${editId}` : '/omai-daily/items';
+    if (editId) {
+      return apiClient.put<any>(url, form);
+    } else {
+      return apiClient.post<any>(url, form);
+    }
   }, []);
 
   const deleteItem = useCallback(async (id: number) => {
-    const resp = await fetch(`/api/omai-daily/items/${id}`, { method: 'DELETE', credentials: 'include' });
-    if (!resp.ok) throw new Error('Failed to delete');
+    await apiClient.delete<any>(`/omai-daily/items/${id}`);
   }, []);
 
   const updateStatus = useCallback(async (id: number, newStatus: string, extra?: Record<string, any>) => {
-    const resp = await fetch(`/api/omai-daily/items/${id}/status`, {
-      method: 'PATCH', credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status: newStatus, ...extra }),
-    });
-    if (!resp.ok) {
-      const data = await resp.json().catch(() => ({}));
-      const err = new Error(data.reasons?.join(' ') || data.error || 'Transition blocked');
-      (err as any).response = { data };
-      throw err;
-    }
-    return resp.json();
+    return apiClient.patch<any>(`/omai-daily/items/${id}/status`, { status: newStatus, ...extra });
   }, []);
 
   const startWork = useCallback(async (id: number, branchType: string, agentTool: string) => {
-    const resp = await fetch(`/api/omai-daily/items/${id}/start-work`, {
-      method: 'POST', credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ branch_type: branchType, agent_tool: agentTool }),
-    });
-    if (!resp.ok) {
-      const data = await resp.json().catch(() => ({}));
-      throw new Error(data.error || 'Failed to start work');
-    }
-    return resp.json();
+    return apiClient.post<any>(`/omai-daily/items/${id}/start-work`, { branch_type: branchType, agent_tool: agentTool });
   }, []);
 
   return {

--- a/front-end/src/features/admin/om-daily/pages/OMDailyChangelogPage.tsx
+++ b/front-end/src/features/admin/om-daily/pages/OMDailyChangelogPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box, Paper, Typography, TextField, Button, Chip, Collapse,
   List, ListItemButton, ListItemText, Badge, CircularProgress,
@@ -40,41 +41,35 @@ const OMDailyChangelogPage: React.FC = () => {
   const [pushing, setPushing] = useState(false);
 
   // ─── API helpers ─────────────────────────────────────────────────
-  const apiFetch = useCallback(async (url: string, opts?: RequestInit) => {
-    const res = await fetch(url, { credentials: 'include', ...opts });
-    if (!res.ok) throw new Error(await res.text());
-    return res.json();
-  }, []);
-
   const fetchChangelog = useCallback(async () => {
     try {
-      const data = await apiFetch('/api/omai-daily/changelog?limit=30');
+      const data = await apiClient.get<any>('/omai-daily/changelog?limit=30');
       setChangelogEntries(Array.isArray(data) ? data : data.entries ?? []);
     } catch {
       /* silent */
     }
-  }, [apiFetch]);
+  }, []);
 
   const fetchChangelogDetail = useCallback(async (date: string) => {
     setChangelogLoading(true);
     try {
-      const data = await apiFetch(`/api/omai-daily/changelog/${date}`);
+      const data = await apiClient.get<any>(`/omai-daily/changelog/${date}`);
       setChangelogDetail(data);
     } catch {
       setChangelogDetail(null);
     } finally {
       setChangelogLoading(false);
     }
-  }, [apiFetch]);
+  }, []);
 
   const fetchBuildInfo = useCallback(async () => {
     try {
-      const data = await apiFetch('/api/omai-daily/build-info');
+      const data = await apiClient.get<any>('/omai-daily/build-info');
       setBuildInfo(data);
     } catch {
       /* silent */
     }
-  }, [apiFetch]);
+  }, []);
 
   // ─── Mount ───────────────────────────────────────────────────────
   useEffect(() => {
@@ -87,7 +82,7 @@ const OMDailyChangelogPage: React.FC = () => {
   const handleGenerate = async () => {
     setChangelogLoading(true);
     try {
-      await apiFetch('/api/omai-daily/changelog/generate', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+      await apiClient.post<any>('/omai-daily/changelog/generate');
       showToast('Changelog generated', 'success');
       await fetchChangelog();
       await fetchChangelogDetail(selectedChangelogDate);
@@ -100,7 +95,7 @@ const OMDailyChangelogPage: React.FC = () => {
 
   const handleSendEmail = async () => {
     try {
-      await apiFetch(`/api/omai-daily/changelog/email/${selectedChangelogDate}`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+      await apiClient.post<any>(`/omai-daily/changelog/email/${selectedChangelogDate}`);
       showToast('Email sent', 'success');
       await fetchChangelogDetail(selectedChangelogDate);
     } catch (err: any) {
@@ -111,7 +106,7 @@ const OMDailyChangelogPage: React.FC = () => {
   const handlePush = async () => {
     setPushing(true);
     try {
-      await apiFetch('/api/omai-daily/push-to-origin', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+      await apiClient.post<any>('/omai-daily/push-to-origin');
       showToast('Pushed to origin', 'success');
     } catch (err: any) {
       showToast(err.message || 'Push failed', 'error');

--- a/front-end/src/features/admin/om-daily/pages/OMDailyDashboardPage.tsx
+++ b/front-end/src/features/admin/om-daily/pages/OMDailyDashboardPage.tsx
@@ -2,6 +2,7 @@
  * OMDailyDashboardPage — Overview/KPI dashboard for OM Daily.
  * Extracted from OMDailyPage Tab 0 (renderOverview).
  */
+import { apiClient } from '@/api/utils/axiosInstance';
 
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -72,39 +73,36 @@ const OMDailyDashboardPage: React.FC = () => {
   // ── Fetchers ──
   const fetchDashboard = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/dashboard', { credentials: 'include' });
-      if (resp.ok) setDashboard(await resp.json());
+      const data = await apiClient.get<any>('/omai-daily/dashboard');
+      setDashboard(data);
     } catch {}
   }, []);
 
   const fetchExtended = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/dashboard/extended', { credentials: 'include' });
-      if (resp.ok) setExtended(await resp.json());
+      const data = await apiClient.get<any>('/omai-daily/dashboard/extended');
+      setExtended(data);
     } catch {}
   }, []);
 
   const fetchGhStatus = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/github/status', { credentials: 'include' });
-      if (resp.ok) setGhStatus(await resp.json());
+      const data = await apiClient.get<any>('/omai-daily/github/status');
+      setGhStatus(data);
     } catch {}
   }, []);
 
   const fetchBuildInfo = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/build-info', { credentials: 'include' });
-      if (resp.ok) setBuildInfo(await resp.json());
+      const data = await apiClient.get<any>('/omai-daily/build-info');
+      setBuildInfo(data);
     } catch {}
   }, []);
 
   const fetchCsList = useCallback(async () => {
     try {
-      const resp = await fetch('/api/admin/change-sets?status=active', { credentials: 'include' });
-      if (resp.ok) {
-        const data = await resp.json();
-        setCsList(Array.isArray(data) ? data : data.changeSets || []);
-      }
+      const data = await apiClient.get<any>('/admin/change-sets?status=active');
+      setCsList(Array.isArray(data) ? data : data.changeSets || []);
     } catch {}
   }, []);
 
@@ -119,22 +117,19 @@ const OMDailyDashboardPage: React.FC = () => {
   const triggerGhSync = async () => {
     setGhSyncing(true);
     try {
-      await fetch('/api/omai-daily/github/sync', { method: 'POST', credentials: 'include' });
+      await apiClient.post<any>('/omai-daily/github/sync');
       showToast('GitHub sync started');
       pollRef.current = setInterval(async () => {
         try {
-          const resp = await fetch('/api/omai-daily/github/sync/progress', { credentials: 'include' });
-          if (resp.ok) {
-            const data = await resp.json();
-            setGhSyncProgress(data);
-            if (data.status === 'complete' || data.status === 'error') {
-              if (pollRef.current) clearInterval(pollRef.current);
-              pollRef.current = null;
-              setGhSyncing(false);
-              setGhSyncProgress(null);
-              fetchGhStatus();
-              showToast(data.status === 'complete' ? 'GitHub sync complete' : 'Sync error', data.status === 'complete' ? 'success' : 'error');
-            }
+          const data = await apiClient.get<any>('/omai-daily/github/sync/progress');
+          setGhSyncProgress(data);
+          if (data.status === 'complete' || data.status === 'error') {
+            if (pollRef.current) clearInterval(pollRef.current);
+            pollRef.current = null;
+            setGhSyncing(false);
+            setGhSyncProgress(null);
+            fetchGhStatus();
+            showToast(data.status === 'complete' ? 'GitHub sync complete' : 'Sync error', data.status === 'complete' ? 'success' : 'error');
           }
         } catch {}
       }, 2000);
@@ -147,7 +142,7 @@ const OMDailyDashboardPage: React.FC = () => {
   const pushToOrigin = async () => {
     setPushing(true);
     try {
-      await fetch('/api/omai-daily/push-to-origin', { method: 'POST', credentials: 'include' });
+      await apiClient.post<any>('/omai-daily/push-to-origin');
       showToast('Pushed to origin');
     } catch {
       showToast('Push failed', 'error');
@@ -160,20 +155,15 @@ const OMDailyDashboardPage: React.FC = () => {
   const handleSave = async () => {
     if (!form.title.trim()) return;
     try {
-      const resp = await fetch(editingItem ? `/api/omai-daily/items/${editingItem.id}` : '/api/omai-daily/items', {
-        method: editingItem ? 'PUT' : 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
-      });
-      if (resp.ok) {
-        showToast(editingItem ? 'Item updated' : 'Item created');
-        setDialogOpen(false);
-        fetchDashboard();
-        fetchExtended();
+      if (editingItem) {
+        await apiClient.put<any>(`/omai-daily/items/${editingItem.id}`, form);
       } else {
-        showToast('Failed to save', 'error');
+        await apiClient.post<any>('/omai-daily/items', form);
       }
+      showToast(editingItem ? 'Item updated' : 'Item created');
+      setDialogOpen(false);
+      fetchDashboard();
+      fetchExtended();
     } catch {
       showToast('Failed to save', 'error');
     }
@@ -184,18 +174,10 @@ const OMDailyDashboardPage: React.FC = () => {
     if (!promptForm.title.trim()) return;
     setPromptSubmitting(true);
     try {
-      const resp = await fetch('/api/prompt-plans', {
-        method: 'POST', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(promptForm),
-      });
-      if (resp.ok) {
-        showToast('Prompt plan created');
-        setPromptDialogOpen(false);
-        setPromptForm({ title: '', description: '', agent_tool: 'claude_cli' });
-      } else {
-        showToast('Failed to create prompt plan', 'error');
-      }
+      await apiClient.post<any>('/prompt-plans', promptForm);
+      showToast('Prompt plan created');
+      setPromptDialogOpen(false);
+      setPromptForm({ title: '', description: '', agent_tool: 'claude_cli' });
     } catch {
       showToast('Failed to create prompt plan', 'error');
     } finally {

--- a/front-end/src/features/admin/tools/OMSiteSurvey.tsx
+++ b/front-end/src/features/admin/tools/OMSiteSurvey.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Typography,
@@ -132,24 +133,13 @@ const OMSiteSurvey: React.FC = () => {
         console.log(`🔄 Executing: ${step.name}`);
         
         try {
-          const response = await fetch(step.endpoint, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            credentials: 'include'
-          });
+          const result = await apiClient.post<any>(step.endpoint.replace('/api', ''));
           
-          if (response.ok) {
-            const result = await response.json();
-            if (result.success) {
-              step.setter(result);
-              console.log(`✅ ${step.name} completed`);
-            } else {
-              console.error(`❌ ${step.name} failed:`, result.error);
-            }
+          if (result.success) {
+            step.setter(result);
+            console.log(`✅ ${step.name} completed`);
           } else {
-            console.error(`❌ ${step.name} failed with status:`, response.status);
+            console.error(`❌ ${step.name} failed:`, result.error);
           }
         } catch (stepError) {
           console.error(`❌ ${step.name} error:`, stepError);


### PR DESCRIPTION
## Batch 5 — Admin Panel Part 2

Migrated **21 files** with **~73 fetch() calls** replaced with `apiClient` methods.

### Legacy duplicates (admin/admin/)
| File | fetch calls |
|------|------------|
| BigBookCustomComponentViewer.tsx | 1 |
| BigBookDynamicRoute.tsx | 1 |
| BigBookSettings.tsx | 2 |
| ChurchAdminList.tsx | 1 |
| ChurchAdminPanelWorking.tsx | 1 |
| EncryptedStoragePanel.tsx | 5 |
| MenuManagement.tsx | 2 |
| MenuPermissions.tsx | 3 |
| OMAIDiscoveryPanel.tsx | 11 |
| OMAIDiscoveryPanelMobile.tsx | 6 |
| ScriptRunner.tsx | 3 |
| TSXComponentInstallWizard.tsx | 3 |
| tools/OMSiteSurvey.tsx | 1 |

### Unique files
| File | fetch calls |
|------|------------|
| components/NotificationManagement.tsx | 5 |
| components/SessionPulse.tsx | 1 |
| control-panel/PendingMembersPage.tsx | 3 |
| headlines/HeadlineSourcePicker.tsx | 8 |
| om-daily/hooks/useOMDailyItems.ts | 6 |
| om-daily/pages/OMDailyChangelogPage.tsx | 8 |
| om-daily/pages/OMDailyDashboardPage.tsx | 10 |
| tools/OMSiteSurvey.tsx | 1 |

### Stats
- **+198 / -571 lines** (net -373 lines)
- `npx tsc --noEmit` passes (only pre-existing error in ConversationLogPage.tsx)
- Zero remaining `fetch()` calls in migrated files

### Pattern
- `fetch('/api/...')` → `apiClient.get/post/put/delete/patch('/...')`
- Removed manual `response.ok`, `response.json()`, `credentials: 'include'`, `Content-Type` headers
- `apiClient` throws on non-2xx, so error handling relies on catch blocks