### PR TITLE
chore: migrate Batch 6 files from fetch() to apiClient

### DIFF
--- a/front-end/src/features/apps/user-profile/UserProfile.tsx
+++ b/front-end/src/features/apps/user-profile/UserProfile.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import Grid2 from '@/components/compat/Grid2';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useAuth } from '@/context/AuthContext';
 import Breadcrumb from '@/layouts/full/shared/breadcrumb/Breadcrumb';
 import PageContainer from '@/shared/ui/PageContainer';
@@ -110,19 +111,16 @@ const UserProfile = () => {
       }
 
       try {
-        const response = await fetch('/api/user/profile', { credentials: 'include' });
-        if (response.ok) {
-          const data = await response.json();
-          if (data.success && data.profile) {
-            const p = data.profile;
-            setProfileData({
-              display_name: p.display_name || `${p.first_name || ''} ${p.last_name || ''}`.trim(),
-              company: p.company || '',
-              location: p.location || '',
-              email: p.email || user.email || '',
-              phone: p.phone || '',
-            });
-          }
+        const data = await apiClient.get<any>('/user/profile');
+        if (data.success && data.profile) {
+          const p = data.profile;
+          setProfileData({
+            display_name: p.display_name || `${p.first_name || ''} ${p.last_name || ''}`.trim(),
+            company: p.company || '',
+            location: p.location || '',
+            email: p.email || user.email || '',
+            phone: p.phone || '',
+          });
         }
       } catch (error) {
         console.error('Error fetching profile:', error);
@@ -162,15 +160,8 @@ const UserProfile = () => {
 
     setSaving(true);
     try {
-      const response = await fetch('/api/user/profile/password', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ currentPassword, newPassword, confirmPassword }),
-      });
-
-      const data = await response.json();
-      if (response.ok && data.success) {
+      const data = await apiClient.put<any>('/user/profile/password', { currentPassword, newPassword, confirmPassword });
+      if (data.success) {
         setPasswordData({ currentPassword: '', newPassword: '', confirmPassword: '' });
         setSnackbar({ open: true, message: 'Password changed successfully', severity: 'success' });
       } else {
@@ -186,20 +177,13 @@ const UserProfile = () => {
   const handleSaveProfile = async () => {
     setSaving(true);
     try {
-      const response = await fetch('/api/user/profile', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          display_name: profileData.display_name,
-          company: profileData.company,
-          location: profileData.location,
-          phone: profileData.phone,
-        }),
+      const data = await apiClient.put<any>('/user/profile', {
+        display_name: profileData.display_name,
+        company: profileData.company,
+        location: profileData.location,
+        phone: profileData.phone,
       });
-
-      const data = await response.json();
-      if (response.ok && data.success) {
+      if (data.success) {
         setSnackbar({ open: true, message: 'Profile saved successfully', severity: 'success' });
       } else {
         throw new Error(data.message || 'Save failed');

--- a/front-end/src/features/auth/AcceptInvite.tsx
+++ b/front-end/src/features/auth/AcceptInvite.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Box,
     Card,
@@ -63,10 +64,9 @@ const AcceptInvite: React.FC = () => {
     useEffect(() => {
         const fetchInvite = async () => {
             try {
-                const res = await fetch(`/api/invite/${token}`);
-                const data = await res.json();
+                const data = await apiClient.get<any>(`/invite/${token}`);
 
-                if (!res.ok || !data.success) {
+                if (!data.success) {
                     setError(data.message || 'Invalid invite link.');
                     return;
                 }
@@ -99,15 +99,9 @@ const AcceptInvite: React.FC = () => {
         setError('');
 
         try {
-            const res = await fetch(`/api/invite/${token}/register`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ first_name: firstName, last_name: lastName, password, phone: phone || undefined }),
-            });
+            const data = await apiClient.post<any>(`/invite/${token}/register`, { first_name: firstName, last_name: lastName, password, phone: phone || undefined });
 
-            const data = await res.json();
-
-            if (!res.ok || !data.success) {
+            if (!data.success) {
                 setError(data.message || 'Registration failed.');
                 return;
             }

--- a/front-end/src/features/auth/VerifyEmailPage.tsx
+++ b/front-end/src/features/auth/VerifyEmailPage.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
   Alert,
@@ -37,14 +38,8 @@ const VerifyEmailPage: React.FC = () => {
 
     const verify = async () => {
       try {
-        const res = await fetch('/api/user/profile/verify-email', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({ token }),
-        });
-        const data = await res.json();
-        if (res.ok && data.success) {
+        const data = await apiClient.post<any>('/user/profile/verify-email', { token });
+        if (data.success) {
           setStatus('success');
           setMessage(data.message || 'Your email has been verified successfully.');
         } else {

--- a/front-end/src/features/auth/authentication/authForms/AuthRegister.tsx
+++ b/front-end/src/features/auth/authentication/authForms/AuthRegister.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Autocomplete,
   Box,
@@ -161,8 +162,7 @@ const AuthRegister = ({ title, subtitle, subtext }: AuthRegisterProps) => {
     try {
       const params = new URLSearchParams({ state });
       if (q.trim().length >= 2) params.set('q', q.trim());
-      const res = await fetch(`/api/auth/church-search?${params}`);
-      const data = await res.json();
+      const data = await apiClient.get<any>(`/auth/church-search?${params}`);
       if (data.success) setChurches(data.churches);
     } catch { /* ignore */ }
     finally { setSearching(false); }
@@ -187,8 +187,7 @@ const AuthRegister = ({ title, subtitle, subtext }: AuthRegisterProps) => {
   const loadAvailableDates = useCallback(async (month: string) => {
     setLoadingDates(true);
     try {
-      const res = await fetch(`/api/crm-public/available-dates?month=${month}`);
-      const data = await res.json();
+      const data = await apiClient.get<any>(`/crm-public/available-dates?month=${month}`);
       if (data.success) setAvailableDates(data.dates);
     } catch { /* ignore */ }
     finally { setLoadingDates(false); }
@@ -205,8 +204,7 @@ const AuthRegister = ({ title, subtitle, subtext }: AuthRegisterProps) => {
     if (!selectedDate) { setTimeSlots([]); return; }
     setLoadingSlots(true);
     setSelectedTime('');
-    fetch(`/api/crm-public/available-slots?date=${selectedDate}`)
-      .then(r => r.json())
+    apiClient.get<any>(`/crm-public/available-slots?date=${selectedDate}`)
       .then(data => { if (data.success) setTimeSlots(data.slots); })
       .catch(() => {})
       .finally(() => setLoadingSlots(false));
@@ -269,29 +267,24 @@ const AuthRegister = ({ title, subtitle, subtext }: AuthRegisterProps) => {
     setError('');
     setSubmitting(true);
     try {
-      const res = await fetch('/api/crm-public/inquiry', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          churchId: selectedChurch?.id || null,
-          churchName: churchName.trim(),
-          stateCode: selectedState || null,
-          firstName: firstName.trim(),
-          lastName: lastName.trim(),
-          email: email.trim(),
-          phone: phone.trim() || null,
-          role,
-          maintainsRecords,
-          heardAbout,
-          heardAboutDetail: heardAboutDetail.trim() || null,
-          interestedDigitalRecords: interestedDigital,
-          wantsMeeting: wantsMeeting === 'yes',
-          appointmentDate: selectedDate || null,
-          appointmentTime: selectedTime || null,
-        }),
+      const data = await apiClient.post<any>('/crm-public/inquiry', {
+        churchId: selectedChurch?.id || null,
+        churchName: churchName.trim(),
+        stateCode: selectedState || null,
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        email: email.trim(),
+        phone: phone.trim() || null,
+        role,
+        maintainsRecords,
+        heardAbout,
+        heardAboutDetail: heardAboutDetail.trim() || null,
+        interestedDigitalRecords: interestedDigital,
+        wantsMeeting: wantsMeeting === 'yes',
+        appointmentDate: selectedDate || null,
+        appointmentTime: selectedTime || null,
       });
-      const data = await res.json();
-      if (!res.ok || !data.success) {
+      if (!data.success) {
         setError(data.message || 'Submission failed. Please try again.');
         return;
       }

--- a/front-end/src/features/auth/authentication/authForms/AuthRegisterToken.tsx
+++ b/front-end/src/features/auth/authentication/authForms/AuthRegisterToken.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box, Typography, Button, Stack, Alert, LinearProgress,
   InputAdornment, IconButton, CircularProgress,
@@ -58,12 +59,8 @@ const AuthRegisterToken = () => {
     if (password !== confirmPassword) { setError('Passwords do not match.'); return; }
     setSubmitting(true);
     try {
-      const res = await fetch('/api/auth/church-register', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ church_name: churchName.trim(), registration_token: registrationToken.trim(), first_name: firstName.trim(), last_name: lastName.trim(), email: email.trim(), password }),
-      });
-      const data = await res.json();
-      if (!res.ok || !data.success) { setError(data.message || 'Registration failed.'); return; }
+      const data = await apiClient.post<any>('/auth/church-register', { church_name: churchName.trim(), registration_token: registrationToken.trim(), first_name: firstName.trim(), last_name: lastName.trim(), email: email.trim(), password });
+      if (!data.success) { setError(data.message || 'Registration failed.'); return; }
       setSuccess(true);
     } catch { setError('Network error.'); }
     finally { setSubmitting(false); }

--- a/front-end/src/features/berry-calendar/BerryCalendarPage.tsx
+++ b/front-end/src/features/berry-calendar/BerryCalendarPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Button,
@@ -73,10 +74,6 @@ const BCrumb = [
   { title: 'Calendar' },
 ];
 
-async function apiJson(url: string, options?: RequestInit) {
-  const res = await fetch(url, { credentials: 'include', ...options });
-  return res.json();
-}
 
 export default function BerryCalendarPage() {
   const theme = useTheme();
@@ -107,8 +104,8 @@ export default function BerryCalendarPage() {
   const fetchEvents = useCallback(async (start: string, end: string) => {
     try {
       const [myEvents, appointments] = await Promise.all([
-        apiJson(`/api/admin/calendar/events?start=${start}&end=${end}`),
-        showAppointments ? apiJson(`/api/admin/calendar/appointments?start=${start}&end=${end}`) : { success: true, events: [] },
+        apiClient.get<any>(`/admin/calendar/events?start=${start}&end=${end}`),
+        showAppointments ? apiClient.get<any>(`/admin/calendar/appointments?start=${start}&end=${end}`) : { success: true, events: [] },
       ]);
 
       const combined: CalendarEvent[] = [];
@@ -203,11 +200,7 @@ export default function BerryCalendarPage() {
     const newEnd = dropInfo.event.endStr || newStart;
 
     try {
-      await apiJson(`/api/admin/calendar/events/${evt.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ start: newStart, end: newEnd }),
-      });
+      await apiClient.put<any>(`/admin/calendar/events/${evt.id}`, { start: newStart, end: newEnd });
       setEvents(prev => prev.map(e =>
         e.id === evt.id ? { ...e, start: newStart, end: newEnd } : e
       ));
@@ -221,24 +214,16 @@ export default function BerryCalendarPage() {
     setSaving(true);
     try {
       if (isEditing && selectedEvent && !selectedEvent.isAppointment) {
-        await apiJson(`/api/admin/calendar/events/${selectedEvent.id}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            title: formTitle, description: formDescription,
-            start: formStart, end: formEnd, allDay: formAllDay,
-            color: formColor, eventType: formEventType, isAvailableSlot: formAvailableSlot,
-          }),
+        await apiClient.put<any>(`/admin/calendar/events/${selectedEvent.id}`, {
+          title: formTitle, description: formDescription,
+          start: formStart, end: formEnd, allDay: formAllDay,
+          color: formColor, eventType: formEventType, isAvailableSlot: formAvailableSlot,
         });
       } else if (!isEditing) {
-        await apiJson('/api/admin/calendar/events', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            title: formTitle, description: formDescription,
-            start: formStart, end: formEnd, allDay: formAllDay,
-            color: formColor, eventType: formEventType, isAvailableSlot: formAvailableSlot,
-          }),
+        await apiClient.post<any>('/admin/calendar/events', {
+          title: formTitle, description: formDescription,
+          start: formStart, end: formEnd, allDay: formAllDay,
+          color: formColor, eventType: formEventType, isAvailableSlot: formAvailableSlot,
         });
       }
       // Refresh
@@ -257,7 +242,7 @@ export default function BerryCalendarPage() {
     if (!selectedEvent || selectedEvent.isAppointment) return;
     setSaving(true);
     try {
-      await apiJson(`/api/admin/calendar/events/${selectedEvent.id}`, { method: 'DELETE' });
+      await apiClient.delete<any>(`/admin/calendar/events/${selectedEvent.id}`);
       if (dateRange.start && dateRange.end) {
         await fetchEvents(dateRange.start, dateRange.end);
       }

--- a/front-end/src/features/certificates/CertificateGeneratorPage.tsx
+++ b/front-end/src/features/certificates/CertificateGeneratorPage.tsx
@@ -9,6 +9,7 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Paper,
@@ -183,17 +184,14 @@ const CertificateGeneratorPage: React.FC = () => {
   // Load saved positions for this church
   const loadSavedPositions = async (): Promise<Record<string, { x: number; y: number }> | null> => {
     try {
-      const response = await fetch(`${API_BASE}/${churchId}/certificate/positions/${recordType}`);
-      if (response.ok) {
-        const data = await response.json();
-        if (data.success && data.positions && !data.isDefault) {
-          setSavedPositions(data.positions);
-          setFieldPositions(data.positions);
-          setPlacedFields(new Set(Object.keys(data.positions)));
-          setSavedPositionsLoaded(true);
-          setShowCoordinates(true); // Show coordinates by default when saved positions exist
-          return data.positions;
-        }
+      const data = await apiClient.get<any>(`/church/${churchId}/certificate/positions/${recordType}`);
+      if (data.success && data.positions && !data.isDefault) {
+        setSavedPositions(data.positions);
+        setFieldPositions(data.positions);
+        setPlacedFields(new Set(Object.keys(data.positions)));
+        setSavedPositionsLoaded(true);
+        setShowCoordinates(true); // Show coordinates by default when saved positions exist
+        return data.positions;
       }
     } catch (err) {
       console.warn('Could not load saved positions:', err);
@@ -253,18 +251,9 @@ const CertificateGeneratorPage: React.FC = () => {
     
     try {
       setSaving(true);
-      const response = await fetch(`${API_BASE}/${churchId}/certificate/positions/${recordType}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ positions: fieldPositions }),
-      });
-      
-      if (response.ok) {
-        setSnackbar({ open: true, message: 'Positions saved! These will be used for all certificates of this type.', severity: 'success' });
-        setSavedPositionsLoaded(true);
-      } else {
-        throw new Error('Failed to save');
-      }
+      await apiClient.post<any>(`/church/${churchId}/certificate/positions/${recordType}`, { positions: fieldPositions });
+      setSnackbar({ open: true, message: 'Positions saved! These will be used for all certificates of this type.', severity: 'success' });
+      setSavedPositionsLoaded(true);
     } catch (err) {
       setSnackbar({ open: true, message: 'Failed to save positions', severity: 'error' });
     } finally {
@@ -284,38 +273,24 @@ const CertificateGeneratorPage: React.FC = () => {
       setLoading(true);
       setError(null);
 
-      const [templateRes, recordRes] = await Promise.all([
-        fetch(`${API_BASE}/${churchId}/certificate/${recordType}/template`),
-        fetch(`${API_BASE}/${churchId}/certificate/${recordType}/${recordId}/preview`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ fieldOffsets: {}, hiddenFields: Object.keys(fieldLabels) }),
-        }),
+      const [templateData, recordResData] = await Promise.all([
+        apiClient.get<any>(`/church/${churchId}/certificate/${recordType}/template`),
+        apiClient.post<any>(`/church/${churchId}/certificate/${recordType}/${recordId}/preview`, { fieldOffsets: {}, hiddenFields: Object.keys(fieldLabels) }),
       ]);
 
-      if (templateRes.ok) {
-        const templateData = await templateRes.json();
-        if (templateData.success && templateData.template) {
-          setTemplateUrl(templateData.template); setImageLoaded(false);
-        }
+      if (templateData.success && templateData.template) {
+        setTemplateUrl(templateData.template); setImageLoaded(false);
       }
 
-      if (recordRes.ok) {
-        const recordResData = await recordRes.json();
-        if (recordResData.success && recordResData.record) {
-          setRecordData(recordResData.record);
-        }
-        if (!templateUrl && recordResData.preview) {
-          setTemplateUrl(recordResData.preview);
-        }
+      if (recordResData.success && recordResData.record) {
+        setRecordData(recordResData.record);
+      }
+      if (!templateUrl && recordResData.preview) {
+        setTemplateUrl(recordResData.preview);
       }
 
       // Load saved positions
       await loadSavedPositions();
-
-      if (!templateRes.ok && !recordRes.ok) {
-        throw new Error('Failed to load certificate data');
-      }
 
     } catch (err) {
       console.error('Fetch error:', err);
@@ -415,13 +390,10 @@ const CertificateGeneratorPage: React.FC = () => {
         }
       });
       
-      const response = await fetch(
-        `${API_BASE}/${churchId}/certificate/${recordType}/${recordId}/download?positions=${encodeURIComponent(JSON.stringify(positions))}&hidden=${encodeURIComponent(JSON.stringify(hiddenFields))}`
+      const blob = await apiClient.get<Blob>(
+        `/church/${churchId}/certificate/${recordType}/${recordId}/download?positions=${encodeURIComponent(JSON.stringify(positions))}&hidden=${encodeURIComponent(JSON.stringify(hiddenFields))}`,
+        { responseType: 'blob' }
       );
-
-      if (!response.ok) throw new Error(`Preview failed: HTTP ${response.status}`);
-
-      const blob = await response.blob();
       const url = window.URL.createObjectURL(blob);
       window.open(url, '_blank');
     } catch (err) {
@@ -447,13 +419,10 @@ const CertificateGeneratorPage: React.FC = () => {
         }
       });
       
-      const response = await fetch(
-        `${API_BASE}/${churchId}/certificate/${recordType}/${recordId}/download?positions=${encodeURIComponent(JSON.stringify(positions))}&hidden=${encodeURIComponent(JSON.stringify(hiddenFields))}`
+      const blob = await apiClient.get<Blob>(
+        `/church/${churchId}/certificate/${recordType}/${recordId}/download?positions=${encodeURIComponent(JSON.stringify(positions))}&hidden=${encodeURIComponent(JSON.stringify(hiddenFields))}`,
+        { responseType: 'blob' }
       );
-
-      if (!response.ok) throw new Error(`Download failed: HTTP ${response.status}`);
-
-      const blob = await response.blob();
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;

--- a/front-end/src/features/certificates/GenerateReportWizard.tsx
+++ b/front-end/src/features/certificates/GenerateReportWizard.tsx
@@ -5,6 +5,7 @@
  * Extracted from CertificateGeneratorPage.tsx
  */
 import React, { useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import JSZip from 'jszip';
 import {
   Box,
@@ -147,17 +148,11 @@ const GenerateReportWizard: React.FC<GenerateReportWizardProps> = ({
       const queryParams = new URLSearchParams();
       validCriteria.forEach(c => queryParams.append(c.field, c.value.trim()));
       
-      const response = await fetch(
-        `${API_BASE}/${churchId}/certificate/${recordType}/search?${queryParams.toString()}`
+      const data = await apiClient.get<any>(
+        `/church/${churchId}/certificate/${recordType}/search?${queryParams.toString()}`
       );
-      
-      if (response.ok) {
-        const data = await response.json();
-        setSearchResults(data.records || []);
-        setWizardStep(1);
-      } else {
-        throw new Error('Search failed');
-      }
+      setSearchResults(data.records || []);
+      setWizardStep(1);
     } catch (err) {
       onSnackbar('Search failed. Please try again.', 'error');
     } finally {
@@ -190,19 +185,12 @@ const GenerateReportWizard: React.FC<GenerateReportWizardProps> = ({
     setLoadingPreview(true);
     try {
       const positions = savedPositions || fieldPositions || {};
-      const response = await fetch(
-        `${API_BASE}/${churchId}/certificate/${recordType}/${recId}/preview`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ fieldOffsets: positions, hiddenFields: [] }),
-        }
+      const data = await apiClient.post<any>(
+        `/church/${churchId}/certificate/${recordType}/${recId}/preview`,
+        { fieldOffsets: positions, hiddenFields: [] }
       );
-      if (response.ok) {
-        const data = await response.json();
-        if (data.success && data.preview) {
-          setPreviewUrl(data.preview);
-        }
+      if (data.success && data.preview) {
+        setPreviewUrl(data.preview);
       }
     } catch (err) {
       console.error('Preview load error:', err);
@@ -251,26 +239,23 @@ const GenerateReportWizard: React.FC<GenerateReportWizardProps> = ({
     for (let i = 0; i < recordIds.length; i++) {
       const recId = recordIds[i];
       try {
-        const response = await fetch(
-          `${API_BASE}/${churchId}/certificate/${recordType}/${recId}/download?positions=${encodeURIComponent(JSON.stringify(positions))}&hidden=${encodeURIComponent(JSON.stringify(hiddenFields))}`
+        const blob = await apiClient.get<Blob>(
+          `/church/${churchId}/certificate/${recordType}/${recId}/download?positions=${encodeURIComponent(JSON.stringify(positions))}&hidden=${encodeURIComponent(JSON.stringify(hiddenFields))}`,
+          { responseType: 'blob' }
         );
-        
-        if (response.ok) {
-          const blob = await response.blob();
-          // Get record info for filename
-          const record = searchResults.find(r => r.id === recId);
-          let filename = `${recordType}_${recId}.pdf`;
-          if (record) {
-            const lastName = (record.last_name || record.lname_groom || '').replace(/[^a-zA-Z]/g, '');
-            const firstName = (record.first_name || record.fname_groom || '').replace(/[^a-zA-Z]/g, '');
-            if (lastName && firstName) {
-              filename = `${recordType}_${lastName}_${firstName}.pdf`;
-            }
+        // Get record info for filename
+        const record = searchResults.find(r => r.id === recId);
+        let filename = `${recordType}_${recId}.pdf`;
+        if (record) {
+          const lastName = (record.last_name || record.lname_groom || '').replace(/[^a-zA-Z]/g, '');
+          const firstName = (record.first_name || record.fname_groom || '').replace(/[^a-zA-Z]/g, '');
+          if (lastName && firstName) {
+            filename = `${recordType}_${lastName}_${firstName}.pdf`;
           }
-          zip.file(filename, blob);
-          successCount++;
-          setGeneratedCount(successCount);
         }
+        zip.file(filename, blob);
+        successCount++;
+        setGeneratedCount(successCount);
       } catch (err) {
         console.error(`Failed to generate certificate for record ${recId}:`, err);
       }

--- a/front-end/src/features/church/FieldMapperPage.tsx
+++ b/front-end/src/features/church/FieldMapperPage.tsx
@@ -1,4 +1,5 @@
 import adminAPI from '@/api/admin.api';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useAuth } from '@/context/AuthContext';
 import { fetchWithChurchContext } from '@/shared/lib/fetchWithChurchContext';
 import { enhancedTableStore, THEME_MAP, type LiturgicalThemeKey, type ThemeTokens } from '@/store/enhancedTableStore';
@@ -154,37 +155,19 @@ const FieldMapperPage: React.FC = () => {
         ? '/api/admin/churches/themes/global'
         : `/api/admin/churches/${churchId}/themes`;
 
-      const response = await fetch(endpoint, {
-        credentials: 'include',
-      });
+      const data = await apiClient.get<any>(endpoint.replace('/api', ''));
+      // Handle both ApiResponse-wrapped ({ data: { themes } }) and direct ({ themes }) formats
+      const themesPayload = data.data?.themes || data.themes;
+      if (themesPayload && typeof themesPayload === 'object' && Object.keys(themesPayload).length > 0) {
+        setThemeStudio(prev => ({
+          ...prev,
+          themes: themesPayload,
+          isGlobal: isGlobal,
+        }));
 
-      if (response.ok) {
-        const data = await response.json();
-        // Handle both ApiResponse-wrapped ({ data: { themes } }) and direct ({ themes }) formats
-        const themesPayload = data.data?.themes || data.themes;
-        if (themesPayload && typeof themesPayload === 'object' && Object.keys(themesPayload).length > 0) {
-          setThemeStudio(prev => ({
-            ...prev,
-            themes: themesPayload,
-            isGlobal: isGlobal,
-          }));
-
-          // Sync church-specific themes to enhancedTableStore so they appear in dropdown
-          if (!isGlobal) {
-            enhancedTableStore.setCustomThemes(themesPayload);
-          }
-        } else {
-          // Initialize with empty themes
-          setThemeStudio(prev => ({
-            ...prev,
-            themes: {},
-            isGlobal: isGlobal,
-          }));
-
-          // Clear custom themes if no themes found
-          if (!isGlobal) {
-            enhancedTableStore.setCustomThemes({});
-          }
+        // Sync church-specific themes to enhancedTableStore so they appear in dropdown
+        if (!isGlobal) {
+          enhancedTableStore.setCustomThemes(themesPayload);
         }
       } else {
         // Initialize with empty themes
@@ -194,7 +177,7 @@ const FieldMapperPage: React.FC = () => {
           isGlobal: isGlobal,
         }));
 
-        // Clear custom themes if request failed
+        // Clear custom themes if no themes found
         if (!isGlobal) {
           enhancedTableStore.setCustomThemes({});
         }
@@ -231,19 +214,9 @@ const FieldMapperPage: React.FC = () => {
         : `/api/admin/churches/${churchId}/themes`;
 
       // Send themes as object (Record<string, ThemeTokens>) to match what loadThemes() expects
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          themes: themeStudio.themes || {},
-        }),
+      await apiClient.post<any>(endpoint.replace('/api', ''), {
+        themes: themeStudio.themes || {},
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to save themes');
-      }
 
       setSuccess(`Themes saved successfully as ${themeStudio.isGlobal ? 'global' : 'church-specific'} themes!`);
 
@@ -286,26 +259,21 @@ const FieldMapperPage: React.FC = () => {
 
       try {
         // Load church information
-        const churchResponse = await fetch(`/api/admin/churches/${churchId}`, {
-          credentials: 'include',
-        });
-        let loadedChurchName = '';
-        if (churchResponse.ok) {
-          const churchData = await churchResponse.json();
-          loadedChurchName = churchData.church?.church_name || churchData.church?.name || churchData.data?.church_name || churchData.data?.name || churchData.church_name || churchData.name || '';
-          setChurchName(loadedChurchName);
-        }
+        const churchData = await apiClient.get<any>(`/admin/churches/${churchId}`);
+        let loadedChurchName = churchData.church?.church_name || churchData.church?.name || churchData.data?.church_name || churchData.data?.name || churchData.church_name || churchData.name || '';
+        setChurchName(loadedChurchName);
 
         // Check if logo exists - try multiple methods
         const logoUrl = `/images/records/${churchId}-logo.png`;
         let logoExists = false;
         try {
-          // Try HEAD request first
+          // rogue-fetch: static asset existence check (not an API call)
           const logoCheck = await fetch(logoUrl, { method: 'HEAD', cache: 'no-cache' });
           logoExists = logoCheck.ok;
         } catch {
           // If HEAD fails, try GET request
           try {
+            // rogue-fetch: static asset existence check (not an API call)
             const logoCheck = await fetch(logoUrl, { method: 'GET', cache: 'no-cache' });
             logoExists = logoCheck.ok;
           } catch {
@@ -315,12 +283,10 @@ const FieldMapperPage: React.FC = () => {
         }
 
         // Load dynamic records config
-        const configResponse = await fetch(`/api/admin/churches/${churchId}/dynamic-records-config`, {
-          credentials: 'include',
-        });
+        const configData = await apiClient.get<any>(`/admin/churches/${churchId}/dynamic-records-config`);
 
-        if (configResponse.ok) {
-          const data = await configResponse.json();
+        {
+          const data = configData;
           if (data.config) {
             // Merge with church info
             setDynamicConfig(prev => ({
@@ -344,18 +310,6 @@ const FieldMapperPage: React.FC = () => {
               fieldRules: storeState.fieldRules,
             });
           }
-        } else {
-          // Use defaults with church info
-          const storeState = enhancedTableStore.getState();
-          setDynamicConfig({
-            branding: {
-              ...storeState.branding,
-              churchName: loadedChurchName,
-              logoUrl: logoExists ? logoUrl : undefined,
-            },
-            liturgicalTheme: storeState.liturgicalTheme,
-            fieldRules: storeState.fieldRules,
-          });
         }
       } catch (err) {
         console.error('Error loading church info and dynamic records config:', err);
@@ -453,12 +407,9 @@ const FieldMapperPage: React.FC = () => {
 
       // Fetch row count for the table
       try {
-        const countRes = await fetch(`/api/admin/church-database/${churchId}/record-counts`, { credentials: 'include' });
-        if (countRes.ok) {
-          const countData = await countRes.json();
-          const counts = countData?.data?.record_counts || countData?.counts || countData;
-          setRowCount(counts[tableName] ?? null);
-        }
+        const countData = await apiClient.get<any>(`/admin/church-database/${churchId}/record-counts`);
+        const counts = countData?.data?.record_counts || countData?.counts || countData;
+        setRowCount(counts[tableName] ?? null);
       } catch { /* non-fatal */ }
     } catch (err: any) {
       console.error('Error loading columns:', err);

--- a/front-end/src/features/church/FieldMapperPage/UIThemeTab.tsx
+++ b/front-end/src/features/church/FieldMapperPage/UIThemeTab.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 import { enhancedTableStore } from '@/store/enhancedTableStore';
 import {
     Add as AddIcon,
@@ -281,23 +282,14 @@ const UIThemeTab: React.FC<UIThemeTabProps> = ({
                   setError(null);
                   setSuccess(null);
                   const storeState = enhancedTableStore.exportConfig();
-                  const response = await fetch(`/api/admin/churches/${churchId}/dynamic-records-config`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    credentials: 'include',
-                    body: JSON.stringify({
-                      config: {
-                        branding: dynamicConfig.branding,
-                        liturgicalTheme: dynamicConfig.liturgicalTheme,
-                        fieldRules: dynamicConfig.fieldRules,
-                        actionButtonConfigs: storeState.actionButtonConfigs,
-                      },
-                    }),
+                  await apiClient.post<any>(`/admin/churches/${churchId}/dynamic-records-config`, {
+                    config: {
+                      branding: dynamicConfig.branding,
+                      liturgicalTheme: dynamicConfig.liturgicalTheme,
+                      fieldRules: dynamicConfig.fieldRules,
+                      actionButtonConfigs: storeState.actionButtonConfigs,
+                    },
                   });
-                  if (!response.ok) {
-                    const errorData = await response.json().catch(() => ({}));
-                    throw new Error(errorData.message || errorData.error || 'Failed to save UI theme');
-                  }
                   setSuccess('UI Theme saved successfully!');
                   setTimeout(() => setSuccess(null), 3000);
                 } catch (err: any) {

--- a/front-end/src/features/church/FieldMapperPage/useRecordSettings.ts
+++ b/front-end/src/features/church/FieldMapperPage/useRecordSettings.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { fetchWithChurchContext } from '@/shared/lib/fetchWithChurchContext';
 import { DEFAULT_RECORD_SETTINGS } from './constants';
 
@@ -130,49 +131,7 @@ export function useRecordSettings(
     formData.append('image', file);
     formData.append('type', type);
 
-    const response = await fetch(`/api/admin/churches/${churchId}/record-images`, {
-      method: 'POST',
-      credentials: 'include',
-      body: formData,
-    });
-
-    if (!response.ok) {
-      let errorMessage = 'Failed to upload image';
-      const responseText = await response.text();
-
-      if (responseText.trim().startsWith('<html') || responseText.trim().startsWith('<!DOCTYPE')) {
-        const titleMatch = responseText.match(/<title>(.*?)<\/title>/i);
-        const title = titleMatch ? titleMatch[1] : 'Internal Server Error';
-        errorMessage = `Server error (${response.status}): ${title}. The server is experiencing issues.`;
-        console.error('Received HTML error page instead of JSON:', {
-          status: response.status,
-          statusText: response.statusText,
-          htmlTitle: title,
-          responsePreview: responseText.substring(0, 300),
-        });
-      } else {
-        try {
-          const errorDetails = JSON.parse(responseText);
-          errorMessage = errorDetails.message || errorDetails.error || errorDetails.error?.message || errorMessage;
-        } catch {
-          if (responseText && responseText.trim() && responseText.length < 500) {
-            errorMessage = responseText.trim();
-          } else {
-            errorMessage = `Server error: ${response.status} ${response.statusText}`;
-          }
-        }
-      }
-
-      console.error('Upload error details:', {
-        status: response.status,
-        statusText: response.statusText,
-        responsePreview: responseText.substring(0, 500),
-      });
-
-      throw new Error(errorMessage);
-    }
-
-    const result = await response.json();
+    const result = await apiClient.post<any>(`/admin/churches/${churchId}/record-images`, formData);
     const imageUrl = result.url || result.path || `/images/records/${churchId}-${type === 'logo' ? 'logo' : type === 'bg' ? 'bg' : type}.png`;
 
     setRecordSettings(prev => {
@@ -291,13 +250,8 @@ export function useRecordSettings(
 
       // Reload settings to ensure preview is updated
       try {
-        const reloadRes = await fetch(`/api/admin/churches/${churchId}/record-settings`, {
-          credentials: 'include',
-          cache: 'no-cache',
-        });
-        if (reloadRes.ok) {
-          const data = await reloadRes.json();
-          if (data.settings) {
+        const data = await apiClient.get<any>(`/admin/churches/${churchId}/record-settings`);
+        if (data.settings) {
             setRecordSettings(prev => ({
               ...prev,
               ...safeObj(data.settings),
@@ -351,7 +305,6 @@ export function useRecordSettings(
                 recordImage: data.settings.currentImageIndex?.recordImage ?? 0,
               },
             }));
-          }
         }
       } catch (err) {
         console.error('Error reloading record settings:', err);

--- a/front-end/src/features/church/apps/church-management/ChurchForm.tsx
+++ b/front-end/src/features/church/apps/church-management/ChurchForm.tsx
@@ -4,6 +4,7 @@
  */
 
 import { adminAPI } from '@/api/admin.api';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useAuth } from '@/context/AuthContext';
 import Breadcrumb from '@/layouts/full/shared/breadcrumb/Breadcrumb';
 import { fetchWithChurchContext } from '@/shared/lib/fetchWithChurchContext';
@@ -177,18 +178,13 @@ const ChurchForm: React.FC = () => {
   const loadFeatures = async (churchId: string) => {
     try {
       setLoadingFeatures(true);
-      const response = await fetch(`/api/churches/${churchId}/features`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await response.json();
-        if (data.success && data.data) {
-          setFeatureData({
-            globalDefaults: data.data.globalDefaults,
-            overrides: data.data.overrides,
-            effective: data.data.effective
-          });
-        }
+      const data = await apiClient.get<any>(`/churches/${churchId}/features`);
+      if (data.success && data.data) {
+        setFeatureData({
+          globalDefaults: data.data.globalDefaults,
+          overrides: data.data.overrides,
+          effective: data.data.effective
+        });
       }
     } catch (err) {
       console.error('Error loading features:', err);
@@ -210,36 +206,27 @@ const ChurchForm: React.FC = () => {
         effective: { ...prev.effective, [featureKey]: value }
       }));
 
-      const response = await fetch(`/api/churches/${id}/features`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          features: { [featureKey]: value }
-        }),
+      const data = await apiClient.put<any>(`/churches/${id}/features`, {
+        features: { [featureKey]: value }
       });
 
-      if (response.ok) {
-        const data = await response.json();
-        if (data.success && data.data) {
-          setFeatureData({
-            globalDefaults: data.data.globalDefaults,
-            overrides: data.data.overrides,
-            effective: data.data.effective
-          });
-          setSnackbar({ 
-            open: true, 
-            message: 'Feature override updated successfully', 
-            severity: 'success' 
-          });
-        }
+      if (data.success && data.data) {
+        setFeatureData({
+          globalDefaults: data.data.globalDefaults,
+          overrides: data.data.overrides,
+          effective: data.data.effective
+        });
+        setSnackbar({ 
+          open: true, 
+          message: 'Feature override updated successfully', 
+          severity: 'success' 
+        });
       } else {
         // Revert on failure
         setFeatureData(previousFeatureData);
-        const errorData = await response.json();
         setSnackbar({ 
           open: true, 
-          message: errorData.error?.message || 'Failed to update feature', 
+          message: data.error?.message || 'Failed to update feature', 
           severity: 'error' 
         });
       }
@@ -259,19 +246,12 @@ const ChurchForm: React.FC = () => {
   const testDatabaseConnection = async (churchId: string) => {
     try {
       setLoadingDatabase(true);
-      const response = await fetch(`/api/admin/churches/${churchId}/test-connection`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      if (response.ok) {
-        const data = await response.json();
-        if (data.success && data.data?.connection) {
-          setSnackbar({ open: true, message: `Connection OK (${data.data.connection.connection_time_ms}ms)`, severity: 'success' });
-          await loadDatabaseInfo(churchId);
-        } else {
-          setSnackbar({ open: true, message: `Connection failed: ${data.error || 'Unknown'}`, severity: 'error' });
-        }
+      const data = await apiClient.post<any>(`/admin/churches/${churchId}/test-connection`);
+      if (data.success && data.data?.connection) {
+        setSnackbar({ open: true, message: `Connection OK (${data.data.connection.connection_time_ms}ms)`, severity: 'success' });
+        await loadDatabaseInfo(churchId);
+      } else {
+        setSnackbar({ open: true, message: `Connection failed: ${data.error || 'Unknown'}`, severity: 'error' });
       }
     } catch (err: any) {
       setSnackbar({ open: true, message: `Connection error: ${err.message}`, severity: 'error' });
@@ -286,22 +266,12 @@ const ChurchForm: React.FC = () => {
         ? `/api/admin/churches/${id}/users`
         : `/api/admin/churches/${id}/users/${selectedUser?.id}`;
 
-      const response = await fetch(endpoint, {
-        method: userDialogAction === 'add' ? 'POST' : 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(userData),
-      });
-
-      if (response.ok) {
-        setSnackbar({ open: true, message: `User ${userDialogAction === 'add' ? 'added' : 'updated'} successfully`, severity: 'success' });
-        setUserDialogOpen(false);
-        setSelectedUser(null);
-        if (id) loadChurchUsers(id);
-      } else {
-        const data = await response.json();
-        setSnackbar({ open: true, message: data.message || 'Failed to save user', severity: 'error' });
-      }
+      const method = userDialogAction === 'add' ? 'post' : 'put';
+      const data = await apiClient[method]<any>(endpoint.replace('/api', ''), userData);
+      setSnackbar({ open: true, message: `User ${userDialogAction === 'add' ? 'added' : 'updated'} successfully`, severity: 'success' });
+      setUserDialogOpen(false);
+      setSelectedUser(null);
+      if (id) loadChurchUsers(id);
     } catch (err: any) {
       setSnackbar({ open: true, message: err.message, severity: 'error' });
     }
@@ -309,15 +279,9 @@ const ChurchForm: React.FC = () => {
 
   const handleUserAction = async (userId: number, action: string) => {
     try {
-      const response = await fetch(`/api/admin/churches/${id}/users/${userId}/${action}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-      });
-      if (response.ok) {
-        setSnackbar({ open: true, message: `User ${action} successful`, severity: 'success' });
-        if (id) loadChurchUsers(id);
-      }
+      await apiClient.post<any>(`/admin/churches/${id}/users/${userId}/${action}`);
+      setSnackbar({ open: true, message: `User ${action} successful`, severity: 'success' });
+      if (id) loadChurchUsers(id);
     } catch (err: any) {
       setSnackbar({ open: true, message: err.message, severity: 'error' });
     }
@@ -325,15 +289,8 @@ const ChurchForm: React.FC = () => {
 
   const handlePasswordReset = async (userId: number, email: string) => {
     try {
-      const response = await fetch(`/api/admin/churches/${id}/users/${userId}/reset-password`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setSnackbar({ open: true, message: `Password reset for ${email}. New: ${data.newPassword}`, severity: 'success' });
-      }
+      const data = await apiClient.post<any>(`/admin/churches/${id}/users/${userId}/reset-password`);
+      setSnackbar({ open: true, message: `Password reset for ${email}. New: ${data.newPassword}`, severity: 'success' });
     } catch (err: any) {
       setSnackbar({ open: true, message: err.message, severity: 'error' });
     }
@@ -344,16 +301,10 @@ const ChurchForm: React.FC = () => {
     try {
       setUpdatingDatabase(true);
       setDatabaseUpdateResult(null);
-      const response = await fetch(`/api/admin/churches/${id}/update-database`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ template: selectedTemplate }),
-      });
-      const result = await response.json();
+      const result = await apiClient.post<any>(`/admin/churches/${id}/update-database`, { template: selectedTemplate });
       setDatabaseUpdateResult({
-        success: response.ok,
-        message: response.ok ? (result.message || 'Database updated') : (result.error || 'Update failed'),
+        success: true,
+        message: result.message || 'Database updated',
       });
     } catch (err: any) {
       setDatabaseUpdateResult({ success: false, message: err.message });

--- a/front-end/src/features/devel-tools/PageImageIndex.tsx
+++ b/front-end/src/features/devel-tools/PageImageIndex.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Alert,
     Autocomplete,
@@ -152,11 +153,8 @@ const PageImageIndex: React.FC = () => {
 
   const fetchPages = async () => {
     try {
-      const response = await fetch('/api/gallery/admin/images/all-pages', { credentials: 'include' });
-      if (response.ok) {
-        const data = await response.json();
-        setPages(data.pages || []);
-      }
+      const data = await apiClient.get<any>('/gallery/admin/images/all-pages');
+      setPages(data.pages || []);
     } catch (error) {
       console.error('Error fetching pages:', error);
     }
@@ -165,14 +163,9 @@ const PageImageIndex: React.FC = () => {
   const fetchPageIndex = async (pageKey: string) => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/gallery/admin/images/page-index?page_key=${encodeURIComponent(pageKey)}`, {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setBindings(data.all_bindings || []);
-        setBindingsByKey(data.bindings_by_key || {});
-      }
+      const data = await apiClient.get<any>(`/gallery/admin/images/page-index?page_key=${encodeURIComponent(pageKey)}`);
+      setBindings(data.all_bindings || []);
+      setBindingsByKey(data.bindings_by_key || {});
     } catch (error) {
       console.error('Error fetching page index:', error);
     } finally {
@@ -182,14 +175,11 @@ const PageImageIndex: React.FC = () => {
 
   const fetchChurches = async () => {
     try {
-      const response = await fetch('/api/admin/churches', { credentials: 'include' });
-      if (response.ok) {
-        const data = await response.json();
-        const list = (data.data || data.churches || data || [])
-          .filter((c: any) => c && c.id)
-          .map((c: any) => ({ id: c.id, name: c.name || c.church_name || `Church ${c.id}` }));
-        setChurches(list);
-      }
+      const data = await apiClient.get<any>('/admin/churches');
+      const list = (data.data || data.churches || data || [])
+        .filter((c: any) => c && c.id)
+        .map((c: any) => ({ id: c.id, name: c.name || c.church_name || `Church ${c.id}` }));
+      setChurches(list);
     } catch (error) {
       console.error('Error fetching churches:', error);
     }
@@ -197,11 +187,8 @@ const PageImageIndex: React.FC = () => {
 
   const fetchRegistry = async () => {
     try {
-      const response = await fetch('/api/gallery/admin/images/registry', { credentials: 'include' });
-      if (response.ok) {
-        const data = await response.json();
-        setRegistryImages(data.images || []);
-      }
+      const data = await apiClient.get<any>('/gallery/admin/images/registry');
+      setRegistryImages(data.images || []);
     } catch (error) {
       console.error('Error fetching registry:', error);
     }
@@ -210,17 +197,9 @@ const PageImageIndex: React.FC = () => {
   const handleSyncRegistry = async () => {
     setSyncStatus('Syncing...');
     try {
-      const response = await fetch('/api/gallery/admin/images/registry/sync', {
-        method: 'POST',
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setSyncStatus(`Synced: ${data.discovered} discovered, ${data.inserted} new, ${data.skipped} existing`);
-        fetchRegistry();
-      } else {
-        setSyncStatus('Sync failed');
-      }
+      const data = await apiClient.post<any>('/gallery/admin/images/registry/sync');
+      setSyncStatus(`Synced: ${data.discovered} discovered, ${data.inserted} new, ${data.skipped} existing`);
+      fetchRegistry();
     } catch (error) {
       setSyncStatus('Sync error');
       console.error('Error syncing registry:', error);
@@ -247,27 +226,17 @@ const PageImageIndex: React.FC = () => {
     }
     setBindSaving(true);
     try {
-      const response = await fetch('/api/gallery/admin/images/bindings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          page_key: bindPageKey,
-          image_key: bindImageKey,
-          scope: bindScope,
-          church_id: bindScope === 'church' ? bindChurchId : null,
-          image_path: bindImagePath,
-          notes: bindNotes || null,
-        }),
+      await apiClient.post<any>('/gallery/admin/images/bindings', {
+        page_key: bindPageKey,
+        image_key: bindImageKey,
+        scope: bindScope,
+        church_id: bindScope === 'church' ? bindChurchId : null,
+        image_path: bindImagePath,
+        notes: bindNotes || null,
       });
-      if (response.ok) {
-        setBindDialogOpen(false);
-        fetchPages();
-        if (selectedPageKey) fetchPageIndex(selectedPageKey);
-      } else {
-        const err = await response.json();
-        alert(`Error: ${err.error || 'Failed to save binding'}`);
-      }
+      setBindDialogOpen(false);
+      fetchPages();
+      if (selectedPageKey) fetchPageIndex(selectedPageKey);
     } catch (error: any) {
       alert(`Error: ${error.message}`);
     } finally {
@@ -278,19 +247,9 @@ const PageImageIndex: React.FC = () => {
   const handleDeleteBinding = async (binding: Binding) => {
     if (!window.confirm(`Delete binding ${binding.page_key} → ${binding.image_key} (${binding.scope})?`)) return;
     try {
-      const response = await fetch('/api/gallery/admin/images/bindings', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ id: binding.id }),
-      });
-      if (response.ok) {
-        fetchPages();
-        if (selectedPageKey) fetchPageIndex(selectedPageKey);
-      } else {
-        const err = await response.json();
-        alert(`Error: ${err.error || 'Failed to delete'}`);
-      }
+      await apiClient.delete<any>('/gallery/admin/images/bindings', { data: { id: binding.id } });
+      fetchPages();
+      if (selectedPageKey) fetchPageIndex(selectedPageKey);
     } catch (error: any) {
       alert(`Error: ${error.message}`);
     }

--- a/front-end/src/features/devel-tools/RouterMenuStudio/api.ts
+++ b/front-end/src/features/devel-tools/RouterMenuStudio/api.ts
@@ -3,6 +3,8 @@
  * Frontend API client for Router/Menu Studio functionality
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
+
 // Types for the API responses
 export interface Route {
   id: number;
@@ -98,30 +100,23 @@ export interface RoutesQuery {
 export interface MenusQuery extends RoutesQuery {}
 
 class RouterMenuStudioAPI {
-  private baseURL = '/api/studio';
+  private basePath = '/studio';
 
   private async request<T = any>(
     endpoint: string,
     options: RequestInit = {}
   ): Promise<ApiResponse<T>> {
-    const url = `${this.baseURL}${endpoint}`;
-    
-    const config: RequestInit = {
-      headers: {
-        'Content-Type': 'application/json',
-        ...options.headers,
-      },
-      ...options,
-    };
+    const url = `${this.basePath}${endpoint}`;
+    const method = (options.method || 'GET').toLowerCase() as 'get' | 'post' | 'put' | 'delete' | 'patch';
 
     try {
-      const response = await fetch(url, config);
-      const data = await response.json();
-      
-      if (!response.ok) {
-        throw new Error(data.reason || `HTTP ${response.status}`);
+      const body = options.body ? JSON.parse(options.body as string) : undefined;
+      let data: any;
+      if (method === 'get' || method === 'delete') {
+        data = await apiClient[method]<any>(url);
+      } else {
+        data = await apiClient[method]<any>(url, body);
       }
-      
       return data;
     } catch (error) {
       console.error(`API request failed for ${endpoint}:`, error);

--- a/front-end/src/features/devel-tools/basic-refactor/BasicRefactor.tsx
+++ b/front-end/src/features/devel-tools/basic-refactor/BasicRefactor.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 import { CustomizerContext } from '@/context/CustomizerContext';
 import {
     Box,
@@ -113,10 +114,7 @@ const BasicRefactor: React.FC = () => {
   const loadPolicyFiles = useCallback(async () => {
     setIsLoadingFiles(true);
     try {
-      const res = await fetch('/api/refactor-console/policy/list', {
-        credentials: 'include',
-      });
-      const data = await res.json();
+      const data = await apiClient.get<any>('/refactor-console/policy/list');
       if (data.ok) {
         setPolicyFiles(data.files);
         // Auto-select first if none selected
@@ -141,10 +139,7 @@ const BasicRefactor: React.FC = () => {
   const loadPolicyContent = useCallback(async (policyPath: string) => {
     if (!policyPath) return;
     try {
-      const res = await fetch(`/api/refactor-console/policy?path=${encodeURIComponent(policyPath)}`, {
-        credentials: 'include',
-      });
-      const data = await res.json();
+      const data = await apiClient.get<any>(`/refactor-console/policy?path=${encodeURIComponent(policyPath)}`);
       if (data.ok) {
         setEditorContent(data.content);
         setEditorDirty(false);
@@ -169,13 +164,7 @@ const BasicRefactor: React.FC = () => {
     if (!selectedPolicyPath) return;
     setIsSaving(true);
     try {
-      const res = await fetch('/api/refactor-console/policy', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ path: selectedPolicyPath, content: editorContent }),
-      });
-      const data = await res.json();
+      const data = await apiClient.put<any>('/refactor-console/policy', { path: selectedPolicyPath, content: editorContent });
       if (data.ok) {
         setEditorDirty(false);
         toast.success('Policy saved');
@@ -205,13 +194,7 @@ const BasicRefactor: React.FC = () => {
     const fullPath = `/var/www/orthodoxmetrics/prod/ops/refactor/${filename}`;
     setIsSaving(true);
     try {
-      const res = await fetch('/api/refactor-console/policy', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ path: fullPath, content: NEW_POLICY_TEMPLATE }),
-      });
-      const data = await res.json();
+      const data = await apiClient.put<any>('/refactor-console/policy', { path: fullPath, content: NEW_POLICY_TEMPLATE });
       if (data.ok) {
         toast.success(`Created: ${filename}`);
         setNewFileName('');
@@ -234,11 +217,7 @@ const BasicRefactor: React.FC = () => {
   const handleDelete = useCallback(async (filePath: string) => {
     if (!window.confirm(`Delete policy file?\n${filePath}`)) return;
     try {
-      const res = await fetch(`/api/refactor-console/policy?path=${encodeURIComponent(filePath)}`, {
-        method: 'DELETE',
-        credentials: 'include',
-      });
-      const data = await res.json();
+      const data = await apiClient.delete<any>(`/refactor-console/policy?path=${encodeURIComponent(filePath)}`);
       if (data.ok) {
         toast.success('Policy deleted');
         if (selectedPolicyPath === filePath) {
@@ -301,10 +280,7 @@ const BasicRefactor: React.FC = () => {
 
       // Use the existing scan endpoint for the first enabled scope
       const scope = enabledScopes[0];
-      const scanRes = await fetch(`/api/refactor-console/scan?sourcePath=${encodeURIComponent(scope.root)}&sourceType=local`, {
-        credentials: 'include',
-      });
-      const scanData = await scanRes.json();
+      const scanData = await apiClient.get<any>(`/refactor-console/scan?sourcePath=${encodeURIComponent(scope.root)}&sourceType=local`);
 
       if (!scanData.ok || !scanData.nodes || scanData.nodes.length === 0) {
         toast.warning('Scan returned no data. Run a scan in the Refactor Console first, or check the scope root path.');


### PR DESCRIPTION
## Batch 6 — features/{apps,auth,berry-calendar,certificates,church} + devel-tools (part 1)

Migrated **15 files** with **~57 fetch() calls** replaced with `apiClient` methods.

### Files migrated
| File | fetch calls | Notes |
|------|------------|-------|
| apps/user-profile/UserProfile.tsx | 3 | |
| auth/AcceptInvite.tsx | 2 | |
| auth/VerifyEmailPage.tsx | 1 | |
| auth/authForms/AuthRegister.tsx | 4 | incl .then() chain |
| auth/authForms/AuthRegisterToken.tsx | 1 | |
| berry-calendar/BerryCalendarPage.tsx | 6 | removed local apiJson wrapper |
| certificates/CertificateGeneratorPage.tsx | 6 | 2 blob downloads via responseType: 'blob' |
| certificates/GenerateReportWizard.tsx | 3 | 1 blob download |
| church/FieldMapperPage.tsx | 5+2 | 2 rogue-fetch: static asset HEAD/GET checks |
| church/FieldMapperPage/UIThemeTab.tsx | 1 | |
| church/FieldMapperPage/useRecordSettings.ts | 3 | incl FormData upload |
| church/apps/church-management/ChurchForm.tsx | 8 | |
| devel-tools/PageImageIndex.tsx | 7 | |
| devel-tools/RouterMenuStudio/api.ts | 1 | gateway request() method |
| devel-tools/basic-refactor/BasicRefactor.tsx | 6 | |

### False positives (no migration needed)
- **MenuTree.tsx** / **RouteGrid.tsx** — use RouterMenuStudioAPI class, no raw fetch
- **QuickContactSidebar.tsx** — only a commented-out fetch (TODO placeholder)

### Stats
- **+244 / -565 lines** (net -321 lines)
- `npx tsc --noEmit` passes (only pre-existing error in ConversationLogPage.tsx)
- 2 rogue-fetch calls tagged in FieldMapperPage.tsx (static asset existence checks, not API calls)