### PR TITLE
chore: migrate devel-tools fetch() calls to apiClient (Batch 7)

### DIFF
--- a/front-end/src/features/devel-tools/crm/CRMPage.tsx
+++ b/front-end/src/features/devel-tools/crm/CRMPage.tsx
@@ -7,6 +7,7 @@
  * Church detail opens as a drawer with Overview / Contacts / Activities sub-tabs.
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
 import Breadcrumb from '@/layouts/full/shared/breadcrumb/Breadcrumb';
 import PageContainer from '@/shared/ui/PageContainer';
 import {
@@ -129,15 +130,15 @@ const CRMPage: React.FC = () => {
 
   const fetchStages = useCallback(async () => {
     try {
-      const resp = await fetch('/api/crm/pipeline-stages', { credentials: 'include' });
-      if (resp.ok) { const data = await resp.json(); setStages(data.stages); }
+      const data = await apiClient.get<any>('/crm/pipeline-stages');
+      setStages(data.stages);
     } catch {}
   }, []);
 
   const fetchDashboard = useCallback(async () => {
     try {
-      const resp = await fetch('/api/crm/dashboard', { credentials: 'include' });
-      if (resp.ok) { const data = await resp.json(); setDashboard(data); }
+      const data = await apiClient.get<any>('/crm/dashboard');
+      setDashboard(data);
     } catch (err: any) { setError(err.message); }
   }, []);
 
@@ -150,33 +151,27 @@ const CRMPage: React.FC = () => {
       if (filterJurisdiction) params.set('jurisdiction', filterJurisdiction);
       if (filterPriority) params.set('priority', filterPriority);
 
-      const resp = await fetch(`/api/crm/churches?${params}`, { credentials: 'include' });
-      if (resp.ok) {
-        const data = await resp.json();
-        setChurches(data.churches);
-        setChurchesTotal(data.total);
-      }
+      const data = await apiClient.get<any>(`/crm/churches?${params}`);
+      setChurches(data.churches);
+      setChurchesTotal(data.total);
     } catch {}
   }, [searchTerm, filterStage, filterState, filterJurisdiction, filterPriority, churchSort, churchSortDir]);
 
   const fetchFollowUps = useCallback(async () => {
     try {
-      const resp = await fetch('/api/crm/follow-ups?status=pending&limit=100', { credentials: 'include' });
-      if (resp.ok) { const data = await resp.json(); setFollowUps(data.followUps); }
+      const data = await apiClient.get<any>('/crm/follow-ups?status=pending&limit=100');
+      setFollowUps(data.followUps);
     } catch {}
   }, []);
 
   const fetchChurchDetail = useCallback(async (id: number) => {
     setDetailLoading(true);
     try {
-      const resp = await fetch(`/api/crm/churches/${id}`, { credentials: 'include' });
-      if (resp.ok) {
-        const data = await resp.json();
-        setSelectedChurch(data.church);
-        setChurchContacts(data.contacts);
-        setChurchActivities(data.activities);
-        setChurchFollowUps(data.followUps);
-      }
+      const data = await apiClient.get<any>(`/crm/churches/${id}`);
+      setSelectedChurch(data.church);
+      setChurchContacts(data.contacts);
+      setChurchActivities(data.activities);
+      setChurchFollowUps(data.followUps);
     } catch {}
     setDetailLoading(false);
   }, []);
@@ -214,17 +209,11 @@ const CRMPage: React.FC = () => {
   const handleStageChange = async () => {
     if (!selectedChurch || !newStage) return;
     try {
-      const resp = await fetch(`/api/crm/churches/${selectedChurch.id}`, {
-        method: 'PUT', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pipeline_stage: newStage }),
-      });
-      if (resp.ok) {
-        showToast('Pipeline stage updated');
-        fetchChurchDetail(selectedChurch.id);
-        fetchDashboard();
-        fetchChurches(churchPage);
-      }
+      await apiClient.put<any>(`/crm/churches/${selectedChurch.id}`, { pipeline_stage: newStage });
+      showToast('Pipeline stage updated');
+      fetchChurchDetail(selectedChurch.id);
+      fetchDashboard();
+      fetchChurches(churchPage);
     } catch { showToast('Failed to update stage', 'error'); }
     setStageDialogOpen(false);
   };
@@ -232,11 +221,7 @@ const CRMPage: React.FC = () => {
   const handlePriorityChange = async (priority: string) => {
     if (!selectedChurch) return;
     try {
-      await fetch(`/api/crm/churches/${selectedChurch.id}`, {
-        method: 'PUT', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ priority }),
-      });
+      await apiClient.put<any>(`/crm/churches/${selectedChurch.id}`, { priority });
       showToast('Priority updated');
       fetchChurchDetail(selectedChurch.id);
       fetchChurches(churchPage);
@@ -246,11 +231,7 @@ const CRMPage: React.FC = () => {
   const handleNotesChange = async (notes: string) => {
     if (!selectedChurch) return;
     try {
-      await fetch(`/api/crm/churches/${selectedChurch.id}`, {
-        method: 'PUT', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ crm_notes: notes }),
-      });
+      await apiClient.put<any>(`/crm/churches/${selectedChurch.id}`, { crm_notes: notes });
     } catch {}
   };
 
@@ -259,17 +240,11 @@ const CRMPage: React.FC = () => {
   const handleAddActivity = async () => {
     if (!selectedChurch || !activityForm.subject) return;
     try {
-      const resp = await fetch(`/api/crm/churches/${selectedChurch.id}/activities`, {
-        method: 'POST', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(activityForm),
-      });
-      if (resp.ok) {
-        showToast('Activity logged');
-        fetchChurchDetail(selectedChurch.id);
-        fetchDashboard();
-        setActivityForm({ activity_type: 'note', subject: '', body: '' });
-      }
+      await apiClient.post<any>(`/crm/churches/${selectedChurch.id}/activities`, activityForm);
+      showToast('Activity logged');
+      fetchChurchDetail(selectedChurch.id);
+      fetchDashboard();
+      setActivityForm({ activity_type: 'note', subject: '', body: '' });
     } catch { showToast('Failed to log activity', 'error'); }
     setActivityDialogOpen(false);
   };
@@ -279,28 +254,22 @@ const CRMPage: React.FC = () => {
   const handleSaveContact = async () => {
     if (!selectedChurch || !contactForm.first_name) return;
     try {
-      const url = editingContact
-        ? `/api/crm/contacts/${editingContact.id}`
-        : `/api/crm/churches/${selectedChurch.id}/contacts`;
-      const method = editingContact ? 'PUT' : 'POST';
-      const resp = await fetch(url, {
-        method, credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(contactForm),
-      });
-      if (resp.ok) {
-        showToast(editingContact ? 'Contact updated' : 'Contact added');
-        fetchChurchDetail(selectedChurch.id);
-        setContactForm({ first_name: '', last_name: '', role: '', email: '', phone: '', is_primary: false, notes: '' });
-        setEditingContact(null);
+      if (editingContact) {
+        await apiClient.put<any>(`/crm/contacts/${editingContact.id}`, contactForm);
+      } else {
+        await apiClient.post<any>(`/crm/churches/${selectedChurch.id}/contacts`, contactForm);
       }
+      showToast(editingContact ? 'Contact updated' : 'Contact added');
+      fetchChurchDetail(selectedChurch.id);
+      setContactForm({ first_name: '', last_name: '', role: '', email: '', phone: '', is_primary: false, notes: '' });
+      setEditingContact(null);
     } catch { showToast('Failed to save contact', 'error'); }
     setContactDialogOpen(false);
   };
 
   const handleDeleteContact = async (contactId: number) => {
     try {
-      await fetch(`/api/crm/contacts/${contactId}`, { method: 'DELETE', credentials: 'include' });
+      await apiClient.delete<any>(`/crm/contacts/${contactId}`);
       showToast('Contact deleted');
       if (selectedChurch) fetchChurchDetail(selectedChurch.id);
     } catch { showToast('Failed to delete contact', 'error'); }
@@ -311,29 +280,19 @@ const CRMPage: React.FC = () => {
   const handleAddFollowUp = async () => {
     if (!selectedChurch || !followUpForm.due_date || !followUpForm.subject) return;
     try {
-      const resp = await fetch(`/api/crm/churches/${selectedChurch.id}/follow-ups`, {
-        method: 'POST', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(followUpForm),
-      });
-      if (resp.ok) {
-        showToast('Follow-up created');
-        fetchChurchDetail(selectedChurch.id);
-        fetchFollowUps();
-        fetchDashboard();
-        setFollowUpForm({ due_date: '', subject: '', description: '' });
-      }
+      await apiClient.post<any>(`/crm/churches/${selectedChurch.id}/follow-ups`, followUpForm);
+      showToast('Follow-up created');
+      fetchChurchDetail(selectedChurch.id);
+      fetchFollowUps();
+      fetchDashboard();
+      setFollowUpForm({ due_date: '', subject: '', description: '' });
     } catch { showToast('Failed to create follow-up', 'error'); }
     setFollowUpDialogOpen(false);
   };
 
   const handleCompleteFollowUp = async (fId: number) => {
     try {
-      await fetch(`/api/crm/follow-ups/${fId}`, {
-        method: 'PUT', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: 'completed' }),
-      });
+      await apiClient.put<any>(`/crm/follow-ups/${fId}`, { status: 'completed' });
       showToast('Follow-up completed');
       if (selectedChurch) fetchChurchDetail(selectedChurch.id);
       fetchFollowUps();
@@ -346,19 +305,11 @@ const CRMPage: React.FC = () => {
   const handleProvision = async () => {
     if (!selectedChurch) return;
     try {
-      const resp = await fetch(`/api/crm/churches/${selectedChurch.id}/provision`, {
-        method: 'POST', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      const data = await resp.json();
-      if (resp.ok) {
-        showToast(data.message || 'Church provisioned!');
-        fetchChurchDetail(selectedChurch.id);
-        fetchDashboard();
-        fetchChurches(churchPage);
-      } else {
-        showToast(data.error || 'Provision failed', 'error');
-      }
+      const data = await apiClient.post<any>(`/crm/churches/${selectedChurch.id}/provision`);
+      showToast(data.message || 'Church provisioned!');
+      fetchChurchDetail(selectedChurch.id);
+      fetchDashboard();
+      fetchChurches(churchPage);
     } catch { showToast('Provision failed', 'error'); }
     setProvisionDialogOpen(false);
   };

--- a/front-end/src/features/devel-tools/git-operations/GitOperations.tsx
+++ b/front-end/src/features/devel-tools/git-operations/GitOperations.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Container,
@@ -61,21 +62,7 @@ const GitOperations: React.FC = () => {
     setUnauthorized(false);
 
     try {
-      const response = await fetch('/api/ops/git/status', {
-        credentials: 'include',
-      });
-
-      if (response.status === 401 || response.status === 403) {
-        setUnauthorized(true);
-        setLoading(false);
-        return;
-      }
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      const data: GitStatusResponse = await response.json();
+      const data: GitStatusResponse = await apiClient.get<any>('/ops/git/status');
 
       if (data.success && data.output) {
         setGitStatus(data.output);
@@ -107,26 +94,7 @@ const GitOperations: React.FC = () => {
     setBranchResults(null);
 
     try {
-      const response = await fetch('/api/ops/git/branches/create-default', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (response.status === 401 || response.status === 403) {
-        setUnauthorized(true);
-        setCreatingBranches(false);
-        return;
-      }
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || `HTTP ${response.status}`);
-      }
-
-      const data: CreateBranchesResponse = await response.json();
+      const data: CreateBranchesResponse = await apiClient.post<any>('/ops/git/branches/create-default');
       setBranchResults(data);
     } catch (err: any) {
       setError(err.message || 'Failed to create branches');

--- a/front-end/src/features/devel-tools/interactive-reports/InteractiveReportJobsPage.tsx
+++ b/front-end/src/features/devel-tools/interactive-reports/InteractiveReportJobsPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Typography,
@@ -148,20 +149,7 @@ const InteractiveReportJobsPage: React.FC = () => {
       params.append('limit', '50');
       params.append('offset', '0');
 
-      const response = await fetch(`/api/records/interactive-reports/jobs?${params.toString()}`, {
-        signal: abortControllerRef.current.signal,
-      });
-
-      if (response.status === 401 || response.status === 403) {
-        setError('Unauthorized. Please log in.');
-        return;
-      }
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch jobs: ${response.statusText}`);
-      }
-
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/records/interactive-reports/jobs?${params.toString()}`);
       setJobs(data.items || []);
       setTotal(data.total || 0);
       setError(null);
@@ -214,11 +202,7 @@ const InteractiveReportJobsPage: React.FC = () => {
   // Fetch job details
   const fetchJobDetails = async (jobId: number) => {
     try {
-      const response = await fetch(`/api/records/interactive-reports/jobs/${jobId}`);
-      if (!response.ok) {
-        throw new Error('Failed to fetch job details');
-      }
-      const job = await response.json();
+      const job = await apiClient.get<any>(`/records/interactive-reports/jobs/${jobId}`);
       setSelectedJob(job);
       setDrawerOpen(true);
     } catch (err: any) {
@@ -233,13 +217,7 @@ const InteractiveReportJobsPage: React.FC = () => {
     }
 
     try {
-      const response = await fetch(`/api/records/interactive-reports/jobs/${jobId}/cancel`, {
-        method: 'POST',
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to cancel job');
-      }
+      await apiClient.post<any>(`/records/interactive-reports/jobs/${jobId}/cancel`);
 
       setSnackbar({ message: 'Job cancelled successfully', severity: 'success' });
       fetchJobs(); // Refresh list

--- a/front-end/src/features/devel-tools/menu-editor/MenuEditor.tsx
+++ b/front-end/src/features/devel-tools/menu-editor/MenuEditor.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Card,
@@ -118,18 +119,7 @@ const MenuEditor: React.FC = () => {
     setError(null);
     
     try {
-      const response = await fetch('/api/admin/menus', {
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to load menu items');
-      }
-
-      const data = await response.json();
+      const data = await apiClient.get<any>('/admin/menus');
       setMenuItems(data.items || []);
     } catch (err: any) {
       setError(err.message || 'Failed to load menu items');
@@ -152,21 +142,7 @@ const MenuEditor: React.FC = () => {
     setSuccess(null);
 
     try {
-      const response = await fetch('/api/admin/menus', {
-        method: 'PUT',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ items: menuItems }),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to save menu items');
-      }
-
-      const data = await response.json();
+      const data = await apiClient.put<any>('/admin/menus', { items: menuItems });
       setSuccess(data.message || 'Menu items saved successfully');
       
       // Reload to get updated data
@@ -275,21 +251,7 @@ const MenuEditor: React.FC = () => {
       }
 
       // Send to backend
-      const response = await fetch('/api/admin/menus/seed', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ items: transformedItems }),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to seed menu items');
-      }
-
-      const data = await response.json();
+      const data = await apiClient.post<any>('/admin/menus/seed', { items: transformedItems });
       setSuccess(data.message || 'Menu seeded successfully');
       setSeedDialogOpen(false);
       
@@ -315,20 +277,7 @@ const MenuEditor: React.FC = () => {
     setSuccess(null);
 
     try {
-      const response = await fetch('/api/admin/menus/reset', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to reset menu');
-      }
-
-      const data = await response.json();
+      const data = await apiClient.post<any>('/admin/menus/reset');
       setSuccess(data.message || 'Menu reset successfully');
       setResetDialogOpen(false);
       
@@ -380,19 +329,7 @@ const MenuEditor: React.FC = () => {
       );
       
       // Send to backend
-      const response = await fetch('/api/admin/menus/seed', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to seed from template');
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.post<any>('/admin/menus/seed', payload);
       console.log('✅ Seed response:', data);
       
       setSuccess(`${data.message} (${data.stats.inserted} inserted, ${data.stats.updated} updated)`);
@@ -442,19 +379,7 @@ const MenuEditor: React.FC = () => {
       );
       
       // Send to backend
-      const response = await fetch('/api/admin/menus/reset-to-template', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to reset to template');
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.post<any>('/admin/menus/reset-to-template', payload);
       console.log('✅ Reset response:', data);
       
       setSuccess(`${data.message} (${data.stats.deleted} deleted, ${data.stats.inserted} inserted)`);
@@ -483,16 +408,7 @@ const MenuEditor: React.FC = () => {
     setSuccess(null);
 
     try {
-      const response = await fetch(`/api/admin/menus/${itemToDelete.id}`, {
-        method: 'DELETE',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to delete menu item');
-      }
+      await apiClient.delete<any>(`/admin/menus/${itemToDelete.id}`);
 
       setSuccess(`Deleted menu item "${itemToDelete.label}"`);
       setDeleteDialogOpen(false);

--- a/front-end/src/features/devel-tools/om-church-wizard/ChurchSetupWizard.tsx
+++ b/front-end/src/features/devel-tools/om-church-wizard/ChurchSetupWizard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Stepper,
@@ -157,33 +158,24 @@ const ChurchSetupWizard: React.FC = () => {
     const fetchTemplateChurches = async () => {
       try {
         setLoading(true);
-        const response = await fetch('/api/admin/churches?preferred_language=en', {
-          credentials: 'include'
-        });
-
-        if (response.ok) {
-          const data = await response.json();
-          const templatesWithTables = await Promise.all(
-            data.churches.map(async (church: any) => {
-              try {
-                const tablesResponse = await fetch(`/api/admin/churches/${church.id}/tables`, {
-                  credentials: 'include'
-                });
-                const tablesData = await tablesResponse.json();
-                return {
-                  ...church,
-                  available_tables: tablesData.tables || []
-                };
-              } catch {
-                return {
-                  ...church,
-                  available_tables: []
-                };
-              }
-            })
-          );
-          setTemplateChurches(templatesWithTables);
-        }
+        const data = await apiClient.get<any>('/admin/churches?preferred_language=en');
+        const templatesWithTables = await Promise.all(
+          data.churches.map(async (church: any) => {
+            try {
+              const tablesData = await apiClient.get<any>(`/admin/churches/${church.id}/tables`);
+              return {
+                ...church,
+                available_tables: tablesData.tables || []
+              };
+            } catch {
+              return {
+                ...church,
+                available_tables: []
+              };
+            }
+          })
+        );
+        setTemplateChurches(templatesWithTables);
       } catch (error) {
         console.error('Error fetching template churches:', error);
       } finally {
@@ -268,37 +260,15 @@ const ChurchSetupWizard: React.FC = () => {
     try {
       setIsSubmitting(true);
 
-      const response = await fetch('/api/admin/churches/wizard', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include',
-        body: JSON.stringify(values)
+      const result = await apiClient.post<any>('/admin/churches/wizard', values);
+      // Store result and advance to token step
+      setWizardResult({
+        church_id: result.church_id,
+        db_name: result.db_name,
+        registration_token: result.registration_token,
+        church_name: values.name,
       });
-
-      if (response.ok) {
-        const result = await response.json();
-        // Store result and advance to token step
-        setWizardResult({
-          church_id: result.church_id,
-          db_name: result.db_name,
-          registration_token: result.registration_token,
-          church_name: values.name,
-        });
-        setActiveStep(steps.length - 1); // Go to Registration Token step
-      } else {
-        const errorData = await response.json();
-
-        if (response.status === 400 && errorData.required) {
-          const missingFields = errorData.required.join(', ');
-          setToast({ message: `Please fill in all required fields: ${missingFields}`, severity: 'error' });
-        } else {
-          setToast({ message: errorData.message || 'Failed to create church', severity: 'error' });
-        }
-
-        throw new Error(errorData.message || 'Failed to create church');
-      }
+      setActiveStep(steps.length - 1); // Go to Registration Token step
     } catch (error: any) {
       console.error('Error creating church:', error);
       if (!error.message?.includes('required fields')) {

--- a/front-end/src/features/devel-tools/om-gallery/Gallery.tsx
+++ b/front-end/src/features/devel-tools/om-gallery/Gallery.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Typography,
@@ -146,38 +147,25 @@ const Gallery: React.FC = () => {
     try {
       const urlParams = new URLSearchParams(window.location.search);
       const debug = urlParams.get('debug') === '1' ? '&debug=1' : '';
-      const response = await fetch(`/api/gallery/tree?depth=3${debug}`, {
-        credentials: 'include',
+      const data = await apiClient.get<any>(`/gallery/tree?depth=3${debug}`);
+      console.log('📁 Directory tree loaded:', {
+        directories: data.directories?.length || 0,
+        files: data.files?.length || 0,
+        path: data.path
       });
-      if (response.ok) {
-        const data = await response.json();
-        console.log('📁 Directory tree loaded:', {
-          directories: data.directories?.length || 0,
-          files: data.files?.length || 0,
-          path: data.path
-        });
-        setDirectoryTree(data);
-        
-        // Log debug info if available
-        if (data.debug) {
-          console.log('🔍 [DEBUG] Directory tree debug info:', data.debug);
-          if (data.debug.resolvedImagesRoot) {
-            console.log(`🔍 [DEBUG] Images root: ${data.debug.resolvedImagesRoot}`);
-            console.log(`🔍 [DEBUG] Root exists: ${data.debug.rootExists}`);
-            console.log(`🔍 [DEBUG] Root readable: ${data.debug.rootCanRead}`);
-            if (data.debug.firstEntries && data.debug.firstEntries.length > 0) {
-              console.log(`🔍 [DEBUG] First entries:`, data.debug.firstEntries);
-            }
+      setDirectoryTree(data);
+      
+      // Log debug info if available
+      if (data.debug) {
+        console.log('🔍 [DEBUG] Directory tree debug info:', data.debug);
+        if (data.debug.resolvedImagesRoot) {
+          console.log(`🔍 [DEBUG] Images root: ${data.debug.resolvedImagesRoot}`);
+          console.log(`🔍 [DEBUG] Root exists: ${data.debug.rootExists}`);
+          console.log(`🔍 [DEBUG] Root readable: ${data.debug.rootCanRead}`);
+          if (data.debug.firstEntries && data.debug.firstEntries.length > 0) {
+            console.log(`🔍 [DEBUG] First entries:`, data.debug.firstEntries);
           }
         }
-      } else {
-        const errorData = await response.json().catch(() => ({}));
-        console.error('❌ Error loading directory tree:', {
-          status: response.status,
-          error: errorData
-        });
-        // Don't wipe state - keep existing tree if available
-        // Just log the error
       }
     } catch (error) {
       console.error('❌ Error loading directory tree:', error);
@@ -192,10 +180,8 @@ const Gallery: React.FC = () => {
       const path = selectedDirectory === '' ? '' : selectedDirectory;
       const url = `/api/gallery/images?path=${encodeURIComponent(path)}&recursive=1`;
 
-      const response = await fetch(url, { credentials: 'include' });
-
-      if (response.ok) {
-        const data = await response.json();
+      const data = await apiClient.get<any>(url.replace('/api', ''));
+      {
         if (data.debug) console.log('🔍 [DEBUG] Images API:', data.debug);
 
         const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.tiff', '.webp', '.svg'];
@@ -246,9 +232,6 @@ const Gallery: React.FC = () => {
 
         setImages(transformedImages);
         setCurrentIndex(0);
-      } else {
-        console.error('Gallery API error:', response.status, response.statusText);
-        setImages([]);
       }
     } catch (error: any) {
       console.error('Gallery API request failed:', error.message);
@@ -290,36 +273,12 @@ const Gallery: React.FC = () => {
         selectedDirectory: selectedDirectory
       });
       
-      const response = await fetch('/api/gallery/file', {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ path: relativePath })
-      });
-
-      console.log('🗑️ [Frontend] Delete response status:', response.status, response.statusText);
-
-      if (response.ok) {
-        const result = await response.json().catch(() => ({}));
-        console.log('🗑️ [Frontend] Delete successful:', result);
-        await loadImages();
-        await loadDirectoryTree();
-        setImageDialogOpen(false);
-        setSelectedImage(null);
-      } else {
-        let errorMessage = 'Unknown error';
-        try {
-          const errorData = await response.json();
-          console.error('🗑️ [Frontend] Delete error response:', errorData);
-          errorMessage = errorData.error || errorData.message || `HTTP ${response.status}: ${response.statusText}`;
-        } catch (e) {
-          console.error('🗑️ [Frontend] Failed to parse error response:', e);
-          errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-        }
-        alert(`Failed to delete image: ${errorMessage}`);
-      }
+      await apiClient.delete<any>('/gallery/file', { data: { path: relativePath } });
+      console.log('🗑️ [Frontend] Delete successful');
+      await loadImages();
+      await loadDirectoryTree();
+      setImageDialogOpen(false);
+      setSelectedImage(null);
     } catch (error: any) {
       console.error('🗑️ [Frontend] Error deleting image:', error);
       alert(`Failed to delete image: ${error.message || 'Network error'}`);
@@ -333,22 +292,11 @@ const Gallery: React.FC = () => {
       const relativePath = image.path.replace(/^\/images\//, '');
       const targetPath = targetDir ? `${targetDir}/${image.name}` : image.name;
       
-      const response = await fetch('/api/gallery/move', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ from: relativePath, to: targetPath, overwrite: false })
-      });
-
-      if (response.ok) {
-        await loadImages();
-        await loadDirectoryTree();
-        setMoveDialogOpen(false);
-        setItemToMove(null);
-      } else {
-        const data = await response.json();
-        alert(data.error || 'Failed to move image');
-      }
+      await apiClient.post<any>('/gallery/move', { from: relativePath, to: targetPath, overwrite: false });
+      await loadImages();
+      await loadDirectoryTree();
+      setMoveDialogOpen(false);
+      setItemToMove(null);
     } catch (error) {
       console.error('Error moving image:', error);
       alert('Failed to move image');
@@ -358,23 +306,12 @@ const Gallery: React.FC = () => {
   const handleRenameImage = async (image: GalleryImage, newName: string) => {
     try {
       const relativePath = image.path.replace(/^\/images\//, '');
-      const response = await fetch('/api/gallery/rename', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ path: relativePath, newName })
-      });
-
-      if (response.ok) {
-        await loadImages();
-        await loadDirectoryTree();
-        setRenameDialogOpen(false);
-        setItemToMove(null);
-        setNewName('');
-      } else {
-        const data = await response.json();
-        alert(data.error || 'Failed to rename image');
-      }
+      await apiClient.post<any>('/gallery/rename', { path: relativePath, newName });
+      await loadImages();
+      await loadDirectoryTree();
+      setRenameDialogOpen(false);
+      setItemToMove(null);
+      setNewName('');
     } catch (error) {
       console.error('Error renaming image:', error);
       alert('Failed to rename image');
@@ -389,26 +326,9 @@ const Gallery: React.FC = () => {
     
     try {
       const targetPath = selectedDirectory ? `${selectedDirectory}/${dirName.trim()}` : dirName.trim();
-      const response = await fetch('/api/gallery/mkdir', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ path: targetPath })
-      });
-
-      if (response.ok) {
-        await loadDirectoryTree();
-        // Show success message
-        const data = await response.json();
-        console.log('Directory created:', data);
-      } else {
-        const data = await response.json();
-        // Show detailed error message
-        const errorMsg = data.error || 'Failed to create directory';
-        const code = data.code ? ` (${data.code})` : '';
-        const pathInfo = data.path ? `\nPath: ${data.path}` : '';
-        alert(`${errorMsg}${code}${pathInfo}`);
-      }
+      const data = await apiClient.post<any>('/gallery/mkdir', { path: targetPath });
+      await loadDirectoryTree();
+      console.log('Directory created:', data);
     } catch (error: any) {
       console.error('Error creating directory:', error);
       alert(`Failed to create directory: ${error.message || 'Unknown error'}`);
@@ -465,26 +385,7 @@ const Gallery: React.FC = () => {
           selectedDirectory: selectedDirectory
         });
         try {
-          const response = await fetch('/api/gallery/file', {
-            method: 'DELETE',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            credentials: 'include',
-            body: JSON.stringify({ path: relativePath })
-          });
-
-          if (!response.ok) {
-            let errorMessage = 'Unknown error';
-            try {
-              const errorData = await response.json();
-              errorMessage = errorData.error || errorData.message || `HTTP ${response.status}`;
-            } catch (e) {
-              errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-            }
-            return { success: false, image: image.name, error: errorMessage, path: relativePath };
-          }
-
+          await apiClient.delete<any>('/gallery/file', { data: { path: relativePath } });
           return { success: true, image: image.name, path: relativePath };
         } catch (error: any) {
           console.error(`Error deleting ${image.name}:`, error);
@@ -541,19 +442,11 @@ const Gallery: React.FC = () => {
   // Clean up empty directories
   const cleanupEmptyDirectories = async () => {
     try {
-      const response = await fetch('/api/gallery/cleanup-empty-dirs', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        if (data.deleted && data.deleted.length > 0) {
-          console.log(`🗑️ Cleaned up ${data.deleted.length} empty directory(ies):`, data.deleted);
-          // Reload directory tree after cleanup
-          await loadDirectoryTree();
-        }
+      const data = await apiClient.post<any>('/gallery/cleanup-empty-dirs');
+      if (data.deleted && data.deleted.length > 0) {
+        console.log(`🗑️ Cleaned up ${data.deleted.length} empty directory(ies):`, data.deleted);
+        // Reload directory tree after cleanup
+        await loadDirectoryTree();
       }
     } catch (error) {
       console.error('Error cleaning up empty directories:', error);

--- a/front-end/src/features/devel-tools/om-gallery/Gallery/exportUtils.ts
+++ b/front-end/src/features/devel-tools/om-gallery/Gallery/exportUtils.ts
@@ -2,6 +2,7 @@
  * exportUtils.ts — Export functions for Gallery.
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
 import type { GalleryImage } from './types';
 
 export function exportCSV(images: GalleryImage[]): void {
@@ -52,26 +53,7 @@ export async function exportUsedImages(
     let limited = false;
 
     while (hasMore) {
-      const response = await fetch(`/api/gallery/used-images?format=json&offset=${offset}&limit=${limit}`, {
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        let errorMessage = 'Failed to export used images list';
-        try {
-          const data = JSON.parse(errorText);
-          errorMessage = data.error || data.message || errorMessage;
-        } catch (e) {
-          errorMessage = errorText || errorMessage;
-        }
-        alert(`Error: ${errorMessage}`);
-        if (setUploadError) setUploadError(errorMessage);
-        setExportingUsedImages(false);
-        return;
-      }
-
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/gallery/used-images?format=json&offset=${offset}&limit=${limit}`);
 
       if (data.success && data.used) {
         allUsedImages = [...allUsedImages, ...data.used];

--- a/front-end/src/features/devel-tools/om-gallery/Gallery/useGallerySuggestions.ts
+++ b/front-end/src/features/devel-tools/om-gallery/Gallery/useGallerySuggestions.ts
@@ -4,6 +4,7 @@
  * Extracted from Gallery.tsx
  */
 import { useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import type { GalleryImage, SuggestionStatus } from './types';
 import { normalizePath } from './galleryUtils';
 
@@ -47,22 +48,10 @@ export function useGallerySuggestions({
 
   const handleGetSuggestions = async () => {
     try {
-      const response = await fetch('/api/gallery/suggest-destination', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ images: images.map(img => ({ path: img.path, name: img.name })) })
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setSuggestions(data.suggestions || []);
-        setSuggestionStatuses({}); // Reset statuses
-        setSuggestionsDialogOpen(true);
-      } else {
-        const data = await response.json();
-        alert(data.error || 'Failed to get catalog suggestions');
-      }
+      const data = await apiClient.post<any>('/gallery/suggest-destination', { images: images.map(img => ({ path: img.path, name: img.name })) });
+      setSuggestions(data.suggestions || []);
+      setSuggestionStatuses({}); // Reset statuses
+      setSuggestionsDialogOpen(true);
     } catch (error) {
       console.error('Error getting suggestions:', error);
       alert('Failed to get catalog suggestions');
@@ -88,31 +77,19 @@ export function useGallerySuggestions({
         };
       });
 
-      const response = await fetch('/api/gallery/validate-actions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ actions })
+      const data = await apiClient.post<any>('/gallery/validate-actions', { actions });
+      const newStatuses: Record<number, any> = {};
+      
+      data.results.forEach((result: any, idx: number) => {
+        newStatuses[idx] = {
+          status: result.ok ? 'valid' : 'invalid',
+          message: result.message,
+          code: result.code
+        };
       });
-
-      if (response.ok) {
-        const data = await response.json();
-        const newStatuses: Record<number, any> = {};
-        
-        data.results.forEach((result: any, idx: number) => {
-          newStatuses[idx] = {
-            status: result.ok ? 'valid' : 'invalid',
-            message: result.message,
-            code: result.code
-          };
-        });
-        
-        setSuggestionStatuses(newStatuses);
-        setSummaryExpanded(true);
-      } else {
-        const data = await response.json();
-        alert(data.error || 'Failed to validate actions');
-      }
+      
+      setSuggestionStatuses(newStatuses);
+      setSummaryExpanded(true);
     } catch (error) {
       console.error('Error validating actions:', error);
       alert('Failed to validate actions');
@@ -138,41 +115,22 @@ export function useGallerySuggestions({
         to: targetPath
       }];
 
-      const response = await fetch('/api/gallery/apply-actions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ actions, continueOnError: false })
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        const result = data.results[0];
-        
-        setSuggestionStatuses(prev => ({
-          ...prev,
-          [idx]: {
-            status: result.ok ? 'applied' : 'failed',
-            message: result.message,
-            code: result.code
-          }
-        }));
-
-        if (result.ok) {
-          // Reload images and directory tree
-          await loadImages();
-          await loadDirectoryTree();
+      const data = await apiClient.post<any>('/gallery/apply-actions', { actions, continueOnError: false });
+      const result = data.results[0];
+      
+      setSuggestionStatuses(prev => ({
+        ...prev,
+        [idx]: {
+          status: result.ok ? 'applied' : 'failed',
+          message: result.message,
+          code: result.code
         }
-      } else {
-        const data = await response.json();
-        setSuggestionStatuses(prev => ({
-          ...prev,
-          [idx]: {
-            status: 'failed',
-            message: data.error || 'Failed to apply action',
-            code: 'APPLY_ERROR'
-          }
-        }));
+      }));
+
+      if (result.ok) {
+        // Reload images and directory tree
+        await loadImages();
+        await loadDirectoryTree();
       }
     } catch (error) {
       console.error('Error applying action:', error);
@@ -220,36 +178,24 @@ export function useGallerySuggestions({
         };
       });
 
-      const response = await fetch('/api/gallery/apply-actions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ actions, continueOnError: true })
+      const data = await apiClient.post<any>('/gallery/apply-actions', { actions, continueOnError: true });
+      const newStatuses: Record<number, any> = {};
+      
+      data.results.forEach((result: any, idx: number) => {
+        newStatuses[idx] = {
+          status: result.ok ? 'applied' : 'failed',
+          message: result.message,
+          code: result.code
+        };
       });
+      
+      setSuggestionStatuses(newStatuses);
+      setSummaryExpanded(true);
 
-      if (response.ok) {
-        const data = await response.json();
-        const newStatuses: Record<number, any> = {};
-        
-        data.results.forEach((result: any, idx: number) => {
-          newStatuses[idx] = {
-            status: result.ok ? 'applied' : 'failed',
-            message: result.message,
-            code: result.code
-          };
-        });
-        
-        setSuggestionStatuses(newStatuses);
-        setSummaryExpanded(true);
-
-        // Reload if any succeeded
-        if (data.summary.ok > 0) {
-          await loadImages();
-          await loadDirectoryTree();
-        }
-      } else {
-        const data = await response.json();
-        alert(data.error || 'Failed to apply actions');
+      // Reload if any succeeded
+      if (data.summary.ok > 0) {
+        await loadImages();
+        await loadDirectoryTree();
       }
     } catch (error) {
       console.error('Error applying actions:', error);

--- a/front-end/src/features/devel-tools/om-gallery/Gallery/useImageUsage.ts
+++ b/front-end/src/features/devel-tools/om-gallery/Gallery/useImageUsage.ts
@@ -3,6 +3,7 @@
  */
 
 import { useRef, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import type { GalleryImage } from './types';
 import { sortImages } from './galleryUtils';
 
@@ -39,23 +40,15 @@ export function useImageUsage({ images, setImages, selectedDirectory, usageFilte
       for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
         const batch = batches[batchIndex];
 
-        const response = await fetch('/api/gallery/check-usage', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({
+        try {
+          const data = await apiClient.post<any>('/gallery/check-usage', {
             images: batch.map(img => ({ name: img.name || '', path: img.path || '' }))
-          })
-        });
-
-        if (response.ok) {
-          const data = await response.json();
+          });
           if (data.success && data.usage) {
             allUsage = { ...allUsage, ...data.usage };
           }
-        } else {
-          const errorData = await response.json().catch(() => ({}));
-          console.error(`Usage check failed for batch ${batchIndex + 1}/${batches.length}:`, errorData);
+        } catch (batchErr) {
+          console.error(`Usage check failed for batch ${batchIndex + 1}/${batches.length}:`, batchErr);
         }
       }
 

--- a/front-end/src/features/devel-tools/om-ocr/components/OcrSetupGate.tsx
+++ b/front-end/src/features/devel-tools/om-ocr/components/OcrSetupGate.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Alert, Button, Box, CircularProgress, Typography } from '@mui/material';
 import { Settings } from '@mui/icons-material';
@@ -27,14 +28,9 @@ export default function OcrSetupGate({ children }: OcrSetupGateProps) {
 
   const checkSetupStatus = async () => {
     try {
-      const response = await fetch(`/api/church/${churchId}/ocr/setup-state`);
-      if (response.ok) {
-        const data = await response.json();
-        setSetupComplete(data.isComplete);
-        setPercentComplete(data.percentComplete || 0);
-      } else {
-        setSetupComplete(false);
-      }
+      const data = await apiClient.get<any>(`/church/${churchId}/ocr/setup-state`);
+      setSetupComplete(data.isComplete);
+      setPercentComplete(data.percentComplete || 0);
     } catch (err) {
       console.error('Failed to check setup status:', err);
       setSetupComplete(false);

--- a/front-end/src/features/devel-tools/om-ocr/pages/OcrSetupWizardPage.tsx
+++ b/front-end/src/features/devel-tools/om-ocr/pages/OcrSetupWizardPage.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 import { CustomizerContext } from '@/context/CustomizerContext';
 import { ArrowForward, CheckCircle } from '@mui/icons-material';
 import {
@@ -102,25 +103,22 @@ export default function OcrSetupWizardPage() {
 
   const loadSetupState = async () => {
     try {
-      const response = await fetch(`/api/church/${churchId}/ocr/setup-state`);
-      if (response.ok) {
-        const data = await response.json();
-        setSetupState(data.state || {});
-        setPercentComplete(data.percentComplete || 0);
-        setIsComplete(data.isComplete || false);
-        
-        // Determine active step based on progress
-        if (data.percentComplete >= 100) {
-          setActiveStep(5);
-        } else if (data.percentComplete >= 80) {
-          setActiveStep(4);
-        } else if (data.percentComplete >= 60) {
-          setActiveStep(3);
-        } else if (data.percentComplete >= 40) {
-          setActiveStep(2);
-        } else if (data.percentComplete >= 20) {
-          setActiveStep(1);
-        }
+      const data = await apiClient.get<any>(`/church/${churchId}/ocr/setup-state`);
+      setSetupState(data.state || {});
+      setPercentComplete(data.percentComplete || 0);
+      setIsComplete(data.isComplete || false);
+      
+      // Determine active step based on progress
+      if (data.percentComplete >= 100) {
+        setActiveStep(5);
+      } else if (data.percentComplete >= 80) {
+        setActiveStep(4);
+      } else if (data.percentComplete >= 60) {
+        setActiveStep(3);
+      } else if (data.percentComplete >= 40) {
+        setActiveStep(2);
+      } else if (data.percentComplete >= 20) {
+        setActiveStep(1);
       }
     } catch (err: any) {
       setError(`Failed to load setup state: ${err.message}`);
@@ -131,13 +129,8 @@ export default function OcrSetupWizardPage() {
 
   const validateSetup = async () => {
     try {
-      const response = await fetch(`/api/church/${churchId}/ocr/setup-validate`, {
-        method: 'POST'
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setValidation(data);
-      }
+      const data = await apiClient.post<any>(`/church/${churchId}/ocr/setup-validate`);
+      setValidation(data);
     } catch (err) {
       console.error('Validation failed:', err);
     }
@@ -150,24 +143,16 @@ export default function OcrSetupWizardPage() {
       const totalPercent = Math.max(percentComplete, stepPercent);
       const complete = totalPercent >= 100;
 
-      const response = await fetch(`/api/church/${churchId}/ocr/setup-state`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          state: updatedState,
-          percentComplete: totalPercent,
-          isComplete: complete
-        })
+      await apiClient.put<any>(`/church/${churchId}/ocr/setup-state`, {
+        state: updatedState,
+        percentComplete: totalPercent,
+        isComplete: complete
       });
 
-      if (response.ok) {
-        setSetupState(updatedState);
-        setPercentComplete(totalPercent);
-        setIsComplete(complete);
-        await validateSetup();
-      } else {
-        throw new Error('Failed to save state');
-      }
+      setSetupState(updatedState);
+      setPercentComplete(totalPercent);
+      setIsComplete(complete);
+      await validateSetup();
     } catch (err: any) {
       setError(`Failed to save: ${err.message}`);
     } finally {

--- a/front-end/src/features/devel-tools/om-seedlings/OMSeedlingsPage.tsx
+++ b/front-end/src/features/devel-tools/om-seedlings/OMSeedlingsPage.tsx
@@ -3,6 +3,7 @@
  * Uses POST /api/admin/seed-records (dry_run + insert + purge).
  */
 import React, { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Alert,
   alpha,
@@ -89,8 +90,13 @@ function getPreviewRow(record: any, type: string): string[] {
 }
 
 async function apiJson(url: string, options?: RequestInit) {
-  const res = await fetch(url, { credentials: 'include', ...options, headers: { 'Content-Type': 'application/json', ...options?.headers } });
-  return res.json();
+  const cleanUrl = url.replace(/^\/api/, '');
+  const method = (options?.method || 'GET').toLowerCase() as 'get' | 'post' | 'put' | 'delete';
+  const body = options?.body ? JSON.parse(options.body as string) : undefined;
+  if (method === 'get' || method === 'delete') {
+    return apiClient[method]<any>(cleanUrl);
+  }
+  return apiClient[method]<any>(cleanUrl, body);
 }
 
 export default function OMSeedlingsPage() {

--- a/front-end/src/features/devel-tools/om-seedlings/recordWizardTypes.ts
+++ b/front-end/src/features/devel-tools/om-seedlings/recordWizardTypes.ts
@@ -3,6 +3,8 @@
  * Extracted from RecordCreationWizard.tsx
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
+
 // ============================================================================
 // TYPES
 // ============================================================================
@@ -81,10 +83,11 @@ export const yearAgo = new Date(Date.now() - 365 * 86400000).toISOString().split
 // API HELPER
 // ============================================================================
 export async function apiJson(url: string, options?: RequestInit) {
-  const res = await fetch(url, {
-    credentials: 'include',
-    ...options,
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-  });
-  return res.json();
+  const cleanUrl = url.replace(/^\/api/, '');
+  const method = (options?.method || 'GET').toLowerCase() as 'get' | 'post' | 'put' | 'delete';
+  const body = options?.body ? JSON.parse(options.body as string) : undefined;
+  if (method === 'get' || method === 'delete') {
+    return apiClient[method]<any>(cleanUrl);
+  }
+  return apiClient[method]<any>(cleanUrl, body);
 }

--- a/front-end/src/features/devel-tools/om-tasks/components/EmailSettingsForm.tsx
+++ b/front-end/src/features/devel-tools/om-tasks/components/EmailSettingsForm.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Card,
   CardContent,
@@ -128,21 +129,7 @@ const EmailSettingsForm: React.FC = () => {
   const fetchEmailConfig = async () => {
     try {
       setError(null);
-      const response = await fetch('/api/settings/email', {
-        credentials: 'include'
-      });
-      
-      if (response.status === 404) {
-        // No config found, use defaults
-        setLoading(false);
-        return;
-      }
-      
-      if (!response.ok) {
-        throw new Error('Failed to fetch email configuration');
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>('/settings/email');
       if (data.success && data.data) {
         setConfig(prev => ({ ...prev, ...data.data })); // Keep existing password if not provided
       }
@@ -188,20 +175,7 @@ const EmailSettingsForm: React.FC = () => {
         delete requestBody.smtp_pass;
       }
 
-      const response = await fetch('/api/settings/email', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include',
-        body: JSON.stringify(requestBody)
-      });
-
-      const data = await response.json();
-      
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to save email configuration');
-      }
+      const data = await apiClient.post<any>('/settings/email', requestBody);
 
       if (data.success) {
         setSuccess('Email configuration saved successfully!');
@@ -227,20 +201,7 @@ const EmailSettingsForm: React.FC = () => {
     setTesting(true);
 
     try {
-      const response = await fetch('/api/settings/email/test', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include',
-        body: JSON.stringify({ test_email: testEmail })
-      });
-
-      const data: EmailTestResponse = await response.json();
-      
-      if (!response.ok) {
-        throw new Error(data.error || 'Email test failed');
-      }
+      const data: EmailTestResponse = await apiClient.post<any>('/settings/email/test', { test_email: testEmail });
 
       if (data.success) {
         setSuccess(`Test email sent successfully to ${testEmail}!`);

--- a/front-end/src/features/devel-tools/refactor-console/api/refactorConsoleClient.ts
+++ b/front-end/src/features/devel-tools/refactor-console/api/refactorConsoleClient.ts
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 import { 
   RefactorScan, 
   Snapshot, 
@@ -30,7 +31,7 @@ export const DEFAULT_PATH_CONFIG: PathConfig = {
 const PATHS_STORAGE_KEY = 'refactor-console-paths';
 
 class RefactorConsoleClient {
-  private baseUrl = '/api/refactor-console';
+  private baseUrl = '/refactor-console';
 
   // ============================================================================
   // Path Configuration Management
@@ -90,15 +91,7 @@ class RefactorConsoleClient {
     allowedBasePath: string;
   }> {
     try {
-      const response = await fetch(`${this.baseUrl}/config/paths`, {
-        method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      return await response.json();
+      return await apiClient.get<any>(`${this.baseUrl}/config/paths`);
     } catch (error) {
       console.error('Failed to get default paths:', error);
       throw error;
@@ -119,16 +112,7 @@ class RefactorConsoleClient {
     }>;
   }> {
     try {
-      const response = await fetch(`${this.baseUrl}/config/validate-paths`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(config),
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      return await response.json();
+      return await apiClient.post<any>(`${this.baseUrl}/config/validate-paths`, config);
     } catch (error) {
       console.error('Failed to validate paths:', error);
       throw error;
@@ -170,21 +154,7 @@ class RefactorConsoleClient {
         params.append('sourcePath', sourcePath);
       }
 
-      const response = await fetch(`${this.baseUrl}/snapshots?${params}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
+      return await apiClient.get<any>(`${this.baseUrl}/snapshots?${params}`);
     } catch (error) {
       console.error('Failed to fetch snapshots:', error);
       throw new Error(error instanceof Error ? error.message : 'Failed to fetch snapshots');
@@ -242,21 +212,7 @@ class RefactorConsoleClient {
         params.append('backupPath', paths.backupPath);
       }
 
-      const response = await fetch(`${this.baseUrl}/scan?${params}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
+      return await apiClient.get<any>(`${this.baseUrl}/scan?${params}`);
     } catch (error) {
       console.error('Failed to fetch refactor scan:', error);
       throw new Error(error instanceof Error ? error.message : 'Failed to fetch scan data');
@@ -285,28 +241,13 @@ class RefactorConsoleClient {
       const actualSourceType = sourceType || paths.sourceType || 'local';
       const actualSnapshotId = snapshotId || paths.snapshotId;
       
-      const response = await fetch(`${this.baseUrl}/preview-restore`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ 
-          relPath,
-          sourcePath: paths.sourcePath || paths.backupPath,
-          destinationPath: paths.destinationPath,
-          sourceType: actualSourceType,
-          snapshotId: actualSnapshotId
-        }),
+      return await apiClient.post<any>(`${this.baseUrl}/preview-restore`, { 
+        relPath,
+        sourcePath: paths.sourcePath || paths.backupPath,
+        destinationPath: paths.destinationPath,
+        sourceType: actualSourceType,
+        snapshotId: actualSnapshotId
       });
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
     } catch (error) {
       console.error('Failed to preview restore:', error);
       throw new Error(error instanceof Error ? error.message : 'Failed to preview restore');
@@ -342,52 +283,16 @@ class RefactorConsoleClient {
       const actualSourceType = sourceType || paths.sourceType || 'local';
       const actualSnapshotId = snapshotId || paths.snapshotId;
       
-      const response = await fetch(`${this.baseUrl}/restore`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ 
-          relPath,
-          sourcePath: paths.sourcePath || paths.backupPath,
-          destinationPath: paths.destinationPath,
-          sourceType: actualSourceType,
-          snapshotId: actualSnapshotId
-        }),
+      return await apiClient.post<any>(`${this.baseUrl}/restore`, { 
+        relPath,
+        sourcePath: paths.sourcePath || paths.backupPath,
+        destinationPath: paths.destinationPath,
+        sourceType: actualSourceType,
+        snapshotId: actualSnapshotId
       });
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
     } catch (error) {
       console.error('Failed to restore file:', error);
       throw new Error(error instanceof Error ? error.message : 'Failed to restore file');
-    }
-  }
-
-  /**
-   * Helper to safely parse JSON or text response
-   */
-  private async safeParseResponse(response: Response): Promise<any> {
-    const contentType = response.headers.get('content-type') || '';
-    
-    if (contentType.includes('application/json')) {
-      try {
-        return await response.json();
-      } catch (e) {
-        // Fallback to text if JSON parsing fails
-        const text = await response.text();
-        throw new Error(`Invalid JSON response: ${text.substring(0, 200)}`);
-      }
-    } else {
-      // Non-JSON response (likely HTML error page)
-      const text = await response.text();
-      throw new Error(`Non-JSON response (${contentType}): ${text.substring(0, 500)}`);
     }
   }
 
@@ -397,21 +302,7 @@ class RefactorConsoleClient {
    */
   async startPhase1Analysis(): Promise<{ ok: boolean; jobId: string; status: string; message: string }> {
     try {
-      const response = await fetch(`${this.baseUrl}/phase1/start`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
+      return await apiClient.post<any>(`${this.baseUrl}/phase1/start`);
     } catch (error) {
       console.error('Failed to start Phase 1 analysis:', error);
       throw new Error(error instanceof Error ? error.message : 'Failed to start Phase 1 analysis');
@@ -434,21 +325,7 @@ class RefactorConsoleClient {
     finishedAt: number | null;
   }> {
     try {
-      const response = await fetch(`${this.baseUrl}/jobs/${jobId}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
+      return await apiClient.get<any>(`${this.baseUrl}/jobs/${jobId}`);
     } catch (error) {
       console.error(`Failed to get Phase 1 job ${jobId} status:`, error);
       throw new Error(error instanceof Error ? error.message : 'Failed to get Phase 1 job status');
@@ -462,27 +339,7 @@ class RefactorConsoleClient {
    */
   async getPhase1JobResult(jobId: string): Promise<any> {
     try {
-      const response = await fetch(`${this.baseUrl}/jobs/${jobId}/result`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (response.status === 409) {
-        // Job not ready yet
-        const data = await this.safeParseResponse(response);
-        throw new Error(`Job not ready: ${data.status} (${data.progress}%)`);
-      }
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
+      return await apiClient.get<any>(`${this.baseUrl}/jobs/${jobId}/result`);
     } catch (error) {
       console.error(`Failed to get Phase 1 job ${jobId} result:`, error);
       throw new Error(error instanceof Error ? error.message : 'Failed to get Phase 1 job result');
@@ -501,22 +358,7 @@ class RefactorConsoleClient {
     menuIcon?: string;
   }): Promise<{ success: boolean; message: string; restoredFiles: string[] }> {
     try {
-      const response = await fetch(`${this.baseUrl}/restore-bundle`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify(bundleRequest),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      return data;
+      return await apiClient.post<any>(`${this.baseUrl}/restore-bundle`, bundleRequest);
     } catch (error) {
       console.error('Failed to restore bundle:', error);
       throw new Error(error instanceof Error ? error.message : 'Failed to restore bundle');
@@ -529,19 +371,7 @@ class RefactorConsoleClient {
    */
   async healthCheck(): Promise<{ ok: boolean; service: string; ts: string; uptimeSec?: number; status?: string }> {
     try {
-      const response = await fetch(`${this.baseUrl}/health`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        throw new Error(`Health check failed: ${response.status} ${response.statusText}`);
-      }
-
-      const data = await response.json();
+      const data = await apiClient.get<any>(`${this.baseUrl}/health`);
       // Normalize response - server returns {ok: true, service: string, ts: string}
       return {
         ...data,
@@ -558,20 +388,13 @@ class RefactorConsoleClient {
    */
   async checkCacheStatus(): Promise<{ exists: boolean; age: number }> {
     try {
-      const response = await fetch(`${this.baseUrl}/scan`, {
-        method: 'HEAD',
-        credentials: 'include',
-      });
-
-      const age = response.status === 200 ? 0 : -1;
-      return {
-        exists: response.status === 200,
-        age
-      };
+      await apiClient.request<any>({ method: 'HEAD', url: `${this.baseUrl}/scan` });
+      return { exists: true, age: 0 };
     } catch (error) {
       return { exists: false, age: -1 };
     }
   }
+
 
   // ============================================================================
   // Restore History Endpoints
@@ -592,21 +415,7 @@ class RefactorConsoleClient {
       params.append('limit', limit.toString());
       params.append('offset', offset.toString());
 
-      const response = await fetch(`${this.baseUrl}/restore-history?${params}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
+      return await apiClient.get<any>(`${this.baseUrl}/restore-history?${params}`);
     } catch (error) {
       console.error('Failed to get restore history:', error);
       throw new Error(error instanceof Error ? error.message : 'Failed to get restore history');
@@ -625,21 +434,7 @@ class RefactorConsoleClient {
     entries: RestoreHistoryEntry[];
   }> {
     try {
-      const response = await fetch(`${this.baseUrl}/restore-history/file/${relPath}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
+      return await apiClient.get<any>(`${this.baseUrl}/restore-history/file/${relPath}`);
     } catch (error) {
       console.error('Failed to get file restore history:', error);
       throw new Error(error instanceof Error ? error.message : 'Failed to get file restore history');
@@ -655,21 +450,7 @@ class RefactorConsoleClient {
     stats: RestoreHistoryStats;
   }> {
     try {
-      const response = await fetch(`${this.baseUrl}/restore-history/stats`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        const errorData = await this.safeParseResponse(response);
-        throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
-      }
-
-      const data = await this.safeParseResponse(response);
-      return data;
+      return await apiClient.get<any>(`${this.baseUrl}/restore-history/stats`);
     } catch (error) {
       console.error('Failed to get restore history stats:', error);
       throw new Error(error instanceof Error ? error.message : 'Failed to get restore history stats');
@@ -686,7 +467,7 @@ class RefactorConsoleClient {
       const params = new URLSearchParams();
       params.append('limit', limit.toString());
 
-      const url = `${this.baseUrl}/restore-history/export?${params}`;
+      const url = `/api${this.baseUrl}/restore-history/export?${params}`;
       
       // Trigger download by opening in new window/tab
       window.open(url, '_blank');

--- a/front-end/src/features/devel-tools/refactor-console/engine/policy.ts
+++ b/front-end/src/features/devel-tools/refactor-console/engine/policy.ts
@@ -4,6 +4,7 @@
  * Loads and parses YAML policy files from the backend.
  * Does NOT contain UI logic.
  */
+import { apiClient } from '@/api/utils/axiosInstance';
 import { PolicyFile, PolicyRule } from '@/types/refactorConsole';
 
 const DEFAULT_POLICY_PATH = '/var/www/orthodoxmetrics/prod/ops/refactor/refactor-policies.yml';
@@ -15,18 +16,7 @@ export async function fetchPolicyContent(policyPath?: string): Promise<string> {
   const path = policyPath || DEFAULT_POLICY_PATH;
   const params = new URLSearchParams({ path });
   
-  const response = await fetch(`/api/admin/refactor/policy?${params}`, {
-    method: 'GET',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Failed to load policy file: ${response.status} — ${text.substring(0, 200)}`);
-  }
-
-  const data = await response.json();
+  const data = await apiClient.get<any>(`/admin/refactor/policy?${params}`);
   return data.content;
 }
 

--- a/front-end/src/features/devel-tools/system-documentation/om-library/OMLibrary.tsx
+++ b/front-end/src/features/devel-tools/system-documentation/om-library/OMLibrary.tsx
@@ -9,6 +9,7 @@
  * - Safe loading when librarian is offline
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Alert,
     Badge,
@@ -153,14 +154,8 @@ const OMLibrary: React.FC = () => {
   const loadLibrarianStatus = async () => {
     setStatusLoading(true);
     try {
-      const response = await fetch('/api/library/status', {
-        credentials: 'include'
-      });
-      
-      if (response.ok) {
-        const data = await response.json();
-        setLibrarianStatus(data);
-      }
+      const data = await apiClient.get<any>('/library/status');
+      setLibrarianStatus(data);
     } catch (err) {
       console.warn('Could not load librarian status:', err);
       setLibrarianStatus({ running: false });
@@ -182,15 +177,7 @@ const OMLibrary: React.FC = () => {
         params.append('category', categoryFilter);
       }
       
-      const response = await fetch(`/api/library/files?${params.toString()}`, {
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        throw new Error('Failed to load library files');
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/library/files?${params.toString()}`);
       setFiles(data.files || []);
       setFilteredFiles(data.files || []);
     } catch (err: any) {
@@ -224,15 +211,7 @@ const OMLibrary: React.FC = () => {
         params.append('category', categoryFilter);
       }
       
-      const response = await fetch(`/api/library/search?${params.toString()}`, {
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        throw new Error('Search failed');
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/library/search?${params.toString()}`);
       setSearchResults(data.results || []);
       setFilteredFiles(data.results || []);
     } catch (err) {
@@ -342,20 +321,7 @@ const OMLibrary: React.FC = () => {
   const handleCleanupDryRun = async () => {
     setCleanupLoading(true);
     try {
-      const response = await fetch('/api/library/cleanup/dry-run', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ mode: 'documentation' }),
-      });
-      
-      if (!response.ok) {
-        throw new Error('Cleanup dry-run failed');
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.post<any>('/library/cleanup/dry-run', { mode: 'documentation' });
       setCleanupPlan(data.plan);
       setCleanupDialogOpen(true);
     } catch (err: any) {
@@ -376,20 +342,7 @@ const OMLibrary: React.FC = () => {
     
     setCleanupLoading(true);
     try {
-      const response = await fetch('/api/library/cleanup/apply', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ mode: 'documentation' }),
-      });
-      
-      if (!response.ok) {
-        throw new Error('Cleanup apply failed');
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.post<any>('/library/cleanup/apply', { mode: 'documentation' });
       alert(`Cleanup complete! Moved ${data.summary.moved} files. Manifest: ${data.summary.manifest}`);
       setCleanupDialogOpen(false);
       setCleanupPlan(null);
@@ -414,16 +367,7 @@ const OMLibrary: React.FC = () => {
     
     setStatusLoading(true);
     try {
-      const response = await fetch('/api/library/reindex', {
-        method: 'POST',
-        credentials: 'include',
-      });
-      
-      if (!response.ok) {
-        throw new Error('Reindex failed');
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.post<any>('/library/reindex');
       alert(data.message || 'Reindex triggered successfully');
       
       // Reload files after a delay

--- a/front-end/src/features/devel-tools/table-wizard/TableRequestsManager.tsx
+++ b/front-end/src/features/devel-tools/table-wizard/TableRequestsManager.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box, Typography, Paper, Table, TableBody, TableCell, TableContainer,
   TableHead, TableRow, Chip, Button, FormControl, InputLabel, Select,
@@ -73,10 +74,7 @@ const TableRequestsManager: React.FC = () => {
       const params = new URLSearchParams();
       if (statusFilter) params.set('status', statusFilter);
 
-      const res = await fetch(`/api/admin/table-requests?${params}`, { credentials: 'include' });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-
-      const data = await res.json();
+      const data = await apiClient.get<any>(`/admin/table-requests?${params}`);
       if (data.success) {
         setRequests(data.data.requests || []);
       } else {
@@ -112,16 +110,9 @@ const TableRequestsManager: React.FC = () => {
     setActionResult(null);
 
     try {
-      const res = await fetch(`/api/admin/table-requests/${dialogRequestId}/${dialogAction}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ notes: dialogNotes }),
-      });
+      const data = await apiClient.post<any>(`/admin/table-requests/${dialogRequestId}/${dialogAction}`, { notes: dialogNotes });
 
-      const data = await res.json();
-
-      if (res.ok && data.success) {
+      if (data.success) {
         setDialogOpen(false);
         setActionResult(null);
         fetchRequests();

--- a/front-end/src/features/devel-tools/table-wizard/TableWizard.tsx
+++ b/front-end/src/features/devel-tools/table-wizard/TableWizard.tsx
@@ -10,6 +10,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box, Typography, Paper, Stepper, Step, StepLabel, Button, TextField,
   FormControl, InputLabel, Select, MenuItem, IconButton, Table, TableBody,
@@ -108,11 +109,8 @@ const TableWizard: React.FC = () => {
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch('/api/admin/records-inspector/churches', { credentials: 'include' });
-        if (res.ok) {
-          const data = await res.json();
-          if (data.success) setChurches(data.data.churches || []);
-        }
+        const data = await apiClient.get<any>('/admin/records-inspector/churches');
+        if (data.success) setChurches(data.data.churches || []);
       } catch { /* non-fatal */ }
     };
     load();
@@ -179,21 +177,14 @@ const TableWizard: React.FC = () => {
     setError(null);
 
     try {
-      const res = await fetch('/api/admin/table-requests', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          church_id: churchId,
-          table_name: tableName,
-          display_name: displayName || tableName,
-          columns,
-        }),
+      const data = await apiClient.post<any>('/admin/table-requests', {
+        church_id: churchId,
+        table_name: tableName,
+        display_name: displayName || tableName,
+        columns,
       });
 
-      const data = await res.json();
-
-      if (res.ok && data.success) {
+      if (data.success) {
         setSubmitted(true);
         setSubmitResult(data.data);
       } else {

--- a/front-end/src/features/devel-tools/us-church-map/ExportModal.tsx
+++ b/front-end/src/features/devel-tools/us-church-map/ExportModal.tsx
@@ -5,6 +5,7 @@
  * Calls POST /api/crm/churches/export with current map filters.
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   CheckBox as CheckBoxIcon,
   CheckBoxOutlineBlank as CheckBoxBlankIcon,
@@ -198,14 +199,7 @@ const ExportModal: React.FC<ExportModalProps> = ({
       if (exportMode === 'state' && selectedState) body.state = selectedState;
       if (exportMode === 'region' && activeRegion !== 'all') body.region = activeRegion;
 
-      const resp = await fetch('/api/crm/churches/export-count', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      if (!resp.ok) throw new Error('Failed to get count');
-      const data = await resp.json();
+      const data = await apiClient.post<any>('/crm/churches/export-count', body);
       setPreviewCount(data.count);
     } catch {
       setPreviewCount(null);
@@ -243,23 +237,10 @@ const ExportModal: React.FC<ExportModalProps> = ({
       if (exportMode === 'state' && selectedState) body.state = selectedState;
       if (exportMode === 'region' && activeRegion !== 'all') body.region = activeRegion;
 
-      const resp = await fetch('/api/crm/churches/export', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
-      if (!resp.ok) {
-        const errData = await resp.json().catch(() => ({}));
-        throw new Error(errData.error || `Export failed (${resp.status})`);
-      }
+      const blob = await apiClient.post<any>('/crm/churches/export', body, { responseType: 'blob' });
 
       // Download the file
-      const blob = await resp.blob();
-      const contentDisposition = resp.headers.get('Content-Disposition') || '';
-      const filenameMatch = contentDisposition.match(/filename="?([^"]+)"?/);
-      const filename = filenameMatch ? filenameMatch[1] : `church-export.${format}`;
+      const filename = `church-export.${format}`;
 
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');

--- a/front-end/src/features/devel-tools/us-church-map/USChurchMapPage.tsx
+++ b/front-end/src/features/devel-tools/us-church-map/USChurchMapPage.tsx
@@ -12,6 +12,8 @@
  *   GET /api/analytics/om-churches              — live platform church pins
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
+
 import Breadcrumb from '@/layouts/full/shared/breadcrumb/Breadcrumb';
 import PageContainer from '@/shared/ui/PageContainer';
 import {
@@ -140,11 +142,9 @@ const USChurchMapPage: React.FC = () => {
   const fetchStateChurches = useCallback(async (stateCode: string) => {
     setChurchesLoading(true);
     try {
-      const resp = await fetch(`/api/analytics/us-churches-enriched?state=${stateCode}`, { credentials: 'include' });
-      if (resp.ok) {
-        setStateChurches(await resp.json());
-        setJurisdictionFilter(null);
-      }
+      const data = await apiClient.get<any>(`/analytics/us-churches-enriched?state=${stateCode}`);
+      setStateChurches(data);
+      setJurisdictionFilter(null);
     } catch { /* non-critical */ }
     finally { setChurchesLoading(false); }
   }, []);
@@ -157,13 +157,10 @@ const USChurchMapPage: React.FC = () => {
   const fetchParishGeoData = useCallback(async (stateCode: string) => {
     setParishLoading(true);
     try {
-      const resp = await fetch(`/api/analytics/church-map/parishes?state=${stateCode}`, { credentials: 'include' });
-      if (resp.ok) {
-        const data: ParishGeoJSON = await resp.json();
-        setParishGeoData(data);
-        setAffiliationFilter(new Set());
-        setSelectedParishId(null);
-      }
+      const data: ParishGeoJSON = await apiClient.get<any>(`/analytics/church-map/parishes?state=${stateCode}`);
+      setParishGeoData(data);
+      setAffiliationFilter(new Set());
+      setSelectedParishId(null);
     } catch (err: any) {
       console.error('Parish geo fetch failed:', err);
     } finally {


### PR DESCRIPTION
## Batch 7 — devel-tools apiClient Migration

Migrated **~70 native fetch() calls** across **21 files** in `features/devel-tools/` to use the centralized `apiClient` utility.

### Changes
- Replace `fetch()` with `apiClient.get/post/put/delete`
- Remove `/api` prefix from URLs (apiClient auto-prefixes)
- Remove manual `response.ok` / `response.json()` handling
- Replace local `apiJson` wrappers in seedlings files
- Migrate `refactorConsoleClient` class (15 calls) including baseUrl change

### Files Modified (21)
| File | Calls |
|------|-------|
| crm/CRMPage.tsx | 14 |
| git-operations/GitOperations.tsx | 2 |
| interactive-reports/InteractiveReportJobsPage.tsx | 3 |
| menu-editor/MenuEditor.tsx | 7 |
| om-church-wizard/ChurchSetupWizard.tsx | 3 |
| om-gallery/Gallery.tsx | 10 |
| om-gallery/Gallery/exportUtils.ts | 1 |
| om-gallery/Gallery/useGallerySuggestions.ts | 4 |
| om-gallery/Gallery/useImageUsage.ts | 1 |
| om-ocr/components/OcrSetupGate.tsx | 1 |
| om-ocr/pages/OcrSetupWizardPage.tsx | 3 |
| om-seedlings/OMSeedlingsPage.tsx | 1 (wrapper) |
| om-seedlings/recordWizardTypes.ts | 1 (wrapper) |
| om-tasks/components/EmailSettingsForm.tsx | 3 |
| refactor-console/api/refactorConsoleClient.ts | 15 |
| refactor-console/engine/policy.ts | 1 |
| system-documentation/om-library/OMLibrary.tsx | 6 |
| table-wizard/TableRequestsManager.tsx | 2 |
| table-wizard/TableWizard.tsx | 2 |
| us-church-map/ExportModal.tsx | 2 |
| us-church-map/USChurchMapPage.tsx | 2 |

### Not migrated (intentional)
- `openImageWindow.ts` — fetch inside inline HTML `<script>` tag (rogue-fetch, runs in new window)
- `EnhancedOCRUploader.tsx` — static asset fetch (`/images/misc/demo/...`)
- `ConversationLogPage.tsx` — separate batch
- `transformMenuTemplate.ts` — commented-out fetch in JSDoc

### Verification
- `npx tsc --noEmit` passes (exit 0)
- Net: **+310 / -1,087 lines**