### PR TITLE
chore: migrate admin + conversation-log fetch() calls to apiClient (Batch 8)

### DIFF
--- a/front-end/src/features/admin/control-panel/ChurchOnboardingDetailPage.tsx
+++ b/front-end/src/features/admin/control-panel/ChurchOnboardingDetailPage.tsx
@@ -4,6 +4,7 @@
  * onboarding status, members, tokens, and admin actions.
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
 import Breadcrumb from '@/layouts/full/shared/breadcrumb/Breadcrumb';
 import PageContainer from '@/shared/ui/PageContainer';
 import {
@@ -296,12 +297,7 @@ const ChurchOnboardingDetailPage: React.FC = () => {
   const handleApprove = async (userId: number, email: string) => {
     setActionLoading(userId);
     try {
-      const res = await fetch(`/api/admin/users/${userId}/unlock`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      if (!res.ok) throw new Error('Failed to unlock user');
+      await apiClient.post<any>(`/admin/users/${userId}/unlock`);
       setSnack({ open: true, message: `${email} approved and unlocked`, severity: 'success' });
       fetchDetail();
     } catch (err: any) {
@@ -315,15 +311,7 @@ const ChurchOnboardingDetailPage: React.FC = () => {
     if (!rejectDialog.userId) return;
     setActionLoading(rejectDialog.userId);
     try {
-      const res = await fetch(`/api/admin/users/${rejectDialog.userId}/lockout`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reason: `Registration rejected: ${rejectReason || 'Not approved by admin'}` }),
-      });
-      if (!res.ok) {
-        // User is already locked — still treat as success for UI
-      }
+      await apiClient.post<any>(`/admin/users/${rejectDialog.userId}/lockout`, { reason: `Registration rejected: ${rejectReason || 'Not approved by admin'}` });
       setSnack({ open: true, message: `${rejectDialog.email} registration rejected`, severity: 'success' });
       setRejectDialog({ open: false, userId: null, email: '' });
       setRejectReason('');

--- a/front-end/src/features/admin/control-panel/OMDailyPage.tsx
+++ b/front-end/src/features/admin/control-panel/OMDailyPage.tsx
@@ -8,6 +8,7 @@
 import OMDailyKanban from '@/components/apps/kanban/OMDailyKanban';
 import Breadcrumb from '@/layouts/full/shared/breadcrumb/Breadcrumb';
 import { apiClient } from '@/shared/lib/apiClient';
+import { apiClient as axiosApiClient } from '@/api/utils/axiosInstance';
 import PageContainer from '@/shared/ui/PageContainer';
 import {
     Add as AddIcon,
@@ -268,15 +269,15 @@ const OMDailyPage: React.FC = () => {
 
   const fetchDashboard = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/dashboard', { credentials: 'include' });
-      if (resp.ok) { setDashboard(await resp.json()); }
+      const data = await axiosApiClient.get<any>('/omai-daily/dashboard');
+      setDashboard(data);
     } catch {}
   }, []);
 
   const fetchExtended = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/dashboard/extended', { credentials: 'include' });
-      if (resp.ok) { setExtended(await resp.json()); }
+      const data = await axiosApiClient.get<any>('/omai-daily/dashboard/extended');
+      setExtended(data);
     } catch {}
   }, []);
 
@@ -291,32 +292,31 @@ const OMDailyPage: React.FC = () => {
       if (searchTerm) params.set('search', searchTerm);
       params.set('sort', 'priority');
 
-      const resp = await fetch(`/api/omai-daily/items?${params}`, { credentials: 'include' });
-      if (resp.ok) { const data = await resp.json(); setItems(data.items); }
+      const data = await axiosApiClient.get<any>(`/omai-daily/items?${params}`);
+      setItems(data.items);
     } catch {}
   }, [filterStatus, filterPriority, filterCategory, filterDue, searchTerm]);
 
   const fetchCategories = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/categories', { credentials: 'include' });
-      if (resp.ok) { const data = await resp.json(); setCategories(data.categories); }
+      const data = await axiosApiClient.get<any>('/omai-daily/categories');
+      setCategories(data.categories);
     } catch {}
   }, []);
 
   // Changelog API calls
   const fetchChangelog = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/changelog?limit=30', { credentials: 'include' });
-      if (resp.ok) { const data = await resp.json(); setChangelogEntries(data.entries || []); }
+      const data = await axiosApiClient.get<any>('/omai-daily/changelog?limit=30');
+      setChangelogEntries(data.entries || []);
     } catch {}
   }, []);
 
   const fetchChangelogDetail = useCallback(async (date: string) => {
     try {
       setChangelogLoading(true);
-      const resp = await fetch(`/api/omai-daily/changelog/${date}`, { credentials: 'include' });
-      if (resp.ok) { const data = await resp.json(); setChangelogDetail(data.entry || null); }
-      else { setChangelogDetail(null); }
+      const data = await axiosApiClient.get<any>(`/omai-daily/changelog/${date}`);
+      setChangelogDetail(data.entry || null);
     } catch { setChangelogDetail(null); }
     finally { setChangelogLoading(false); }
   }, []);
@@ -324,41 +324,28 @@ const OMDailyPage: React.FC = () => {
   const triggerGenerate = useCallback(async (date: string) => {
     try {
       setChangelogLoading(true);
-      const resp = await fetch('/api/omai-daily/changelog/generate', {
-        method: 'POST', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ date }),
-      });
-      if (resp.ok) {
-        showToast('Changelog generated');
-        fetchChangelog();
-        fetchChangelogDetail(date);
-      } else { showToast('Failed to generate', 'error'); }
+      await axiosApiClient.post<any>('/omai-daily/changelog/generate', { date });
+      showToast('Changelog generated');
+      fetchChangelog();
+      fetchChangelogDetail(date);
     } catch { showToast('Failed to generate', 'error'); }
     finally { setChangelogLoading(false); }
   }, []);
 
   const triggerEmail = useCallback(async (date: string) => {
     try {
-      const resp = await fetch(`/api/omai-daily/changelog/email/${date}`, {
-        method: 'POST', credentials: 'include',
-      });
-      if (resp.ok) {
-        showToast('Email sent');
-        fetchChangelog();
-        fetchChangelogDetail(date);
-      } else {
-        const data = await resp.json().catch(() => ({}));
-        showToast(data.error || 'Failed to send email', 'error');
-      }
+      await axiosApiClient.post<any>(`/omai-daily/changelog/email/${date}`);
+      showToast('Email sent');
+      fetchChangelog();
+      fetchChangelogDetail(date);
     } catch { showToast('Failed to send email', 'error'); }
   }, []);
 
   // GitHub sync API calls
   const fetchGhStatus = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/github/status', { credentials: 'include' });
-      if (resp.ok) setGhStatus(await resp.json());
+      const data = await axiosApiClient.get<any>('/omai-daily/github/status');
+      setGhStatus(data);
     } catch {}
   }, []);
 
@@ -373,9 +360,7 @@ const OMDailyPage: React.FC = () => {
     stopSyncPolling();
     syncPollRef.current = setInterval(async () => {
       try {
-        const resp = await fetch('/api/omai-daily/github/sync/progress', { credentials: 'include' });
-        if (!resp.ok) return;
-        const data = await resp.json();
+        const data = await axiosApiClient.get<any>('/omai-daily/github/sync/progress');
         setGhSyncProgress({ phase: data.phase, current: data.current, total: data.total, summary: data.summary, error: data.error });
         if (!data.running) {
           stopSyncPolling();
@@ -397,33 +382,29 @@ const OMDailyPage: React.FC = () => {
     setGhSyncing(true);
     setGhSyncProgress(null);
     try {
-      const resp = await fetch('/api/omai-daily/github/sync', { method: 'POST', credentials: 'include' });
-      if (resp.ok) {
-        const data = await resp.json();
-        if (data.already_running) {
-          showToast('Sync already in progress');
-        } else {
-          showToast('GitHub sync started...');
-        }
-        pollSyncProgress();
-      } else { showToast('Failed to start sync', 'error'); setGhSyncing(false); }
+      const data = await axiosApiClient.post<any>('/omai-daily/github/sync');
+      if (data.already_running) {
+        showToast('Sync already in progress');
+      } else {
+        showToast('GitHub sync started...');
+      }
+      pollSyncProgress();
     } catch { showToast('Failed to start sync', 'error'); setGhSyncing(false); }
   }, [pollSyncProgress]);
 
   // Build info API calls
   const fetchBuildInfo = useCallback(async () => {
     try {
-      const resp = await fetch('/api/omai-daily/build-info', { credentials: 'include' });
-      if (resp.ok) setBuildInfo(await resp.json());
+      const data = await axiosApiClient.get<any>('/omai-daily/build-info');
+      setBuildInfo(data);
     } catch {}
   }, []);
 
   const pushToOrigin = useCallback(async () => {
     setPushing(true);
     try {
-      const resp = await fetch('/api/omai-daily/push-to-origin', { method: 'POST', credentials: 'include' });
-      const data = await resp.json();
-      if (resp.ok && data.success) {
+      const data = await axiosApiClient.post<any>('/omai-daily/push-to-origin');
+      if (data.success) {
         showToast(`Pushed to origin/${data.branch}`);
         fetchBuildInfo();
       } else {
@@ -456,13 +437,8 @@ const OMDailyPage: React.FC = () => {
   useEffect(() => {
     if (activeTab === 1 && !commitsSyncedRef.current) {
       commitsSyncedRef.current = true;
-      fetch('/api/omai-daily/sync-commits', {
-        method: 'POST', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ date: new Date().toISOString().split('T')[0] }),
-      })
-        .then(r => r.json())
-        .then(data => {
+      axiosApiClient.post<any>('/omai-daily/sync-commits', { date: new Date().toISOString().split('T')[0] })
+        .then((data: any) => {
           if (data.synced > 0) {
             fetchItems(selectedHorizon || undefined);
             fetchDashboard();
@@ -503,14 +479,12 @@ const OMDailyPage: React.FC = () => {
   const handleSave = async () => {
     if (!form.title) return;
     try {
-      const url = editingItem ? `/api/omai-daily/items/${editingItem.id}` : '/api/omai-daily/items';
-      const method = editingItem ? 'PUT' : 'POST';
-      const resp = await fetch(url, {
-        method, credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
-      });
-      if (resp.ok) {
+      if (editingItem) {
+        await axiosApiClient.put<any>(`/omai-daily/items/${editingItem.id}`, form);
+      } else {
+        await axiosApiClient.post<any>('/omai-daily/items', form);
+      }
+      {
         showToast(editingItem ? 'Item updated' : 'Item created');
         fetchItems(selectedHorizon || undefined);
         fetchDashboard();
@@ -524,7 +498,7 @@ const OMDailyPage: React.FC = () => {
 
   const handleDelete = async (id: number) => {
     try {
-      await fetch(`/api/omai-daily/items/${id}`, { method: 'DELETE', credentials: 'include' });
+      await axiosApiClient.delete<any>(`/omai-daily/items/${id}`);
       showToast('Item deleted');
       fetchItems(selectedHorizon || undefined);
       fetchDashboard();
@@ -534,11 +508,7 @@ const OMDailyPage: React.FC = () => {
 
   const handleStatusChange = async (item: DailyItem, newStatus: string) => {
     try {
-      await fetch(`/api/omai-daily/items/${item.id}`, {
-        method: 'PUT', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: newStatus }),
-      });
+      await axiosApiClient.put<any>(`/omai-daily/items/${item.id}`, { status: newStatus });
       fetchItems(selectedHorizon || undefined);
       fetchDashboard();
       fetchExtended();
@@ -547,11 +517,7 @@ const OMDailyPage: React.FC = () => {
 
   const handleKanbanStatusChange = async (itemId: number, newStatus: string) => {
     try {
-      await fetch(`/api/omai-daily/items/${itemId}`, {
-        method: 'PUT', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: newStatus, ...(newStatus === 'done' ? { progress: 100 } : {}) }),
-      });
+      await axiosApiClient.put<any>(`/omai-daily/items/${itemId}`, { status: newStatus, ...(newStatus === 'done' ? { progress: 100 } : {}) });
       fetchItems(selectedHorizon || undefined);
       fetchDashboard();
       fetchExtended();
@@ -560,11 +526,7 @@ const OMDailyPage: React.FC = () => {
 
   const handleQuickDone = async (itemId: number) => {
     try {
-      await fetch(`/api/omai-daily/items/${itemId}`, {
-        method: 'PUT', credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: 'done', progress: 100 }),
-      });
+      await axiosApiClient.put<any>(`/omai-daily/items/${itemId}`, { status: 'done', progress: 100 });
       showToast('Item marked done');
       fetchItems(selectedHorizon || undefined);
       fetchDashboard();

--- a/front-end/src/features/admin/om-daily/pages/OMDailyItemsPage.tsx
+++ b/front-end/src/features/admin/om-daily/pages/OMDailyItemsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Box,
@@ -125,11 +126,7 @@ const OMDailyItemsPage: React.FC = () => {
       if (selectedHorizon) params.set('horizon', selectedHorizon);
 
       const qs = params.toString();
-      const res = await fetch(`/api/omai-daily/items${qs ? `?${qs}` : ''}`, {
-        credentials: 'include',
-      });
-      if (!res.ok) throw new Error('Failed to fetch items');
-      const data = await res.json();
+      const data = await apiClient.get<any>(`/omai-daily/items${qs ? `?${qs}` : ''}`);
       setItems(Array.isArray(data) ? data : data.items || []);
     } catch (err: any) {
       showToast(err.message || 'Failed to fetch items', 'error');
@@ -141,11 +138,8 @@ const OMDailyItemsPage: React.FC = () => {
   // Fetch categories
   const fetchCategories = useCallback(async () => {
     try {
-      const res = await fetch('/api/omai-daily/categories', { credentials: 'include' });
-      if (res.ok) {
-        const data = await res.json();
-        setCategories(Array.isArray(data) ? data : data.categories || []);
-      }
+      const data = await apiClient.get<any>('/omai-daily/categories');
+      setCategories(Array.isArray(data) ? data : data.categories || []);
     } catch {
       // silently fail
     }
@@ -154,10 +148,7 @@ const OMDailyItemsPage: React.FC = () => {
   // Auto-sync commits on first load
   useEffect(() => {
     if (!synced) {
-      fetch('/api/omai-daily/sync-commits', {
-        method: 'POST',
-        credentials: 'include',
-      }).catch(() => {});
+      apiClient.post<any>('/omai-daily/sync-commits').catch(() => {});
       setSynced(true);
     }
   }, [synced]);
@@ -175,29 +166,15 @@ const OMDailyItemsPage: React.FC = () => {
   const saveItem = async () => {
     try {
       const isNew = !editingItem;
-      const method = isNew ? 'POST' : 'PUT';
-      const url = isNew
-        ? '/api/omai-daily/items'
-        : `/api/omai-daily/items/${editingItem.id}`;
-      const res = await fetch(url, {
-        method,
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
-      });
-      if (!res.ok) throw new Error('Failed to save item');
-      const result = await res.json();
+      const result = isNew
+        ? await apiClient.post<any>('/omai-daily/items', form)
+        : await apiClient.put<any>(`/omai-daily/items/${editingItem.id}`, form);
       const itemId = result?.item?.id || result?.id;
 
       // Auto-create branch if agent_tool + branch_type are set on new items
       if (isNew && (form as any).agent_tool && (form as any).branch_type && itemId) {
         try {
-          const workRes = await fetch(`/api/omai-daily/items/${itemId}/start-work`, {
-            method: 'POST', credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ branch_type: (form as any).branch_type, agent_tool: (form as any).agent_tool }),
-          });
-          const workData = await workRes.json();
+          const workData = await apiClient.post<any>(`/omai-daily/items/${itemId}/start-work`, { branch_type: (form as any).branch_type, agent_tool: (form as any).agent_tool });
           const branch = workData?.branch || workData?.item?.github_branch;
           showToast(`Item created — branch ${branch || 'created'}`, 'success');
         } catch {
@@ -219,11 +196,7 @@ const OMDailyItemsPage: React.FC = () => {
   // Delete item
   const deleteItem = async (id: number) => {
     try {
-      const res = await fetch(`/api/omai-daily/items/${id}`, {
-        method: 'DELETE',
-        credentials: 'include',
-      });
-      if (!res.ok) throw new Error('Failed to delete item');
+      await apiClient.delete<any>(`/omai-daily/items/${id}`);
       showToast('Item deleted', 'success');
       fetchItems();
     } catch (err: any) {
@@ -234,16 +207,11 @@ const OMDailyItemsPage: React.FC = () => {
   // Quick status change (uses SDLC-enforced PATCH endpoint)
   const updateStatus = async (item: DailyItem, status: string) => {
     try {
-      const res = await fetch(`/api/omai-daily/items/${item.id}/status`, {
+      await apiClient.request<any>({
         method: 'PATCH',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status }),
+        url: `/omai-daily/items/${item.id}/status`,
+        data: { status },
       });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.reasons?.join(' ') || data.error || 'Transition blocked');
-      }
       showToast(`Marked as ${STATUS_LABELS[status] || status}`, 'success');
       fetchItems();
     } catch (err: any) {

--- a/front-end/src/features/admin/ops/OpsReportsHub.tsx
+++ b/front-end/src/features/admin/ops/OpsReportsHub.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { apiClient as axiosApiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Card,
@@ -126,22 +127,19 @@ export default function OpsReportsHub() {
     setViewerContent('');
 
     try {
-      const fileUrl = `/api/admin/ops/artifacts/${artifact.id}/file/${filename}`;
-      const response = await fetch(fileUrl, {
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to load file: ${response.statusText}`);
-      }
+      const fileUrl = `/admin/ops/artifacts/${artifact.id}/file/${filename}`;
+      const text = await axiosApiClient.request<string>({ method: 'GET', url: fileUrl, responseType: 'text' });
 
       const ext = filename.split('.').pop()?.toLowerCase();
       if (ext === 'json') {
-        const json = await response.json();
-        setViewerContent(JSON.stringify(json, null, 2));
+        try {
+          const json = JSON.parse(text);
+          setViewerContent(JSON.stringify(json, null, 2));
+        } catch {
+          setViewerContent(text);
+        }
         setViewerTab(1); // Code view
       } else {
-        const text = await response.text();
         setViewerContent(text);
         if (ext === 'html') {
           setViewerTab(0); // HTML view

--- a/front-end/src/features/devel-tools/conversation-log/ConversationLogPage.tsx
+++ b/front-end/src/features/devel-tools/conversation-log/ConversationLogPage.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Alert,
     alpha,
@@ -262,19 +263,7 @@ const ConversationLogPage: React.FC = () => {
         return;
       }
 
-      const response = await fetch('/api/conversation-log/combine-export', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(body),
-      });
-
-      if (!response.ok) {
-        const err = await response.json();
-        throw new Error(err.error || 'Export failed');
-      }
-
-      const blob = await response.blob();
+      const blob = await apiClient.post<any>('/conversation-log/combine-export', body, { responseType: 'blob' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -294,11 +283,7 @@ const ConversationLogPage: React.FC = () => {
 
   const handleExportSingle = useCallback(async (filename: string) => {
     try {
-      const response = await fetch(`/api/conversation-log/export/${encodeURIComponent(filename)}`, {
-        credentials: 'include',
-      });
-      if (!response.ok) throw new Error('Export failed');
-      const blob = await response.blob();
+      const blob = await apiClient.get<any>(`/conversation-log/export/${encodeURIComponent(filename)}`, { responseType: 'blob' } as any);
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -322,14 +307,7 @@ const ConversationLogPage: React.FC = () => {
     setReviewLoading(true);
     setActiveTab(2);
     try {
-      const response = await fetch('/api/conversation-log/review/batch', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ filenames: [...selectedConvs] }),
-      });
-      if (!response.ok) throw new Error('Review failed');
-      const data = await response.json();
+      const data = await apiClient.post<any>('/conversation-log/review/batch', { filenames: [...selectedConvs] });
       if (data.success) {
         setReviewResults(data.results || []);
         // Auto-generate pipeline items from insights
@@ -386,11 +364,7 @@ const ConversationLogPage: React.FC = () => {
     setReviewLoading(true);
     setActiveTab(2);
     try {
-      const response = await fetch(`/api/conversation-log/review/${encodeURIComponent(filename)}`, {
-        credentials: 'include',
-      });
-      if (!response.ok) throw new Error('Review failed');
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/conversation-log/review/${encodeURIComponent(filename)}`);
       if (data.success) {
         setReviewResults([data]);
         const ins = data.insights as ConversationInsights;
@@ -439,18 +413,11 @@ const ConversationLogPage: React.FC = () => {
       const convRef = reviewResults.length === 1
         ? reviewResults[0].filename
         : `batch-${reviewResults.length}-convs`;
-      const response = await fetch('/api/conversation-log/export-to-pipeline', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          items: enabledItems,
-          conversation_ref: convRef,
-          agent_tool: pipelineAgentTool || null,
-        }),
+      const data = await apiClient.post<any>('/conversation-log/export-to-pipeline', {
+        items: enabledItems,
+        conversation_ref: convRef,
+        agent_tool: pipelineAgentTool || null,
       });
-      if (!response.ok) throw new Error('Export failed');
-      const data = await response.json();
       if (data.success) {
         setSnackbar({ open: true, message: `${data.count} item(s) exported to OM Daily pipeline`, severity: 'success' });
         setPipelineItems(prev => prev.map(i => i.enabled ? { ...i, enabled: false } : i));
@@ -467,14 +434,7 @@ const ConversationLogPage: React.FC = () => {
     setBulkExportPreview(null);
     setBulkExportResult(null);
     try {
-      const response = await fetch('/api/conversation-log/tasks/export-completed-to-pipeline', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ agent_tool: pipelineAgentTool || null, horizon: pipelineHorizon, auto_branch: true, dry_run: true }),
-      });
-      if (!response.ok) throw new Error('Preview failed');
-      const data = await response.json();
+      const data = await apiClient.post<any>('/conversation-log/tasks/export-completed-to-pipeline', { agent_tool: pipelineAgentTool || null, horizon: pipelineHorizon, auto_branch: true, dry_run: true });
       if (data.success) {
         setBulkExportPreview(data.items || []);
         if (data.skipped > 0) {
@@ -491,14 +451,7 @@ const ConversationLogPage: React.FC = () => {
   const handleBulkExportConfirm = useCallback(async () => {
     setBulkExportLoading(true);
     try {
-      const response = await fetch('/api/conversation-log/tasks/export-completed-to-pipeline', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ agent_tool: pipelineAgentTool || null, horizon: pipelineHorizon, auto_branch: true, dry_run: false }),
-      });
-      if (!response.ok) throw new Error('Export failed');
-      const data = await response.json();
+      const data = await apiClient.post<any>('/conversation-log/tasks/export-completed-to-pipeline', { agent_tool: pipelineAgentTool || null, horizon: pipelineHorizon, auto_branch: true, dry_run: false });
       if (data.success) {
         setBulkExportResult({ count: data.count, skipped: data.skipped });
         setBulkExportPreview(null);


### PR DESCRIPTION
## Batch 8 — admin + conversation-log apiClient Migration

Migrated **~34 native fetch() calls** across **5 files** to use the centralized `apiClient` utility.

### Changes
- Replace `fetch()` with `apiClient.get/post/put/delete`
- Remove `/api` prefix from URLs (apiClient auto-prefixes)
- Remove manual `response.ok` / `response.json()` handling
- PATCH via `apiClient.request` for SDLC status endpoint
- Blob downloads use `responseType: 'blob'`
- Aliased import as `axiosApiClient` where existing `apiClient` import from `@/shared/lib/apiClient` was present

### Files Modified (5)
| File | Calls |
|------|-------|
| admin/control-panel/OMDailyPage.tsx | 18 |
| admin/control-panel/ChurchOnboardingDetailPage.tsx | 2 |
| admin/om-daily/pages/OMDailyItemsPage.tsx | 6 |
| admin/ops/OpsReportsHub.tsx | 1 |
| devel-tools/conversation-log/ConversationLogPage.tsx | 7 |

### Verification
- `npx tsc --noEmit` passes (exit 0)
- Net: **+83 / -214 lines**