### PR TITLE
chore: migrate components/ fetch() calls to apiClient (Batch 9)

### DIFF
--- a/front-end/src/components/ErrorBoundary/AdminErrorBoundary.tsx
+++ b/front-end/src/components/ErrorBoundary/AdminErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import Grid2 from '@/components/compat/Grid2';
 // AdminErrorBoundary.tsx - Specialized error boundary for admin pages
 import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Box,
     Card,
@@ -105,24 +106,11 @@ class AdminErrorBoundary extends Component<Props, State> {
 
     logAdminError = async (errorDetails: any) => {
         try {
-            const response = await fetch('/api/logs/admin-errors', {
-                method: 'POST',
-                credentials: 'include',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    ...errorDetails,
-                    priority: 'high', // Admin errors get high priority
-                    category: 'admin_ui_error'
-                })
+            await apiClient.post<any>('/logs/admin-errors', {
+                ...errorDetails,
+                priority: 'high', // Admin errors get high priority
+                category: 'admin_ui_error'
             });
-
-            // Handle CORS and other errors silently
-            if (!response.ok && response.status !== 500) {
-                // Don't log CORS errors or other expected failures
-                return;
-            }
         } catch (logError: any) {
             // Silently handle CORS errors and network failures
             // Don't spam console with CORS errors

--- a/front-end/src/components/ImpersonationBanner.tsx
+++ b/front-end/src/components/ImpersonationBanner.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { Box, Button, Typography } from '@mui/material';
 import { IconArrowBack } from '@tabler/icons-react';
 
@@ -24,11 +25,7 @@ const ImpersonationBanner = () => {
   const handleReturn = async () => {
     setReturning(true);
     try {
-      const res = await fetch('/api/admin/impersonate/return', {
-        method: 'POST',
-        credentials: 'include'
-      });
-      const data = await res.json();
+      const data = await apiClient.post<any>('/admin/impersonate/return');
       if (data.success) {
         localStorage.setItem('auth_user', JSON.stringify(data.user));
         window.location.href = '/dashboards/modern';

--- a/front-end/src/components/InviteUserDialog.tsx
+++ b/front-end/src/components/InviteUserDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Dialog,
     DialogTitle,
@@ -86,21 +87,14 @@ const InviteUserDialog: React.FC<InviteUserDialogProps> = ({ open, onClose, chur
         setError('');
 
         try {
-            const response = await fetch('/api/admin/invites', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                credentials: 'include',
-                body: JSON.stringify({
-                    email,
-                    role,
-                    church_id: churchId || null,
-                    expiration_days: expirationDays,
-                }),
+            const data = await apiClient.post<any>('/admin/invites', {
+                email,
+                role,
+                church_id: churchId || null,
+                expiration_days: expirationDays,
             });
 
-            const data = await response.json();
-
-            if (!response.ok || !data.success) {
+            if (!data.success) {
                 setError(data.message || 'Failed to create invite.');
                 return;
             }

--- a/front-end/src/components/SocialPermissionsToggle.tsx
+++ b/front-end/src/components/SocialPermissionsToggle.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Box,
     Typography,
@@ -76,25 +77,17 @@ const SocialPermissionsToggle: React.FC<SocialPermissionsToggleProps> = ({
             setLoading(true);
             setError('');
             
-            const response = await fetch(`/api/admin/social-permissions/user/${userId}`, {
-                credentials: 'include'
-            });
-            
-            if (response.ok) {
-                const data = await response.json();
-                if (data.success) {
-                    setPermissions(data.socialPermissions || []);
-                    
-                    // Check if any social features are enabled
-                    const hasEnabledFeatures = data.socialPermissions?.some((p: SocialPermission) => p.enabled) || false;
-                    setSocialEnabled(hasEnabledFeatures);
-                    
-                    console.log('📱 Loaded social permissions:', data);
-                } else {
-                    setError(data.message || 'Failed to load social permissions');
-                }
+            const data = await apiClient.get<any>(`/admin/social-permissions/user/${userId}`);
+            if (data.success) {
+                setPermissions(data.socialPermissions || []);
+                
+                // Check if any social features are enabled
+                const hasEnabledFeatures = data.socialPermissions?.some((p: SocialPermission) => p.enabled) || false;
+                setSocialEnabled(hasEnabledFeatures);
+                
+                console.log('📱 Loaded social permissions:', data);
             } else {
-                setError('Failed to load social permissions');
+                setError(data.message || 'Failed to load social permissions');
             }
         } catch (err) {
             console.error('Error loading social permissions:', err);
@@ -116,38 +109,25 @@ const SocialPermissionsToggle: React.FC<SocialPermissionsToggleProps> = ({
             setError('');
             setSuccess('');
             
-            const response = await fetch(`/api/admin/social-permissions/user/${userId}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                credentials: 'include',
-                body: JSON.stringify({
-                    enabled,
-                    socialItems: permissions.map(p => p.id)
-                })
+            const data = await apiClient.put<any>(`/admin/social-permissions/user/${userId}`, {
+                enabled,
+                socialItems: permissions.map(p => p.id)
             });
-            
-            if (response.ok) {
-                const data = await response.json();
-                if (data.success) {
-                    setSocialEnabled(enabled);
-                    setSuccess(data.message || `Social features ${enabled ? 'enabled' : 'disabled'} successfully`);
-                    
-                    // Reload permissions to reflect changes
-                    await loadPermissions();
-                    
-                    // Notify parent component
-                    if (onPermissionsChanged) {
-                        onPermissionsChanged();
-                    }
-                    
-                    console.log('📱 Updated social permissions:', data);
-                } else {
-                    setError(data.message || 'Failed to update social permissions');
+            if (data.success) {
+                setSocialEnabled(enabled);
+                setSuccess(data.message || `Social features ${enabled ? 'enabled' : 'disabled'} successfully`);
+                
+                // Reload permissions to reflect changes
+                await loadPermissions();
+                
+                // Notify parent component
+                if (onPermissionsChanged) {
+                    onPermissionsChanged();
                 }
+                
+                console.log('📱 Updated social permissions:', data);
             } else {
-                setError('Failed to update social permissions');
+                setError(data.message || 'Failed to update social permissions');
             }
         } catch (err) {
             console.error('Error updating social permissions:', err);
@@ -169,27 +149,18 @@ const SocialPermissionsToggle: React.FC<SocialPermissionsToggleProps> = ({
             setError('');
             setSuccess('');
             
-            const response = await fetch(`/api/admin/social-permissions/user/${userId}/enable`, {
-                method: 'POST',
-                credentials: 'include'
-            });
-            
-            if (response.ok) {
-                const data = await response.json();
-                if (data.success) {
-                    setSuccess(`Social features enabled for ${userEmail}`);
-                    await loadPermissions();
-                    
-                    if (onPermissionsChanged) {
-                        onPermissionsChanged();
-                    }
-                    
-                    console.log('📱 Quick enabled social features:', data);
-                } else {
-                    setError(data.message || 'Failed to enable social features');
+            const data = await apiClient.post<any>(`/admin/social-permissions/user/${userId}/enable`);
+            if (data.success) {
+                setSuccess(`Social features enabled for ${userEmail}`);
+                await loadPermissions();
+                
+                if (onPermissionsChanged) {
+                    onPermissionsChanged();
                 }
+                
+                console.log('📱 Quick enabled social features:', data);
             } else {
-                setError('Failed to enable social features');
+                setError(data.message || 'Failed to enable social features');
             }
         } catch (err) {
             console.error('Error enabling social features:', err);

--- a/front-end/src/components/apps/userprofile/profile/IntroCard.tsx
+++ b/front-end/src/components/apps/userprofile/profile/IntroCard.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { Stack, Typography, IconButton, TextField, Button, Box, Snackbar, Alert } from '@mui/material';
 
 import ChildCard from 'src/shared/ui/ChildCard';
@@ -47,25 +48,19 @@ const IntroCard = () => {
       }
       
       try {
-        const response = await fetch('/api/user/profile', {
-          credentials: 'include'
-        });
-
-        if (response.ok) {
-          const data = await response.json();
-          if (data.success && data.profile) {
-            const profile = data.profile;
-            const newData: IntroData = {
-              introduction: profile.bio || '',
-              jobTitle: profile.job_title || '',
-              company: profile.company || '',
-              email: profile.email || user.email || '',
-              website: profile.website || '',
-              location: profile.location || ''
-            };
-            setIntroData(newData);
-            setEditData(newData);
-          }
+        const data = await apiClient.get<any>('/user/profile');
+        if (data.success && data.profile) {
+          const profile = data.profile;
+          const newData: IntroData = {
+            introduction: profile.bio || '',
+            jobTitle: profile.job_title || '',
+            company: profile.company || '',
+            email: profile.email || user.email || '',
+            website: profile.website || '',
+            location: profile.location || ''
+          };
+          setIntroData(newData);
+          setEditData(newData);
         }
       } catch (error) {
         console.error('Error fetching profile:', error);
@@ -92,33 +87,19 @@ const IntroCard = () => {
     
     setSaving(true);
     try {
-      const response = await fetch('/api/user/profile', {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          bio: editData.introduction,
-          job_title: editData.jobTitle,
-          company: editData.company,
-          website: editData.website,
-          location: editData.location
-        }),
+      const result = await apiClient.put<any>('/user/profile', {
+        bio: editData.introduction,
+        job_title: editData.jobTitle,
+        company: editData.company,
+        website: editData.website,
+        location: editData.location
       });
-
-      if (response.ok) {
-        const result = await response.json();
-        if (result.success) {
-          setIntroData(editData);
-          setIsEditing(false);
-          setSnackbar({ open: true, message: 'Profile updated successfully!', severity: 'success' });
-        } else {
-          throw new Error(result.error || 'Failed to save');
-        }
+      if (result.success) {
+        setIntroData(editData);
+        setIsEditing(false);
+        setSnackbar({ open: true, message: 'Profile updated successfully!', severity: 'success' });
       } else {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to save profile');
+        throw new Error(result.error || 'Failed to save');
       }
     } catch (error: any) {
       console.error('Error saving profile:', error);

--- a/front-end/src/components/apps/userprofile/profile/ProfileBanner.tsx
+++ b/front-end/src/components/apps/userprofile/profile/ProfileBanner.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Grid,
   Box,
@@ -92,18 +93,11 @@ const ProfileBanner = () => {
   const fetchOrthodoxAvatars = async () => {
     try {
       console.log('📸 Fetching orthodox avatars...');
-      const response = await fetch('/api/images/list?directory=orthodox/avatars');
-      if (response.ok) {
-        const data = await response.json();
-        if (data.files && Array.isArray(data.files)) {
-          const avatarPaths = data.files.map((file: string) => `/images/orthodox/avatars/${file}`);
-          setOrthodoxAvatars(avatarPaths);
-          console.log('📸 Loaded orthodox avatars:', avatarPaths.length);
-        }
-      } else {
-        // Fallback: try to fetch from a manifest or use common image extensions
-        console.log('📸 API not available, trying alternative method...');
-        // We'll handle this in the dialog by trying common filenames
+      const data = await apiClient.get<any>('/images/list?directory=orthodox/avatars');
+      if (data.files && Array.isArray(data.files)) {
+        const avatarPaths = data.files.map((file: string) => `/images/orthodox/avatars/${file}`);
+        setOrthodoxAvatars(avatarPaths);
+        console.log('📸 Loaded orthodox avatars:', avatarPaths.length);
       }
     } catch (error) {
       console.error('Failed to fetch orthodox avatars:', error);
@@ -185,29 +179,19 @@ const ProfileBanner = () => {
         formData.append('fileName', fileName);
 
         // Send to server to save in shared directory
-        const response = await fetch('/api/upload/profile', {
-          method: 'POST',
-          body: formData,
-          credentials: 'include',
-        });
+        const result = await apiClient.post<any>('/upload/profile', formData);
+        // Use the URL from server response (includes correct path)
+        const imageUrl = result.imageUrl || result.profile_image_url;
 
-        if (response.ok) {
-          const result = await response.json();
-          // Use the URL from server response (includes correct path)
-          const imageUrl = result.imageUrl || result.profile_image_url;
+        // Use the sync hook to update profile image
+        await updateProfileImage(imageUrl);
 
-          // Use the sync hook to update profile image
-          await updateProfileImage(imageUrl);
+        setSelectedAvatarId(null); // Reset Orthodox avatar selection
+        setAvatarUploadOpen(false);
 
-          setSelectedAvatarId(null); // Reset Orthodox avatar selection
-          setAvatarUploadOpen(false);
-
-          setSnackbarMessage('Profile picture updated and saved!');
-          setSnackbarOpen(true);
-          console.log('📸 Profile image saved using sync hook:', imageUrl);
-        } else {
-          throw new Error('Failed to upload profile image');
-        }
+        setSnackbarMessage('Profile picture updated and saved!');
+        setSnackbarOpen(true);
+        console.log('📸 Profile image saved using sync hook:', imageUrl);
       } catch (error) {
         console.error('Error uploading profile:', error);
         setSnackbarMessage('Failed to upload profile picture. Please try again.');

--- a/front-end/src/components/global/GlobalOMAI.tsx
+++ b/front-end/src/components/global/GlobalOMAI.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback, useContext } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Paper,
@@ -216,13 +217,8 @@ const GlobalOMAI: React.FC = () => {
 
   const loadCommandHistory = async () => {
     try {
-      const response = await fetch('/api/omai/command-history', {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setCommandHistory(data.history || []);
-      }
+      const data = await apiClient.get<any>('/omai/command-history');
+      setCommandHistory(data.history || []);
     } catch (error) {
       console.error('Failed to load command history:', error);
     }
@@ -230,13 +226,8 @@ const GlobalOMAI: React.FC = () => {
 
   const loadAvailableCommands = async () => {
     try {
-      const response = await fetch('/api/omai/available-commands', {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setAvailableCommands(data.commands || []);
-      }
+      const data = await apiClient.get<any>('/omai/available-commands');
+      setAvailableCommands(data.commands || []);
     } catch (error) {
       console.error('Failed to load available commands:', error);
     }
@@ -283,21 +274,12 @@ const GlobalOMAI: React.FC = () => {
     setCommand('');
 
     try {
-             const response = await fetch('/api/omai/execute-command', {
-         method: 'POST',
-         headers: {
-           'Content-Type': 'application/json'
-         },
-         credentials: 'include',
-         body: JSON.stringify({
-           command: commandText,
-           context: pageContext,
-           handsOnMode: settings.handsOnModeEnabled,
-           settings: settings
-         })
-       });
-
-      const result = await response.json();
+      const result = await apiClient.post<any>('/omai/execute-command', {
+        command: commandText,
+        context: pageContext,
+        handsOnMode: settings.handsOnModeEnabled,
+        settings: settings
+      });
       
       const updatedCommand: OMAICommand = {
         ...newCommand,
@@ -393,19 +375,10 @@ const GlobalOMAI: React.FC = () => {
       
       // Also try to directly test the API
       try {
-        const response = await fetch('/api/kanban/boards', {
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
-        console.log('Direct API response status:', response.status);
-        console.log('Direct API response headers:', Object.fromEntries(response.headers.entries()));
+        const data = await apiClient.get<any>('/kanban/boards');
+        console.log('Direct API response data:', data);
         
-        if (response.ok) {
-          const data = await response.json();
-          console.log('Direct API response data:', data);
-          
+        {
           // If we found boards in the direct API call, try to manually load them
           if (data.success && data.boards && data.boards.length > 0) {
             console.log(`Found ${data.boards.length} boards via direct API call:`);
@@ -447,10 +420,6 @@ const GlobalOMAI: React.FC = () => {
             console.log('Direct API returned success but no boards found');
             alert('❌ API worked but returned no boards. Check user permissions.');
           }
-        } else {
-          const errorText = await response.text();
-          console.error('Direct API error:', errorText);
-          alert(`❌ Direct API error: ${response.status} - ${errorText}`);
         }
       } catch (apiError) {
         console.error('Direct API call failed:', apiError);

--- a/front-end/src/components/global/GlobalOMAI/AssistantTab.tsx
+++ b/front-end/src/components/global/GlobalOMAI/AssistantTab.tsx
@@ -208,17 +208,10 @@ const AssistantTab: React.FC<AssistantTabProps> = ({
                                   onClick={async () => {
                                     console.log('Testing Kanban API directly...');
                                     try {
-                                      const response = await fetch('/api/kanban/health', {
-                                        credentials: 'include'
-                                      });
-                                      console.log('Health check response:', response.status);
-                                      if (response.ok) {
-                                        const data = await response.json();
-                                        console.log('Health check data:', data);
-                                        alert(`✅ Kanban API is working! ${data.message}`);
-                                      } else {
-                                        alert(`❌ Health check failed: ${response.status}`);
-                                      }
+                                      const { apiClient: axiosApiClient } = await import('@/api/utils/axiosInstance');
+                                      const data = await axiosApiClient.get<any>('/kanban/health');
+                                      console.log('Health check data:', data);
+                                      alert(`✅ Kanban API is working! ${data.message}`);
                                     } catch (error: any) {
                                       console.error('Health check error:', error);
                                       alert(`❌ Health check error: ${error.message}`);

--- a/front-end/src/components/layout/ChurchHeader.tsx
+++ b/front-end/src/components/layout/ChurchHeader.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Box,
     Chip,
@@ -70,25 +71,7 @@ const ChurchHeader: React.FC<ChurchHeaderProps> = ({ onChurchChange, currentChur
       }
 
       try {
-        const response = await fetch('/api/admin/churches', {
-          credentials: 'include',
-          headers: { 
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-cache'
-          }
-        });
-
-        if (response.status === 401) {
-          // Session expired — clear auth and redirect to login
-          localStorage.removeItem('auth_user');
-          window.location.href = `/auth/login?redirect=${encodeURIComponent(window.location.pathname)}`;
-          return;
-        }
-        if (!response.ok) {
-          throw new Error('Failed to fetch churches');
-        }
-
-        const data = await response.json();
+        const data = await apiClient.get<any>('/admin/churches');
         const churchList = data.churches || data.data?.churches || [];
         setChurches(churchList.filter((c: ChurchData) => c.is_active !== false));
 

--- a/front-end/src/components/terminal/JITTerminal.tsx
+++ b/front-end/src/components/terminal/JITTerminal.tsx
@@ -2,6 +2,7 @@
 // Web-based terminal with xterm.js for super_admin JIT sessions
 
 import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { 
   Box, 
   Typography, 
@@ -312,13 +313,7 @@ export const JITTerminal: React.FC<JITTerminalProps> = ({
   // End session
   const endSession = useCallback(async () => {
     try {
-      await fetch('/api/jit/end-session', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ sessionId })
-      });
+      await apiClient.post<any>('/jit/end-session', { sessionId });
     } catch (error) {
       console.error('[JIT Terminal] Failed to end session:', error);
     }


### PR DESCRIPTION
## Batch 9 — components/ apiClient Migration

Migrated **~17 native fetch() calls** across **10 files** to use the centralized `apiClient` utility.

### Changes
- Replace `fetch()` with `apiClient.get/post/put/delete`
- Remove `/api` prefix from URLs (apiClient auto-prefixes)
- Remove manual `response.ok` / `response.json()` handling
- FormData uploads passed directly to `apiClient.post` (axios auto-sets Content-Type)

### Files Modified (10)
| File | Calls |
|------|-------|
| components/SocialPermissionsToggle.tsx | 3 |
| components/global/GlobalOMAI.tsx | 4 |
| components/global/GlobalOMAI/AssistantTab.tsx | 1 |
| components/apps/userprofile/profile/ProfileBanner.tsx | 2 |
| components/apps/userprofile/profile/IntroCard.tsx | 2 |
| components/terminal/JITTerminal.tsx | 1 |
| components/layout/ChurchHeader.tsx | 1 |
| components/InviteUserDialog.tsx | 1 |
| components/ImpersonationBanner.tsx | 1 |
| components/ErrorBoundary/AdminErrorBoundary.tsx | 1 |

### Verification
- `npx tsc --noEmit` passes (exit 0)
- Net: **+117 / -262 lines**