### PR TITLE
chore: migrate logs + system fetch() calls to apiClient (Batch 10)

### DIFF
--- a/front-end/src/features/logs/CriticalConsole.tsx
+++ b/front-end/src/features/logs/CriticalConsole.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import ConsoleCard from '../system/logs/ConsoleCard';
 import CriticalAlert from '../system/logs/CriticalAlert';
 import { GitHubIssueModal } from '../system/logs/GitHubIssueModal';
@@ -56,12 +57,7 @@ export const CriticalConsole: React.FC<CriticalConsoleProps> = ({ isLive, logFil
     const fetchCriticalEvents = async () => {
       setLoading(true);
       try {
-        const apiUrl = process.env.NODE_ENV === 'production' 
-          ? '/api/admin/logs/database/critical?limit=20'
-          : 'http://localhost:3002/api/admin/logs/database/critical?limit=20';
-        
-        const response = await fetch(apiUrl);
-        const data = await response.json();
+        const data = await apiClient.get<any>('/admin/logs/database/critical?limit=20');
         
         if (data.events && Array.isArray(data.events) && data.events.length > 0) {
           const formattedEvents: CriticalEvent[] = data.events.map((event: any, index: number) => ({

--- a/front-end/src/features/logs/DateLogsConsole.tsx
+++ b/front-end/src/features/logs/DateLogsConsole.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import ConsoleCard from '../system/logs/ConsoleCard';
 import HistoricalLogItem from '../system/logs/HistoricalLogItem';
 
@@ -96,12 +97,7 @@ export const DateLogsConsole: React.FC<DateLogsConsoleProps> = ({ logFilter = 'A
         const startDate = start.toISOString();
         const endDate = end.toISOString();
         
-        const apiUrl = process.env.NODE_ENV === 'production' 
-          ? `/api/admin/logs/database?start_date=${startDate}&end_date=${endDate}&limit=50&sort=desc&group_similar=true`
-          : `http://localhost:3002/api/admin/logs/database?start_date=${startDate}&end_date=${endDate}&limit=50&sort=desc&group_similar=true`;
-        
-        const response = await fetch(apiUrl);
-        const data = await response.json();
+        const data = await apiClient.get<any>(`/admin/logs/database?start_date=${startDate}&end_date=${endDate}&limit=50&sort=desc&group_similar=true`);
         
         if (data.logs && Array.isArray(data.logs) && data.logs.length > 0) {
           const formattedLogs: HistoricalLog[] = data.logs.map((log: any, index: number) => ({

--- a/front-end/src/features/logs/RealTimeConsole.tsx
+++ b/front-end/src/features/logs/RealTimeConsole.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import ConsoleCard from '../system/logs/ConsoleCard';
 import LogCard from '../system/logs/LogCard';
 
@@ -99,12 +100,7 @@ export const RealTimeConsole: React.FC<RealTimeConsoleProps> = ({ isLive, logFil
   useEffect(() => {
     const fetchLogs = async () => {
       try {
-        const apiUrl = process.env.NODE_ENV === 'production' 
-          ? '/api/admin/logs/database?limit=100&sort=desc'
-          : 'http://localhost:3002/api/admin/logs/database?limit=100&sort=desc';
-        
-        const response = await fetch(apiUrl);
-        const data = await response.json();
+        const data = await apiClient.get<any>('/admin/logs/database?limit=100&sort=desc');
         
         if (data.logs && Array.isArray(data.logs)) {
           const formattedLogs: LogEntry[] = data.logs.map((log: any, index: number) => ({

--- a/front-end/src/features/logs/SystemMessagesConsole.tsx
+++ b/front-end/src/features/logs/SystemMessagesConsole.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import ConsoleCard from '../system/logs/ConsoleCard';
 import SystemMessageCard from '../system/logs/SystemMessageCard';
 
@@ -65,13 +66,8 @@ export const SystemMessagesConsole: React.FC<SystemMessagesConsoleProps> = ({ is
     const fetchSystemMessages = async () => {
       setLoading(true);
       try {
-        const apiUrl = process.env.NODE_ENV === 'production' 
-          ? '/api/admin/logs/database?level=INFO,SUCCESS&source=system&limit=15&sort=desc'
-          : 'http://localhost:3002/api/admin/logs/database?level=INFO,SUCCESS&source=system&limit=15&sort=desc';
-        
-        console.log('SystemMessagesConsole: Fetching from', apiUrl);
-        const response = await fetch(apiUrl);
-        const data = await response.json();
+        console.log('SystemMessagesConsole: Fetching from apiClient');
+        const data = await apiClient.get<any>('/admin/logs/database?level=INFO,SUCCESS&source=system&limit=15&sort=desc');
         console.log('SystemMessagesConsole: Received data', data);
         
         if (data.logs && Array.isArray(data.logs)) {

--- a/front-end/src/features/system/apps/logs/Logs.tsx
+++ b/front-end/src/features/system/apps/logs/Logs.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
   Box,
   Card,
@@ -246,21 +247,12 @@ const Logs: React.FC = () => {
                 level: selectedLevel
             });
 
-            const response = await fetch(`/api/logs?${params}`, {
-                method: 'GET',
-                credentials: 'include',
-            });
-
-            if (response.ok) {
-                const data = await response.json();
-                setLogs(data.logs);
-                
-                // Update available components from server
-                if (data.components) {
-                    setAvailableComponents(data.components);
-                }
-            } else {
-                console.error('Failed to load logs');
+            const data = await apiClient.get<any>(`/logs?${params}`);
+            setLogs(data.logs);
+            
+            // Update available components from server
+            if (data.components) {
+                setAvailableComponents(data.components);
             }
         } catch (error) {
             console.error('Error loading logs:', error);
@@ -318,21 +310,14 @@ const Logs: React.FC = () => {
                 source: selectedSource
             });
 
-            const response = await fetch(`/api/logs?${params}`, {
-                method: 'GET',
-                credentials: 'include',
-            });
-
-            if (response.ok) {
-                const data = await response.json();
-                if (data.logs.length > 0) {
-                    setLogs(prev => {
-                        const newLogs = data.logs.filter((newLog: LogEntry) =>
-                            !prev.some(existingLog => existingLog.id === newLog.id)
-                        );
-                        return [...prev, ...newLogs].slice(-1000);
-                    });
-                }
+            const data = await apiClient.get<any>(`/logs?${params}`);
+            if (data.logs.length > 0) {
+                setLogs(prev => {
+                    const newLogs = data.logs.filter((newLog: LogEntry) =>
+                        !prev.some(existingLog => existingLog.id === newLog.id)
+                    );
+                    return [...prev, ...newLogs].slice(-1000);
+                });
             }
         } catch (error) {
             console.error('Error fetching new logs:', error);
@@ -362,25 +347,13 @@ const Logs: React.FC = () => {
 
     const updateLogLevel = async (component: string, level: string) => {
         try {
-            const response = await fetch(`/api/logs/shared/ui/legacy/${component}/level`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                credentials: 'include',
-                body: JSON.stringify({ level }),
-            });
+            await apiClient.put<any>(`/logs/shared/ui/legacy/${component}/level`, { level });
+            setLogLevels(prev => prev.map(item =>
+                item.component === component ? { ...item, level: level as any } : item
+            ));
 
-            if (response.ok) {
-                setLogLevels(prev => prev.map(item =>
-                    item.component === component ? { ...item, level: level as any } : item
-                ));
-
-                setSnackbarMessage(`Log level updated for ${component}`);
-                setSnackbarOpen(true);
-            } else {
-                throw new Error('Failed to update log level');
-            }
+            setSnackbarMessage(`Log level updated for ${component}`);
+            setSnackbarOpen(true);
         } catch (error) {
             console.error('Error updating log level:', error);
             setSnackbarMessage('Failed to update log level');
@@ -390,25 +363,14 @@ const Logs: React.FC = () => {
 
     const toggleComponent = async (component: string) => {
         try {
-            const response = await fetch(`/api/logs/shared/ui/legacy/${component}/toggle`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                credentials: 'include',
-            });
+            await apiClient.put<any>(`/logs/shared/ui/legacy/${component}/toggle`);
+            setLogLevels(prev => prev.map(item =>
+                item.component === component ? { ...item, enabled: !item.enabled } : item
+            ));
 
-            if (response.ok) {
-                setLogLevels(prev => prev.map(item =>
-                    item.component === component ? { ...item, enabled: !item.enabled } : item
-                ));
-
-                const currentState = logLevels.find(l => l.component === component);
-                setSnackbarMessage(`Logging ${currentState?.enabled ? 'disabled' : 'enabled'} for ${component}`);
-                setSnackbarOpen(true);
-            } else {
-                throw new Error('Failed to toggle component logging');
-            }
+            const currentState = logLevels.find(l => l.component === component);
+            setSnackbarMessage(`Logging ${currentState?.enabled ? 'disabled' : 'enabled'} for ${component}`);
+            setSnackbarOpen(true);
         } catch (error) {
             console.error('Error toggling component:', error);
             setSnackbarMessage('Failed to toggle component logging');
@@ -418,18 +380,10 @@ const Logs: React.FC = () => {
 
     const clearLogs = async () => {
         try {
-            const response = await fetch('/api/logs', {
-                method: 'DELETE',
-                credentials: 'include',
-            });
-
-            if (response.ok) {
-                setLogs([]);
-                setSnackbarMessage('Logs cleared');
-                setSnackbarOpen(true);
-            } else {
-                throw new Error('Failed to clear logs');
-            }
+            await apiClient.delete<any>('/logs');
+            setLogs([]);
+            setSnackbarMessage('Logs cleared');
+            setSnackbarOpen(true);
         } catch (error) {
             console.error('Error clearing logs:', error);
             setSnackbarMessage('Failed to clear logs');
@@ -453,23 +407,11 @@ const Logs: React.FC = () => {
 
     const generateTestLogs = async () => {
         try {
-            const response = await fetch('/api/logs/test', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                credentials: 'include',
-                body: JSON.stringify({ count: 10, component: 'API Server' }),
-            });
-
-            if (response.ok) {
-                setSnackbarMessage('Test logs generated successfully');
-                setSnackbarOpen(true);
-                // Refresh logs to see the new entries
-                loadInitialLogs();
-            } else {
-                throw new Error('Failed to generate test logs');
-            }
+            await apiClient.post<any>('/logs/test', { count: 10, component: 'API Server' });
+            setSnackbarMessage('Test logs generated successfully');
+            setSnackbarOpen(true);
+            // Refresh logs to see the new entries
+            loadInitialLogs();
         } catch (error) {
             console.error('Error generating test logs:', error);
             setSnackbarMessage('Failed to generate test logs');

--- a/front-end/src/features/system/logs/GitHubIssueModal.tsx
+++ b/front-end/src/features/system/logs/GitHubIssueModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { Dialog, DialogContent, DialogTitle, DialogActions } from '@mui/material';
 import { Button, TextField, Typography, Box, Alert, CircularProgress, Chip } from '@mui/material';
 import { IconBrandGithub, IconX, IconCheck } from '@tabler/icons-react';
@@ -50,24 +51,7 @@ export const GitHubIssueModal: React.FC<GitHubIssueModalProps> = ({
         custom_description: customDescription.trim()
       };
 
-      const apiUrl = process.env.NODE_ENV === 'production' 
-        ? '/api/errors/report-to-github'
-        : 'http://localhost:3002/api/errors/report-to-github';
-
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify(payload)
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.message || 'Failed to create GitHub issue');
-      }
+      const data = await apiClient.post<any>('/errors/report-to-github', payload);
 
       setSuccess({
         url: data.github_url,


### PR DESCRIPTION
## Batch 10 — logs + system apiClient Migration

Migrated **~12 native fetch() calls** across **6 files** to use the centralized `apiClient` utility.

### Changes
- Replace `fetch()` with `apiClient.get/post/put/delete`
- Remove `/api` prefix from URLs (apiClient auto-prefixes)
- Remove manual `response.ok` / `response.json()` handling
- Remove `process.env.NODE_ENV` conditional URLs (apiClient handles base URL)

### Files Modified (6)
| File | Calls |
|------|-------|
| features/logs/SystemMessagesConsole.tsx | 1 |
| features/logs/CriticalConsole.tsx | 1 |
| features/logs/DateLogsConsole.tsx | 1 |
| features/logs/RealTimeConsole.tsx | 1 |
| features/system/logs/GitHubIssueModal.tsx | 1 |
| features/system/apps/logs/Logs.tsx | 7 |

### Skipped (rogue-fetches)
- `useVersionCheck.ts` — static file `/build-info.json`
- `useChurchRecordsLanding.ts` — local `fetch` function, not global
- `GreekRecordsViewer.tsx` / `HTMLViewer.tsx` — static HTML files
- `OcrUploader.tsx` — commented out fetch
- `EnhancedOCRUploader.tsx` — static image files
- `QuickContactSidebar.tsx` / `transformMenuTemplate.ts` — fetch in comments

### Verification
- `npx tsc --noEmit` passes (exit 0)
- Net: **+48 / -138 lines**