### PR TITLE
chore: migrate misc fetch() calls to apiClient (Batch 11)

### DIFF
--- a/front-end/src/api/omai.api.ts
+++ b/front-end/src/api/omai.api.ts
@@ -1,3 +1,5 @@
+import { apiClient } from '@/api/utils/axiosInstance';
+
 // OMAI API - Task Assignment and Management
 export const omaiAPI = {
   // Validate email format
@@ -9,15 +11,7 @@ export const omaiAPI = {
   // Get task logs (recent activity)
   getTaskLogs: async (limit: number = 50) => {
     try {
-      const response = await fetch(`/api/omai/task-logs?limit=${limit}`, {
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        throw new Error(`Failed to fetch task logs: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/omai/task-logs?limit=${limit}`);
       return data;
     } catch (error: any) {
       console.error('Error fetching task logs:', error);
@@ -53,15 +47,7 @@ export const omaiAPI = {
       if (filters.dateFrom) params.append('dateFrom', filters.dateFrom);
       if (filters.dateTo) params.append('dateTo', filters.dateTo);
 
-      const response = await fetch(`/api/omai/task-history?${params.toString()}`, {
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        throw new Error(`Failed to fetch task history: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/omai/task-history?${params.toString()}`);
       return data;
     } catch (error: any) {
       console.error('Error fetching task history:', error);
@@ -85,29 +71,15 @@ export const omaiAPI = {
     try {
       // Admin endpoint: POST /api/omai/task-link with email tracking
       // Public endpoint (from docs): POST /api/omai/task-link without email
-      const response = await fetch('/api/omai/task-link', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          email, // Admin-specific: track which admin generated the link
-          expiresInMinutes: options.expiresInMinutes || 1440,
-          meta: {
-            notes: options.notes || '',
-            source: 'admin-panel',
-            purpose: 'task-assignment'
-          }
-        })
+      const data = await apiClient.post<any>('/omai/task-link', {
+        email, // Admin-specific: track which admin generated the link
+        expiresInMinutes: options.expiresInMinutes || 1440,
+        meta: {
+          notes: options.notes || '',
+          source: 'admin-panel',
+          purpose: 'task-assignment'
+        }
       });
-      
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `Failed to generate task link: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
       return data;
     } catch (error: any) {
       console.error('Error generating task link:', error);
@@ -121,15 +93,7 @@ export const omaiAPI = {
   // Validate token (from PUBLIC_TASK_ASSIGNMENT_API.md)
   validateToken: async (token: string) => {
     try {
-      const response = await fetch(`/api/omai/validate-token?t=${token}`, {
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        throw new Error(`Failed to validate token: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/omai/validate-token?t=${token}`);
       return data;
     } catch (error: any) {
       console.error('Error validating token:', error);
@@ -148,24 +112,10 @@ export const omaiAPI = {
     priority?: string;
   }>) => {
     try {
-      const response = await fetch('/api/omai/submit-task', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          token,
-          tasks
-        })
+      const data = await apiClient.post<any>('/omai/submit-task', {
+        token,
+        tasks
       });
-      
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `Failed to submit tasks: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
       return data;
     } catch (error: any) {
       console.error('Error submitting tasks:', error);
@@ -179,15 +129,7 @@ export const omaiAPI = {
   // Get public token statistics (from PUBLIC_TASK_ASSIGNMENT_API.md - Admin endpoint)
   getPublicTokenStatistics: async () => {
     try {
-      const response = await fetch('/api/omai/public-tokens', {
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        throw new Error(`Failed to fetch public token statistics: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>('/omai/public-tokens');
       return data;
     } catch (error: any) {
       console.error('Error fetching public token statistics:', error);
@@ -211,17 +153,7 @@ export const omaiAPI = {
   // Delete public token (from PUBLIC_TASK_ASSIGNMENT_API.md - Admin endpoint)
   deletePublicToken: async (token: string) => {
     try {
-      const response = await fetch(`/api/omai/public-token/${token}`, {
-        method: 'DELETE',
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `Failed to delete public token: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.delete<any>(`/omai/public-token/${token}`);
       return data;
     } catch (error: any) {
       console.error('Error deleting public token:', error);
@@ -235,17 +167,7 @@ export const omaiAPI = {
   // Delete task link
   deleteTaskLink: async (linkId: number) => {
     try {
-      const response = await fetch(`/api/omai/task-link/${linkId}`, {
-        method: 'DELETE',
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `Failed to delete task link: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.delete<any>(`/omai/task-link/${linkId}`);
       return data;
     } catch (error: any) {
       console.error('Error deleting task link:', error);
@@ -259,17 +181,7 @@ export const omaiAPI = {
   // Delete task submission
   deleteSubmission: async (submissionId: number) => {
     try {
-      const response = await fetch(`/api/omai/task-submission/${submissionId}`, {
-        method: 'DELETE',
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `Failed to delete submission: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.delete<any>(`/omai/task-submission/${submissionId}`);
       return data;
     } catch (error: any) {
       console.error('Error deleting submission:', error);
@@ -283,21 +195,11 @@ export const omaiAPI = {
   // Delete multiple submissions (batch)
   deleteSubmissionsBatch: async (submissionIds: number[]) => {
     try {
-      const response = await fetch('/api/omai/task-submissions/batch', {
+      const data = await apiClient.request<any>({
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include',
-        body: JSON.stringify({ ids: submissionIds })
+        url: '/omai/task-submissions/batch',
+        data: { ids: submissionIds }
       });
-      
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `Failed to delete submissions: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
       return data;
     } catch (error: any) {
       console.error('Error deleting submissions batch:', error);
@@ -328,42 +230,7 @@ export const omaiAPI = {
     revisions?: any[];
   }) => {
     try {
-      const response = await fetch('/api/omai/tasks', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include',
-        body: JSON.stringify(taskData)
-      });
-      
-      if (!response.ok) {
-        let errorMessage = `Failed to create task: ${response.statusText}`;
-        let errorDetails: any = null;
-        
-        if (response.status === 404) {
-          errorMessage = 'Backend endpoint not found. The task creation API endpoint needs to be implemented on the server.';
-        } else {
-          try {
-            const errorData = await response.json();
-            errorMessage = errorData.error || errorMessage;
-            errorDetails = errorData.details || null;
-            
-            // Include SQL error details if available (for debugging)
-            if (errorDetails && errorDetails.sqlMessage) {
-              errorMessage += ` (${errorDetails.sqlMessage})`;
-            }
-          } catch {
-            // If response is not JSON, use status text
-          }
-        }
-        
-        const error = new Error(errorMessage) as any;
-        error.details = errorDetails;
-        throw error;
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.post<any>('/omai/tasks', taskData);
       return {
         success: true,
         data
@@ -392,15 +259,7 @@ export const omaiAPI = {
       if (filters?.page) params.append('page', filters.page.toString());
       if (filters?.limit) params.append('limit', filters.limit.toString());
 
-      const response = await fetch(`/api/omai/tasks?${params.toString()}`, {
-        credentials: 'include'
-      });
-      
-      if (!response.ok) {
-        throw new Error(`Failed to fetch tasks: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/omai/tasks?${params.toString()}`);
       return data;
     } catch (error: any) {
       console.error('Error fetching tasks:', error);
@@ -431,13 +290,7 @@ export const omaiAPI = {
       if (filters?.page) params.append('page', filters.page.toString());
       if (filters?.limit) params.append('limit', filters.limit.toString());
 
-      const response = await fetch(`/api/public/tasks?${params.toString()}`);
-      
-      if (!response.ok) {
-        throw new Error(`Failed to fetch public tasks: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/public/tasks?${params.toString()}`);
       return data;
     } catch (error: any) {
       console.error('Error fetching public tasks:', error);
@@ -455,13 +308,7 @@ export const omaiAPI = {
   // Get public task by ID (Public endpoint)
   getPublicTask: async (taskId: string | number) => {
     try {
-      const response = await fetch(`/api/public/tasks/${taskId}`);
-      
-      if (!response.ok) {
-        throw new Error(`Failed to fetch task: ${response.statusText}`);
-      }
-      
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/public/tasks/${taskId}`);
       return data;
     } catch (error: any) {
       console.error('Error fetching public task:', error);

--- a/front-end/src/context/UserDataContext/index.tsx
+++ b/front-end/src/context/UserDataContext/index.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import useSWR from 'swr';
 import { getFetcher, postFetcher } from '@/api/globalFetcher';
 import { useAuth } from '../AuthContext';
+import { apiClient } from '@/api/utils/axiosInstance';
 
 /**
  * Validates if a profile should be persisted to localStorage.
@@ -325,22 +326,7 @@ function UserDataProvider({ children }: { children: React.ReactNode }) {
         
         // Call backend API to persist changes
         try {
-            const response = await fetch(`/api/om/profile/${userId}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                credentials: 'include',
-                body: JSON.stringify(data),
-            });
-            
-            if (!response.ok) {
-                const errorData = await response.json();
-                console.error('Failed to save profile to backend:', errorData);
-                throw new Error(errorData.error || 'Failed to save profile');
-            }
-            
-            const result = await response.json();
+            const result = await apiClient.put<any>(`/om/profile/${userId}`, data);
             console.log('Profile saved to backend:', result);
             return result;
         } catch (error) {

--- a/front-end/src/features/tables/settings/ImageGridExtractor.tsx
+++ b/front-end/src/features/tables/settings/ImageGridExtractor.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useRef } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import {
     Box,
     Typography,
@@ -197,35 +198,15 @@ const ImageGridExtractor: React.FC<ImageGridExtractorProps> = ({
             }
             
             // Send to server to save as individual files
-            const response = await fetch('/api/admin/global-images/save-extracted', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    images: imagesToUpload,
-                    type: type
-                }),
+            const result = await apiClient.post<any>('/admin/global-images/save-extracted', {
+                images: imagesToUpload,
+                type: type
             });
+            console.log('✅ Extracted images saved successfully:', result);
             
-            if (response.ok) {
-                const result = await response.json();
-                console.log('✅ Extracted images saved successfully:', result);
-                
-                // Call the callback with the saved images
-                onImagesExtracted(extractedImages, type);
-                onClose();
-            } else {
-                let errorMessage = 'Failed to save extracted images';
-                try {
-                    const errorData = await response.json();
-                    errorMessage = errorData.error || errorMessage;
-                } catch (e) {
-                    // If response is not JSON, use status text
-                    errorMessage = response.statusText || errorMessage;
-                }
-                throw new Error(errorMessage);
-            }
+            // Call the callback with the saved images
+            onImagesExtracted(extractedImages, type);
+            onClose();
         } catch (error) {
             console.error('Error saving extracted images:', error);
             setError(error instanceof Error ? error.message : 'Failed to save extracted images');

--- a/front-end/src/utils/logger.ts
+++ b/front-end/src/utils/logger.ts
@@ -2,6 +2,7 @@
  * Frontend Logger Utility
  * Provides easy interface for sending SUCCESS/DEBUG logs to backend
  */
+import { apiClient } from '@/api/utils/axiosInstance';
 
 interface LogEntry {
   log_level: 'INFO' | 'WARN' | 'ERROR' | 'DEBUG' | 'SUCCESS';
@@ -20,9 +21,7 @@ class Logger {
   private defaultOrigin: string;
 
   constructor() {
-    this.apiUrl = process.env.NODE_ENV === 'production' 
-      ? '/api/logger' 
-      : 'http://localhost:3002/api/logger';
+    this.apiUrl = '/logger';
     this.defaultSource = 'frontend';
     this.defaultOrigin = 'browser';
   }
@@ -40,18 +39,7 @@ class Logger {
         user_agent: navigator.userAgent
       };
 
-      const response = await fetch(this.apiUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify(logData)
-      });
-
-      if (!response.ok) {
-        console.warn('Logger API error:', response.status);
-      }
+      await apiClient.post<any>(this.apiUrl, logData);
     } catch (error) {
       // Fail silently to avoid breaking app
       console.warn('Logger send failed:', error);


### PR DESCRIPTION
## Batch 11 — misc apiClient Migration

Migrated **~17 native fetch() calls** across **4 files** to use the centralized `apiClient` utility.

### Changes
- Replace `fetch()` with `apiClient.get/post/put/delete`
- Remove `/api` prefix from URLs (apiClient auto-prefixes)
- Remove manual `response.ok` / `response.json()` handling
- DELETE with body uses `apiClient.request()`
- Removed `process.env.NODE_ENV` conditional URLs

### Files Modified (4)
| File | Calls |
|------|-------|
| api/omai.api.ts | 14 |
| context/UserDataContext/index.tsx | 1 |
| utils/logger.ts | 1 |
| features/tables/settings/ImageGridExtractor.tsx | 1 |

### Skipped (rogue-fetches)
- `shared/lib/debugLogger.ts` — recursion risk (overrides console.*)
- `shared/lib/apiClient.ts` — IS the old fetch wrapper implementation
- `auth/authClient.ts` — auth bootstrap, must work before interceptors
- `utils/authErrorHandler.ts` — token refresh infrastructure
- `features/church/FieldMapperPage.tsx` — static HEAD checks + fetchWithChurchContext helper
- `sandbox/field-mapper/api/client.ts` — its own API client wrapper

### Verification
- `npx tsc --noEmit` passes (exit 0)
- Net: **+40 / -238 lines**