### PR TITLE
chore: migrate records-centralized fetch() calls to apiClient (Batch 12)

### DIFF
--- a/front-end/src/features/records-centralized/baptism/BaptismRecordEntryPage.tsx
+++ b/front-end/src/features/records-centralized/baptism/BaptismRecordEntryPage.tsx
@@ -19,6 +19,7 @@
  */
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { Users } from '@/ui/icons';
 import { useAuth } from '../../../context/AuthContext';
@@ -115,12 +116,7 @@ const BaptismRecordEntryPage: React.FC = () => {
           setLoading(true);
           setError(null);
           const params = new URLSearchParams({ church_id: churchId });
-          const response = await fetch(`/api/baptism-records/${id}?${params.toString()}`, {
-            credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-          });
-          if (!response.ok) throw new Error('Failed to load record');
-          const data = await response.json();
+          const data = await apiClient.get<any>(`/baptism-records/${id}?${params.toString()}`);
           if (data.success && data.record) {
             const r = data.record;
             setFormData({
@@ -195,19 +191,10 @@ const BaptismRecordEntryPage: React.FC = () => {
       const method = isEditMode ? 'PUT' : 'POST';
       const params = new URLSearchParams({ church_id: churchId });
 
-      const response = await fetch(`${url}?${params.toString()}`, {
-        method,
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...formData, church_id: parseInt(churchId) }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to save record');
-      }
-
-      const data = await response.json();
+      const apiUrl = url.replace(/^\/api/, '');
+      const data = isEditMode
+        ? await apiClient.put<any>(`${apiUrl}?${params.toString()}`, { ...formData, church_id: parseInt(churchId) })
+        : await apiClient.post<any>(`${apiUrl}?${params.toString()}`, { ...formData, church_id: parseInt(churchId) });
       if (data.success) {
         setSuccess(true);
         if (createAnotherRef.current) {

--- a/front-end/src/features/records-centralized/components/collaborationLinks/CollaborationWizardDialog.tsx
+++ b/front-end/src/features/records-centralized/components/collaborationLinks/CollaborationWizardDialog.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 /**
  * CollaborationWizardDialog
  *
@@ -125,11 +126,7 @@ const CollaborationWizardDialog: React.FC<CollaborationWizardDialogProps> = ({
         limit: '50',
         page: '1',
       });
-      const res = await fetch(`/api/churches/${churchId}/records/${recordType}?${params}`, {
-        credentials: 'include',
-      });
-      if (!res.ok) throw new Error('Failed to search records');
-      const data = await res.json();
+      const data = await apiClient.get<any>(`/churches/${churchId}/records/${recordType}?${params}`);
       setSearchResults(data.data?.records || data.records || []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Search failed');
@@ -197,19 +194,7 @@ const CollaborationWizardDialog: React.FC<CollaborationWizardDialogProps> = ({
         body.targetRecordIds = selectedRecordIds;
       }
 
-      const res = await fetch('/api/collaboration-links', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to create link');
-      }
-
-      const data = await res.json();
+      const data = await apiClient.post<any>('/collaboration-links', body);
       setGeneratedUrl(data.url);
       setActiveStep(2);
     } catch (err) {

--- a/front-end/src/features/records-centralized/components/collaborationLinks/PublicCollaborationPage.tsx
+++ b/front-end/src/features/records-centralized/components/collaborationLinks/PublicCollaborationPage.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from '@/api/utils/axiosInstance';
 /**
  * PublicCollaborationPage
  *
@@ -130,16 +131,7 @@ const PublicCollaborationPage: React.FC = () => {
     try {
       setSubmitting(true);
       setError(null);
-      const res = await fetch(`/api/collaboration-links/public/${token}/submit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ records: [currentRecord] }),
-      });
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Submit failed');
-      }
-      const data = await res.json();
+      const data = await apiClient.post<any>(`/collaboration-links/public/${token}/submit`, { records: [currentRecord] });
       setRecordsSubmitted(data.recordsSubmitted);
       setCurrentRecord({});
       if (data.completed) {
@@ -172,15 +164,7 @@ const PublicCollaborationPage: React.FC = () => {
         return;
       }
 
-      const res = await fetch(`/api/collaboration-links/public/${token}/submit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ updates }),
-      });
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Submit failed');
-      }
+      await apiClient.post<any>(`/collaboration-links/public/${token}/submit`, { updates });
       setCompleted(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to submit');

--- a/front-end/src/features/records-centralized/components/interactiveReport/InteractiveReportsPage.tsx
+++ b/front-end/src/features/records-centralized/components/interactiveReport/InteractiveReportsPage.tsx
@@ -11,6 +11,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { apiClient } from '@/api/utils/axiosInstance';
 import Breadcrumb from '@/layouts/full/shared/breadcrumb/Breadcrumb';
 import PageContainer from '@/shared/ui/PageContainer';
 import { useChurch } from '@/context/ChurchContext';
@@ -118,18 +119,7 @@ const InteractiveReportsPage: React.FC = () => {
     try {
       setLoading(true);
       setError(null);
-      const response = await fetch('/api/records/interactive-reports/list', {
-        credentials: 'include',
-        headers: authHeaders(),
-      });
-
-      if (response.status === 401 || response.status === 403) {
-        setError('Unauthorized. Please log in with an admin or priest account.');
-        return;
-      }
-      if (!response.ok) throw new Error(`Failed to fetch: ${response.statusText}`);
-
-      const data = await response.json();
+      const data = await apiClient.get<any>('/records/interactive-reports/list');
       setReports(data.reports || []);
     } catch (err: any) {
       setError(err.message || 'Failed to load reports');
@@ -155,16 +145,13 @@ const InteractiveReportsPage: React.FC = () => {
       }
 
       // Fetch records to assign — get first 10 records for this type
-      const recsRes = await fetch(`/api/church-records/${createForm.recordType}?limit=10`, {
-        credentials: 'include',
-        headers: authHeaders(),
-      });
-
       let recordIds: number[] = [];
-      if (recsRes.ok) {
-        const recsData = await recsRes.json();
+      try {
+        const recsData = await apiClient.get<any>(`/church-records/${createForm.recordType}?limit=10`);
         const records = recsData.data?.records || recsData.records || recsData.data || [];
         recordIds = Array.isArray(records) ? records.slice(0, 10).map((r: any) => r.id) : [];
+      } catch {
+        // If records fetch fails, recordIds stays empty
       }
 
       if (recordIds.length === 0) {
@@ -180,30 +167,20 @@ const InteractiveReportsPage: React.FC = () => {
         funeral: ['first_name', 'last_name', 'death_date', 'burial_date', 'cemetery'],
       };
 
-      const res = await fetch('/api/records/interactive-reports', {
-        method: 'POST',
-        credentials: 'include',
-        headers: authHeaders(),
-        body: JSON.stringify({
-          churchId,
-          recordType: createForm.recordType,
-          title: createForm.title.trim(),
-          filters: {},
-          allowedFields: defaultFields[createForm.recordType] || ['first_name', 'last_name'],
-          recipients: [
-            {
-              email: createForm.recipientEmail.trim(),
-              recordIds,
-            },
-          ],
-          expiresDays: createForm.expiresDays,
-        }),
+      await apiClient.post<any>('/records/interactive-reports', {
+        churchId,
+        recordType: createForm.recordType,
+        title: createForm.title.trim(),
+        filters: {},
+        allowedFields: defaultFields[createForm.recordType] || ['first_name', 'last_name'],
+        recipients: [
+          {
+            email: createForm.recipientEmail.trim(),
+            recordIds,
+          },
+        ],
+        expiresDays: createForm.expiresDays,
       });
-
-      if (!res.ok) {
-        const errData = await res.json().catch(() => ({}));
-        throw new Error(errData.error || `Failed to create report (${res.status})`);
-      }
 
       setCreateOpen(false);
       setCreateForm({ title: '', recordType: 'baptism', recipientEmail: '', expiresDays: 30 });
@@ -221,12 +198,7 @@ const InteractiveReportsPage: React.FC = () => {
     if (!deleteTarget) return;
     setDeleting(true);
     try {
-      const res = await fetch(`/api/records/interactive-reports/${deleteTarget.id}`, {
-        method: 'DELETE',
-        credentials: 'include',
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error('Failed to delete report');
+      await apiClient.delete<any>(`/records/interactive-reports/${deleteTarget.id}`);
       setDeleteTarget(null);
       fetchReports();
     } catch (err: any) {

--- a/front-end/src/features/records-centralized/components/records/DynamicRecordsApiService.ts
+++ b/front-end/src/features/records-centralized/components/records/DynamicRecordsApiService.ts
@@ -4,6 +4,7 @@
  * Uses column positions instead of field names for display
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
 import { apiJson, FieldMapperApiError } from '@/sandbox/field-mapper/api/client';
 
 // Types
@@ -401,18 +402,12 @@ class DynamicRecordsApiService {
         });
       }
 
-      const url = `${ENDPOINTS.export(this.churchId, tableName)}?${params.toString()}`;
-      const response = await fetch(url, {
-        headers: {
-          'Authorization': `Bearer ${localStorage.getItem('auth_token')}`
-        }
+      const exportUrl = ENDPOINTS.export(this.churchId, tableName).replace(/^\/api/, '');
+      const blob = await apiClient.request<Blob>({
+        method: 'GET',
+        url: `${exportUrl}?${params.toString()}`,
+        responseType: 'blob',
       });
-      
-      if (!response.ok) {
-        throw new Error(`Export failed: ${response.statusText}`);
-      }
-      
-      const blob = await response.blob();
       
       return {
         success: true,

--- a/front-end/src/features/records-centralized/components/records/RecordsApiService.ts
+++ b/front-end/src/features/records-centralized/components/records/RecordsApiService.ts
@@ -3,6 +3,7 @@
  * Consolidates all record-related API calls with consistent error handling and loading states
  */
 
+import { apiClient } from '@/api/utils/axiosInstance';
 import { apiJson, FieldMapperApiError } from '../client';
 
 // Types
@@ -311,18 +312,12 @@ class RecordsApiService {
         });
       }
 
-      const url = `${ENDPOINTS.export(this.churchId, recordType)}?${params.toString()}`;
-      const response = await fetch(url, {
-        headers: {
-          'Authorization': `Bearer ${localStorage.getItem('auth_token')}`
-        }
+      const exportUrl = ENDPOINTS.export(this.churchId, recordType).replace(/^\/api/, '');
+      const blob = await apiClient.request<Blob>({
+        method: 'GET',
+        url: `${exportUrl}?${params.toString()}`,
+        responseType: 'blob',
       });
-      
-      if (!response.ok) {
-        throw new Error(`Export failed: ${response.statusText}`);
-      }
-      
-      const blob = await response.blob();
       
       return {
         success: true,

--- a/front-end/src/features/records-centralized/components/records/RecordsPage/useRecordsAutocomplete.ts
+++ b/front-end/src/features/records-centralized/components/records/RecordsPage/useRecordsAutocomplete.ts
@@ -3,6 +3,7 @@
  * field mapping, fetch logic, and cache management for record form fields.
  * Extracted from RecordsPage.tsx
  */
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 
 interface AutocompleteMapping {
@@ -77,11 +78,8 @@ export function useRecordsAutocomplete({
           prefix: inputValue,
           ...(selectedChurch && selectedChurch !== 0 ? { church_id: selectedChurch.toString() } : {}),
         });
-        const resp = await fetch(`/api/${mapping.apiEndpoint}-records/autocomplete?${params}`);
-        if (resp.ok) {
-          const data = await resp.json();
-          setAcSuggestions(prev => ({ ...prev, [cacheKey]: data.suggestions || [] }));
-        }
+        const data = await apiClient.get<any>(`/${mapping.apiEndpoint}-records/autocomplete?${params}`);
+        setAcSuggestions(prev => ({ ...prev, [cacheKey]: data.suggestions || [] }));
       } catch (err) {
         console.warn('Autocomplete fetch failed:', err);
       } finally {

--- a/front-end/src/features/records-centralized/components/records/RecordsPage/useRecordsFetch.ts
+++ b/front-end/src/features/records-centralized/components/records/RecordsPage/useRecordsFetch.ts
@@ -1,7 +1,7 @@
 /**
  * useRecordsFetch.ts — Data fetching functions for RecordsPage.
  */
-
+import { apiClient } from '@/api/utils/axiosInstance';
 import churchService, { Church } from '@/shared/lib/churchService';
 import LookupService from '@/shared/lib/lookupService';
 import { RECORD_TYPE_CONFIGS, DEFAULT_DATE_SORT_FIELD } from './utils';
@@ -92,8 +92,7 @@ export async function fetchRecords(
         sortDirection: activeSortDir,
       });
     } else {
-      const response = await fetch(`/api/${selectedType.apiEndpoint}-records?page=${requestPage}&limit=${requestLimit}&search=${encodeURIComponent(querySearch || '')}&sortField=${encodeURIComponent(activeSortField)}&sortDirection=${encodeURIComponent(activeSortDir)}`);
-      const data = await response.json();
+      const data = await apiClient.get<any>(`/${selectedType.apiEndpoint}-records?page=${requestPage}&limit=${requestLimit}&search=${encodeURIComponent(querySearch || '')}&sortField=${encodeURIComponent(activeSortField)}&sortDirection=${encodeURIComponent(activeSortDir)}`);
 
       if (data && data.records) {
         recordData = {

--- a/front-end/src/features/records-centralized/funeral/FuneralRecordEntryPage.tsx
+++ b/front-end/src/features/records-centralized/funeral/FuneralRecordEntryPage.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { Cross } from '@/ui/icons';
 import { useAuth } from '../../../context/AuthContext';
@@ -114,12 +115,7 @@ const FuneralRecordEntryPage: React.FC = () => {
           setLoading(true);
           setError(null);
           const params = new URLSearchParams({ church_id: churchId });
-          const response = await fetch(`/api/funeral-records/${id}?${params.toString()}`, {
-            credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-          });
-          if (!response.ok) throw new Error('Failed to load record');
-          const data = await response.json();
+          const data = await apiClient.get<any>(`/funeral-records/${id}?${params.toString()}`);
           if (data.success && data.record) {
             const r = data.record;
             setFormData({
@@ -195,19 +191,10 @@ const FuneralRecordEntryPage: React.FC = () => {
         church_id: parseInt(churchId),
       };
 
-      const response = await fetch(`${url}?${params.toString()}`, {
-        method,
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(backendData),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to save record');
-      }
-
-      const data = await response.json();
+      const apiUrl = url.replace(/^\/api/, '');
+      const data = isEditMode
+        ? await apiClient.put<any>(`${apiUrl}?${params.toString()}`, backendData)
+        : await apiClient.post<any>(`${apiUrl}?${params.toString()}`, backendData);
       if (data.success) {
         setSuccess(true);
         if (createAnotherRef.current) {

--- a/front-end/src/features/records-centralized/marriage/MarriageRecordEntryPage.tsx
+++ b/front-end/src/features/records-centralized/marriage/MarriageRecordEntryPage.tsx
@@ -18,6 +18,7 @@
  */
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { apiClient } from '@/api/utils/axiosInstance';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { Heart } from '@/ui/icons';
 import { useAuth } from '../../../context/AuthContext';
@@ -119,12 +120,7 @@ const MarriageRecordEntryPage: React.FC = () => {
           setLoading(true);
           setError(null);
           const params = new URLSearchParams({ church_id: churchId });
-          const response = await fetch(`/api/marriage-records/${id}?${params.toString()}`, {
-            credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-          });
-          if (!response.ok) throw new Error('Failed to load record');
-          const data = await response.json();
+          const data = await apiClient.get<any>(`/marriage-records/${id}?${params.toString()}`);
           if (data.success && data.record) {
             const r = data.record;
             setFormData({
@@ -202,19 +198,10 @@ const MarriageRecordEntryPage: React.FC = () => {
         church_id: parseInt(churchId),
       };
 
-      const response = await fetch(`${url}?${params.toString()}`, {
-        method,
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(backendData),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to save record');
-      }
-
-      const data = await response.json();
+      const apiUrl = url.replace(/^\/api/, '');
+      const data = isEditMode
+        ? await apiClient.put<any>(`${apiUrl}?${params.toString()}`, backendData)
+        : await apiClient.post<any>(`${apiUrl}?${params.toString()}`, backendData);
       if (data.success) {
         setSuccess(true);
         if (createAnotherRef.current) {


### PR DESCRIPTION
## Batch 12 — records-centralized apiClient Migration

Migrated **~19 native fetch() calls** across **10 files** to use the centralized `apiClient` utility.

### Changes
- Replace `fetch()` with `apiClient.get/post/put/delete`
- Remove `/api` prefix from URLs (apiClient auto-prefixes)
- Remove manual `response.ok` / `response.json()` handling
- Blob exports use `apiClient.request` with `responseType: 'blob'`
- Entry page save uses conditional put/post based on `isEditMode`

### Files Modified (10)
| File | Calls |
|------|-------|
| baptism/BaptismRecordEntryPage.tsx | 2 |
| marriage/MarriageRecordEntryPage.tsx | 2 |
| funeral/FuneralRecordEntryPage.tsx | 2 |
| interactiveReport/InteractiveReportsPage.tsx | 4 |
| collaborationLinks/PublicCollaborationPage.tsx | 3 |
| collaborationLinks/CollaborationWizardDialog.tsx | 2 |
| records/RecordsPage/useRecordsAutocomplete.ts | 1 |
| records/RecordsPage/useRecordsFetch.ts | 1 |
| records/DynamicRecordsApiService.ts | 1 (blob) |
| records/RecordsApiService.ts | 1 (blob) |

### Skipped (rogue-fetches)
- `client.ts` — own API client wrapper implementation
- `RecipientSubmissionPage.tsx` — all fetch calls commented out (TODO)
- `InteractiveReportReview.tsx` — all fetch calls commented out (TODO)
- `apps/records-ui/index.tsx` — fetch call commented out (TODO)

### Verification
- `npx tsc --noEmit` passes (exit 0)
- Net: **+61 / -172 lines**