### PR TITLE
OMD-835: Restore deleted OCR stub components (build hotfix)

### DIFF
--- a/front-end/src/features/ocr/components/ConfigPanel.tsx
+++ b/front-end/src/features/ocr/components/ConfigPanel.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+interface ConfigPanelProps {
+  [key: string]: any;
+}
+
+const ConfigPanel: React.FC<ConfigPanelProps> = (props) => {
+  return (
+    <Box {...props}>
+      <Typography variant="subtitle2" gutterBottom>OCR Configuration</Typography>
+      <Typography variant="body2" color="text.secondary">Configuration options will appear here.</Typography>
+    </Box>
+  );
+};
+
+export default ConfigPanel;

--- a/front-end/src/features/ocr/components/JobList.tsx
+++ b/front-end/src/features/ocr/components/JobList.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Box, Typography, List } from '@mui/material';
+
+interface JobListProps {
+  jobs?: any[];
+  onSelectJob?: (jobId: string) => void;
+  [key: string]: any;
+}
+
+const JobList: React.FC<JobListProps> = ({ jobs = [], onSelectJob, ...props }) => {
+  return (
+    <Box {...props}>
+      <Typography variant="subtitle2" gutterBottom>OCR Jobs</Typography>
+      {jobs.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">No jobs yet</Typography>
+      ) : (
+        <List>{/* Job items render here */}</List>
+      )}
+    </Box>
+  );
+};
+
+export default JobList;

--- a/front-end/src/features/ocr/components/OutputViewer.tsx
+++ b/front-end/src/features/ocr/components/OutputViewer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+interface OutputViewerProps {
+  output?: string;
+  [key: string]: any;
+}
+
+const OutputViewer: React.FC<OutputViewerProps> = ({ output, ...props }) => {
+  return (
+    <Box {...props}>
+      <Typography variant="subtitle2" gutterBottom>OCR Output</Typography>
+      {output ? (
+        <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{output}</pre>
+      ) : (
+        <Typography variant="body2" color="text.secondary">No output to display.</Typography>
+      )}
+    </Box>
+  );
+};
+
+export default OutputViewer;

--- a/front-end/src/features/ocr/components/UploadZone.tsx
+++ b/front-end/src/features/ocr/components/UploadZone.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Box, Typography, Paper } from '@mui/material';
+
+interface UploadZoneProps {
+  onUpload?: (files: File[]) => void;
+  [key: string]: any;
+}
+
+const UploadZone: React.FC<UploadZoneProps> = ({ onUpload, ...props }) => {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ p: 4, textAlign: 'center', border: '2px dashed', borderColor: 'divider', cursor: 'pointer' }}
+      {...props}
+    >
+      <Typography variant="body1" color="text.secondary">
+        Drag & drop files here or click to upload
+      </Typography>
+    </Paper>
+  );
+};
+
+export default UploadZone;


### PR DESCRIPTION
## Summary

Restores 4 OCR stub components that were incorrectly deleted in commit 80495be9 (PLACEHOLDER_STUB drain). The audit triage missed that `ChurchOCRPage.tsx` (routed at `/devel/ocr-studio/church/:churchId`) imports all 4, breaking the Vite production build.

**Build error before fix:**
```
Could not resolve "../components/UploadZone" from
"src/features/ocr/pages/ChurchOCRPage.tsx"
```

## Changes

Restored verbatim from `80495be9^` (no modifications):

- `features/ocr/components/UploadZone.tsx` (23 LOC)
- `features/ocr/components/JobList.tsx` (23 LOC)
- `features/ocr/components/ConfigPanel.tsx` (17 LOC)
- `features/ocr/components/OutputViewer.tsx` (22 LOC)

These are still placeholder stubs as they were in their original state. Replacing them with real implementations is a separate effort tracked elsewhere.

## Verification

- `npx vite build` → ✓ built in 1m 24s (was failing before)
- No other files touched

## Test plan

- [x] CI build passes
- [x] Visit `/devel/ocr-studio/church/:churchId` after deploy — page renders with placeholder UI as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)