### PR TITLE
chore: fix 2 missed fetch() calls from Batch 10/12

### DIFF
--- a/front-end/src/features/records-centralized/components/collaborationLinks/PublicCollaborationPage.tsx
+++ b/front-end/src/features/records-centralized/components/collaborationLinks/PublicCollaborationPage.tsx
@@ -78,12 +78,7 @@ const PublicCollaborationPage: React.FC = () => {
       try {
         setLoading(true);
         setError(null);
-        const res = await fetch(`/api/collaboration-links/public/${token}`);
-        if (!res.ok) {
-          const data = await res.json();
-          throw new Error(data.error || 'Failed to load');
-        }
-        const data: CollabConfig = await res.json();
+        const data: CollabConfig = await apiClient.get<any>(`/collaboration-links/public/${token}`);
         setConfig(data);
         setRecordsSubmitted(data.recordsSubmitted || 0);
 

--- a/front-end/src/features/system/apps/logs/Logs.tsx
+++ b/front-end/src/features/system/apps/logs/Logs.tsx
@@ -203,28 +203,13 @@ const Logs: React.FC = () => {
 
     const initializeLogLevels = async () => {
         try {
-            const response = await fetch('/api/logs/components', {
-                method: 'GET',
-                credentials: 'include',
-            });
-
-            if (response.ok) {
-                const data = await response.json();
-                const levels: LogLevel[] = data.components.map((comp: any) => ({
-                    component: comp.name,
-                    level: comp.level,
-                    enabled: comp.enabled,
-                }));
-                setLogLevels(levels);
-            } else {
-                // Fallback to initial levels
-                const initialLevels: LogLevel[] = components.map(component => ({
-                    component: component.name,
-                    level: 'info',
-                    enabled: true,
-                }));
-                setLogLevels(initialLevels);
-            }
+            const data = await apiClient.get<any>('/logs/components');
+            const levels: LogLevel[] = data.components.map((comp: any) => ({
+                component: comp.name,
+                level: comp.level,
+                enabled: comp.enabled,
+            }));
+            setLogLevels(levels);
         } catch (error) {
             console.error('Error initializing log levels:', error);
             // Fallback to initial levels


### PR DESCRIPTION
## Batch 12 Fixup — 2 missed fetch() calls

Caught during post-merge audit scan.

### Files Modified (2)
| File | Calls |
|------|-------|
| features/system/apps/logs/Logs.tsx | 1 (initializeLogLevels) |
| collaborationLinks/PublicCollaborationPage.tsx | 1 (config load) |

### Verification
- `npx tsc --noEmit` passes (exit 0)
- Net: **+8 / -28 lines**