### PR TITLE
OMD-838: Refactor SessionsTab state explosion (16 → 3 useStates)

### DIFF
--- a/front-end/src/features/admin/dashboard/SessionsTab.tsx
+++ b/front-end/src/features/admin/dashboard/SessionsTab.tsx
@@ -2,8 +2,12 @@
  * SessionsTab — Session management tab for the System Logs & Monitoring page.
  * Self-contained with own state, handlers, and dialogs.
  * Extracted from LogSearch.tsx
+ *
+ * State is split across helpers to keep this file focused on rendering:
+ *   - useSessionsData    → list/stats/filter/pagination state + fetching
+ *   - sessionsTabDialogs → 6 dialogs collapsed into a single reducer
  */
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useReducer, useState } from 'react';
 import {
   Alert, alpha,
   Box,
@@ -45,10 +49,10 @@ import {
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { adminAPI } from '@/api/admin.api';
-import type { SessionData, SessionStats } from './logSearchTypes';
+import type { SessionData } from './logSearchTypes';
 import { STAT_CARD } from './logSearchTypes';
-
-const SESSION_PER_PAGE = 20;
+import { useSessionsData } from './useSessionsData';
+import { dialogReducer, initialDialogState } from './sessionsTabDialogs';
 
 interface SessionsTabProps {
   active: boolean;
@@ -57,84 +61,27 @@ interface SessionsTabProps {
 const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
   const theme = useTheme();
 
-  const [sessions, setSessions] = useState<SessionData[]>([]);
-  const [sessionStats, setSessionStats] = useState<SessionStats | null>(null);
-  const [sessionLoading, setSessionLoading] = useState(false);
-  const [sessionSearch, setSessionSearch] = useState('');
-  const [sessionStatusFilter, setSessionStatusFilter] = useState<'all' | 'active' | 'expired'>('all');
-  const [sessionPage, setSessionPage] = useState(1);
-  const [sessionTotalPages, setSessionTotalPages] = useState(1);
-  const [terminateDialog, setTerminateDialog] = useState<{ open: boolean; session: SessionData | null }>({ open: false, session: null });
-  const [terminateAllDialog, setTerminateAllDialog] = useState<{ open: boolean; session: SessionData | null }>({ open: false, session: null });
-  const [lockoutDialog, setLockoutDialog] = useState<{ open: boolean; session: SessionData | null }>({ open: false, session: null });
-  const [sessionCleanupDialog, setSessionCleanupDialog] = useState(false);
-  const [killAllDialog, setKillAllDialog] = useState(false);
-  const [messageDialog, setMessageDialog] = useState<{ open: boolean; session: SessionData | null }>({ open: false, session: null });
-  const [messageText, setMessageText] = useState('');
-  const [sendingMessage, setSendingMessage] = useState(false);
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({ open: false, message: '', severity: 'success' });
-
   const showSnack = (message: string, severity: 'success' | 'error' = 'success') =>
     setSnackbar({ open: true, message, severity });
 
-  const fetchSessions = useCallback(async () => {
-    setSessionLoading(true);
-    try {
-      const filters: any = {
-        search: sessionSearch || undefined,
-        status: sessionStatusFilter === 'all' ? undefined : sessionStatusFilter,
-        limit: SESSION_PER_PAGE,
-        offset: (sessionPage - 1) * SESSION_PER_PAGE,
-      };
-      const response = await adminAPI.sessions.getAll(filters);
-      const transformed = (response.sessions || []).map((s: any) => {
-        const u = s.user || {};
-        return {
-          session_id: s.session_id,
-          user_id: u.id || u.user_id || 0,
-          email: u.email || 'Unknown',
-          first_name: u.first_name || u.firstName || '',
-          last_name: u.last_name || u.lastName || '',
-          role: u.role || 'unknown',
-          church_name: u.church_name || u.churchName || '',
-          ip_address: s.ip_address || 'N/A',
-          user_agent: s.user_agent || 'Unknown',
-          login_time: s.login_time || s.created_at || new Date().toISOString(),
-          expires: s.expires || s.expires_readable,
-          is_active: s.is_active === 1 || s.is_active === true,
-          minutes_until_expiry: s.minutes_until_expiry || 0,
-        };
-      });
-      setSessions(transformed);
-      setSessionTotalPages(Math.ceil((response.total || transformed.length) / SESSION_PER_PAGE));
-    } catch (err) { showSnack('Failed to load sessions', 'error'); }
-    finally { setSessionLoading(false); }
-  }, [sessionSearch, sessionStatusFilter, sessionPage]);
+  const data = useSessionsData({ active, onError: msg => showSnack(msg, 'error') });
+  const { sessions, stats: sessionStats, loading: sessionLoading, search: sessionSearch, setSearch: setSessionSearch,
+          statusFilter: sessionStatusFilter, setStatusFilter: setSessionStatusFilter,
+          page: sessionPage, setPage: setSessionPage, totalPages: sessionTotalPages, refresh } = data;
 
-  const fetchSessionStats = useCallback(async () => {
-    try {
-      const response = await adminAPI.sessions.getStats();
-      const bs = response.stats || response.statistics || response;
-      if (bs) {
-        setSessionStats({
-          total_sessions: bs.total_sessions || 0,
-          active_sessions: bs.active_sessions || 0,
-          expired_sessions: bs.expired_sessions || 0,
-          unique_users: bs.unique_users || 0,
-          unique_ips: bs.unique_ips || 0,
-          latest_login: bs.newest_session || bs.latest_login || '',
-          earliest_login: bs.oldest_session || bs.earliest_login || '',
-        });
-      }
-    } catch (err) { console.error('Failed to fetch session stats:', err); }
-  }, []);
+  const [dialog, dispatchDialog] = useReducer(dialogReducer, initialDialogState);
+  const closeDialog = () => dispatchDialog({ type: 'close' });
+
+  const [messageText, setMessageText] = useState('');
+  const [sendingMessage, setSendingMessage] = useState(false);
 
   const handleTerminateSession = async (session: SessionData) => {
     try {
       await adminAPI.sessions.terminate(session.session_id);
       showSnack(`Session terminated for ${session.email}`);
-      setTerminateDialog({ open: false, session: null });
-      fetchSessions(); fetchSessionStats();
+      closeDialog();
+      refresh();
     } catch (err) { showSnack('Failed to terminate session', 'error'); }
   };
 
@@ -142,8 +89,8 @@ const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
     try {
       await adminAPI.sessions.terminateAllForUser(session.user_id);
       showSnack(`All sessions terminated for ${session.email}`);
-      setTerminateAllDialog({ open: false, session: null });
-      fetchSessions(); fetchSessionStats();
+      closeDialog();
+      refresh();
     } catch (err) { showSnack('Failed to terminate sessions', 'error'); }
   };
 
@@ -152,8 +99,8 @@ const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
       if (session.is_active) await adminAPI.sessions.terminate(session.session_id);
       await adminAPI.users.toggleStatus(session.user_id);
       showSnack(`User ${session.email} deactivated`);
-      setLockoutDialog({ open: false, session: null });
-      fetchSessions(); fetchSessionStats();
+      closeDialog();
+      refresh();
     } catch (err) { showSnack('Failed to lockout user', 'error'); }
   };
 
@@ -161,8 +108,8 @@ const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
     try {
       await adminAPI.sessions.cleanup(7);
       showSnack('Expired sessions cleaned up');
-      setSessionCleanupDialog(false);
-      fetchSessions(); fetchSessionStats();
+      closeDialog();
+      refresh();
     } catch (err) { showSnack('Failed to cleanup sessions', 'error'); }
   };
 
@@ -170,18 +117,19 @@ const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
     try {
       await adminAPI.sessions.terminateAll();
       showSnack('All sessions terminated');
-      setKillAllDialog(false);
-      fetchSessions(); fetchSessionStats();
+      closeDialog();
+      refresh();
     } catch (err) { showSnack('Failed to terminate all sessions', 'error'); }
   };
 
   const handleSendMessage = async () => {
-    if (!messageDialog.session || !messageText.trim()) return;
+    if (dialog.kind !== 'message' || !messageText.trim()) return;
+    const session = dialog.session;
     try {
       setSendingMessage(true);
-      await adminAPI.messages.sendToSession(messageDialog.session.session_id, messageText);
-      showSnack(`Message sent to ${messageDialog.session.email}`);
-      setMessageDialog({ open: false, session: null });
+      await adminAPI.messages.sendToSession(session.session_id, messageText);
+      showSnack(`Message sent to ${session.email}`);
+      closeDialog();
       setMessageText('');
     } catch (err) { showSnack('Failed to send message', 'error'); }
     finally { setSendingMessage(false); }
@@ -195,10 +143,6 @@ const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
       default: return 'primary';
     }
   };
-
-  useEffect(() => {
-    if (active) { fetchSessions(); fetchSessionStats(); }
-  }, [active, sessionSearch, sessionStatusFilter, sessionPage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!active) return null;
 
@@ -251,9 +195,9 @@ const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
               </FormControl>
             </Grid>
             <Grid size={{ xs: 12, md: 7 }} sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-              <Button variant="outlined" startIcon={<IconRefresh size={18} />} onClick={() => { fetchSessions(); fetchSessionStats(); }}>Refresh</Button>
-              <Button variant="outlined" color="warning" startIcon={<IconX size={18} />} onClick={() => setSessionCleanupDialog(true)}>Cleanup Expired</Button>
-              <Button variant="contained" color="error" startIcon={<IconAlertTriangle size={18} />} onClick={() => setKillAllDialog(true)}>Kill All Sessions</Button>
+              <Button variant="outlined" startIcon={<IconRefresh size={18} />} onClick={() => refresh()}>Refresh</Button>
+              <Button variant="outlined" color="warning" startIcon={<IconX size={18} />} onClick={() => dispatchDialog({ type: 'open', dialog: { kind: 'cleanup' } })}>Cleanup Expired</Button>
+              <Button variant="contained" color="error" startIcon={<IconAlertTriangle size={18} />} onClick={() => dispatchDialog({ type: 'open', dialog: { kind: 'killAll' } })}>Kill All Sessions</Button>
             </Grid>
           </Grid>
         </CardContent>
@@ -302,13 +246,13 @@ const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
                     <TableCell>
                       <Stack direction="row" spacing={0.5}>
                         {s.is_active && (
-                          <Tooltip title="Terminate Session"><IconButton size="small" color="error" onClick={() => setTerminateDialog({ open: true, session: s })}><IconShieldX size={16} /></IconButton></Tooltip>
+                          <Tooltip title="Terminate Session"><IconButton size="small" color="error" onClick={() => dispatchDialog({ type: 'open', dialog: { kind: 'terminate', session: s } })}><IconShieldX size={16} /></IconButton></Tooltip>
                         )}
-                        <Tooltip title="Terminate All User Sessions"><IconButton size="small" color="error" onClick={() => setTerminateAllDialog({ open: true, session: s })}><IconShieldOff size={16} /></IconButton></Tooltip>
+                        <Tooltip title="Terminate All User Sessions"><IconButton size="small" color="error" onClick={() => dispatchDialog({ type: 'open', dialog: { kind: 'terminateAll', session: s } })}><IconShieldOff size={16} /></IconButton></Tooltip>
                         {s.is_active && (
-                          <Tooltip title="Send Message"><IconButton size="small" color="primary" onClick={() => setMessageDialog({ open: true, session: s })}><IconMessage size={16} /></IconButton></Tooltip>
+                          <Tooltip title="Send Message"><IconButton size="small" color="primary" onClick={() => dispatchDialog({ type: 'open', dialog: { kind: 'message', session: s } })}><IconMessage size={16} /></IconButton></Tooltip>
                         )}
-                        <Tooltip title="Lockout User"><IconButton size="small" color="warning" onClick={() => setLockoutDialog({ open: true, session: s })}><IconLock size={16} /></IconButton></Tooltip>
+                        <Tooltip title="Lockout User"><IconButton size="small" color="warning" onClick={() => dispatchDialog({ type: 'open', dialog: { kind: 'lockout', session: s } })}><IconLock size={16} /></IconButton></Tooltip>
                       </Stack>
                     </TableCell>
                   </TableRow>
@@ -327,59 +271,59 @@ const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
       {/* ── Dialogs ───────────────────────────────────────────────────── */}
 
       {/* Terminate Session Dialog */}
-      <Dialog open={terminateDialog.open} onClose={() => setTerminateDialog({ open: false, session: null })}>
+      <Dialog open={dialog.kind === 'terminate'} onClose={closeDialog}>
         <DialogTitle sx={{ fontWeight: 700 }}>Terminate Session</DialogTitle>
         <DialogContent>
-          <Typography>Are you sure you want to terminate the session for <strong>{terminateDialog.session?.email}</strong>?</Typography>
+          <Typography>Are you sure you want to terminate the session for <strong>{dialog.kind === 'terminate' ? dialog.session.email : ''}</strong>?</Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>This will immediately log out the user.</Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setTerminateDialog({ open: false, session: null })}>Cancel</Button>
-          <Button onClick={() => terminateDialog.session && handleTerminateSession(terminateDialog.session)} color="error" variant="contained">Terminate</Button>
+          <Button onClick={closeDialog}>Cancel</Button>
+          <Button onClick={() => dialog.kind === 'terminate' && handleTerminateSession(dialog.session)} color="error" variant="contained">Terminate</Button>
         </DialogActions>
       </Dialog>
 
       {/* Terminate All User Sessions Dialog */}
-      <Dialog open={terminateAllDialog.open} onClose={() => setTerminateAllDialog({ open: false, session: null })}>
+      <Dialog open={dialog.kind === 'terminateAll'} onClose={closeDialog}>
         <DialogTitle sx={{ fontWeight: 700 }}>Terminate All Sessions</DialogTitle>
         <DialogContent>
-          <Typography>Terminate ALL sessions for <strong>{terminateAllDialog.session?.email}</strong>?</Typography>
+          <Typography>Terminate ALL sessions for <strong>{dialog.kind === 'terminateAll' ? dialog.session.email : ''}</strong>?</Typography>
           <Alert severity="warning" sx={{ mt: 2 }}>This will log out the user from all devices. They can log back in immediately.</Alert>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setTerminateAllDialog({ open: false, session: null })}>Cancel</Button>
-          <Button onClick={() => terminateAllDialog.session && handleTerminateAllUserSessions(terminateAllDialog.session)} color="warning" variant="contained">Terminate All</Button>
+          <Button onClick={closeDialog}>Cancel</Button>
+          <Button onClick={() => dialog.kind === 'terminateAll' && handleTerminateAllUserSessions(dialog.session)} color="warning" variant="contained">Terminate All</Button>
         </DialogActions>
       </Dialog>
 
       {/* Lockout User Dialog */}
-      <Dialog open={lockoutDialog.open} onClose={() => setLockoutDialog({ open: false, session: null })}>
+      <Dialog open={dialog.kind === 'lockout'} onClose={closeDialog}>
         <DialogTitle sx={{ fontWeight: 700 }}>Lockout User</DialogTitle>
         <DialogContent>
-          <Typography>Deactivate <strong>{lockoutDialog.session?.email}</strong> and terminate all their sessions?</Typography>
+          <Typography>Deactivate <strong>{dialog.kind === 'lockout' ? dialog.session.email : ''}</strong> and terminate all their sessions?</Typography>
           <Alert severity="error" sx={{ mt: 2 }}>The user will not be able to log in until reactivated by an admin.</Alert>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setLockoutDialog({ open: false, session: null })}>Cancel</Button>
-          <Button onClick={() => lockoutDialog.session && handleLockoutUser(lockoutDialog.session)} color="error" variant="contained">Lockout</Button>
+          <Button onClick={closeDialog}>Cancel</Button>
+          <Button onClick={() => dialog.kind === 'lockout' && handleLockoutUser(dialog.session)} color="error" variant="contained">Lockout</Button>
         </DialogActions>
       </Dialog>
 
       {/* Session Cleanup Dialog */}
-      <Dialog open={sessionCleanupDialog} onClose={() => setSessionCleanupDialog(false)}>
+      <Dialog open={dialog.kind === 'cleanup'} onClose={closeDialog}>
         <DialogTitle sx={{ fontWeight: 700 }}>Cleanup Expired Sessions</DialogTitle>
         <DialogContent>
           <Typography>Permanently delete all expired sessions older than 7 days.</Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>This action cannot be undone.</Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setSessionCleanupDialog(false)}>Cancel</Button>
+          <Button onClick={closeDialog}>Cancel</Button>
           <Button onClick={handleSessionCleanup} color="warning" variant="contained">Cleanup</Button>
         </DialogActions>
       </Dialog>
 
       {/* Kill All Sessions Dialog */}
-      <Dialog open={killAllDialog} onClose={() => setKillAllDialog(false)}>
+      <Dialog open={dialog.kind === 'killAll'} onClose={closeDialog}>
         <DialogTitle sx={{ fontWeight: 700, color: 'error.main' }}>Kill All Active Sessions</DialogTitle>
         <DialogContent>
           <Alert severity="error" sx={{ mb: 2 }}>
@@ -388,20 +332,20 @@ const SessionsTab: React.FC<SessionsTabProps> = ({ active }) => {
           <Typography variant="body2" fontWeight={700} color="error">Use this only in emergency situations!</Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setKillAllDialog(false)}>Cancel</Button>
+          <Button onClick={closeDialog}>Cancel</Button>
           <Button onClick={handleKillAllSessions} color="error" variant="contained">Kill All Sessions</Button>
         </DialogActions>
       </Dialog>
 
       {/* Send Message Dialog */}
-      <Dialog open={messageDialog.open} onClose={() => { setMessageDialog({ open: false, session: null }); setMessageText(''); }} maxWidth="sm" fullWidth>
+      <Dialog open={dialog.kind === 'message'} onClose={() => { closeDialog(); setMessageText(''); }} maxWidth="sm" fullWidth>
         <DialogTitle sx={{ fontWeight: 700 }}>Send Message</DialogTitle>
         <DialogContent>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>Send an instant message to <strong>{messageDialog.session?.email}</strong></Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>Send an instant message to <strong>{dialog.kind === 'message' ? dialog.session.email : ''}</strong></Typography>
           <TextField autoFocus fullWidth multiline rows={4} label="Message" value={messageText} onChange={e => setMessageText(e.target.value)} placeholder="Enter your message..." sx={{ mt: 1 }} />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => { setMessageDialog({ open: false, session: null }); setMessageText(''); }} disabled={sendingMessage}>Cancel</Button>
+          <Button onClick={() => { closeDialog(); setMessageText(''); }} disabled={sendingMessage}>Cancel</Button>
           <Button onClick={handleSendMessage} color="primary" variant="contained" disabled={!messageText.trim() || sendingMessage}
             startIcon={sendingMessage ? <CircularProgress size={16} /> : <IconMessage size={18} />}>
             {sendingMessage ? 'Sending...' : 'Send'}

--- a/front-end/src/features/admin/dashboard/sessionsTabDialogs.ts
+++ b/front-end/src/features/admin/dashboard/sessionsTabDialogs.ts
@@ -1,0 +1,31 @@
+/**
+ * Dialog state machine for SessionsTab.
+ *
+ * Replaces 6 separate useState dialog flags with a single discriminated union
+ * (STATE_EXPLOSION refactor — OMD-838).
+ */
+import type { SessionData } from './logSearchTypes';
+
+export type DialogState =
+  | { kind: 'none' }
+  | { kind: 'terminate'; session: SessionData }
+  | { kind: 'terminateAll'; session: SessionData }
+  | { kind: 'lockout'; session: SessionData }
+  | { kind: 'cleanup' }
+  | { kind: 'killAll' }
+  | { kind: 'message'; session: SessionData };
+
+export type DialogAction =
+  | { type: 'open'; dialog: Exclude<DialogState, { kind: 'none' }> }
+  | { type: 'close' };
+
+export const initialDialogState: DialogState = { kind: 'none' };
+
+export function dialogReducer(_state: DialogState, action: DialogAction): DialogState {
+  switch (action.type) {
+    case 'open':
+      return action.dialog;
+    case 'close':
+      return { kind: 'none' };
+  }
+}

--- a/front-end/src/features/admin/dashboard/useSessionsData.ts
+++ b/front-end/src/features/admin/dashboard/useSessionsData.ts
@@ -1,0 +1,125 @@
+/**
+ * useSessionsData — fetches and manages the sessions list, stats, and
+ * filter/pagination state for SessionsTab.
+ *
+ * Owns 7 of the 16 useStates that previously lived in SessionsTab.tsx
+ * (STATE_EXPLOSION refactor — OMD-838).
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { adminAPI } from '@/api/admin.api';
+import type { SessionData, SessionStats } from './logSearchTypes';
+
+const SESSION_PER_PAGE = 20;
+
+export type SessionStatusFilter = 'all' | 'active' | 'expired';
+
+export interface UseSessionsDataResult {
+  sessions: SessionData[];
+  stats: SessionStats | null;
+  loading: boolean;
+  search: string;
+  setSearch: (s: string) => void;
+  statusFilter: SessionStatusFilter;
+  setStatusFilter: (s: SessionStatusFilter) => void;
+  page: number;
+  setPage: (p: number) => void;
+  totalPages: number;
+  refresh: () => Promise<void>;
+}
+
+interface UseSessionsDataOptions {
+  active: boolean;
+  onError?: (msg: string) => void;
+}
+
+export function useSessionsData({ active, onError }: UseSessionsDataOptions): UseSessionsDataResult {
+  const [sessions, setSessions] = useState<SessionData[]>([]);
+  const [stats, setStats] = useState<SessionStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<SessionStatusFilter>('all');
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  const fetchSessions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const filters: any = {
+        search: search || undefined,
+        status: statusFilter === 'all' ? undefined : statusFilter,
+        limit: SESSION_PER_PAGE,
+        offset: (page - 1) * SESSION_PER_PAGE,
+      };
+      const response = await adminAPI.sessions.getAll(filters);
+      const transformed = (response.sessions || []).map((s: any) => {
+        const u = s.user || {};
+        return {
+          session_id: s.session_id,
+          user_id: u.id || u.user_id || 0,
+          email: u.email || 'Unknown',
+          first_name: u.first_name || u.firstName || '',
+          last_name: u.last_name || u.lastName || '',
+          role: u.role || 'unknown',
+          church_name: u.church_name || u.churchName || '',
+          ip_address: s.ip_address || 'N/A',
+          user_agent: s.user_agent || 'Unknown',
+          login_time: s.login_time || s.created_at || new Date().toISOString(),
+          expires: s.expires || s.expires_readable,
+          is_active: s.is_active === 1 || s.is_active === true,
+          minutes_until_expiry: s.minutes_until_expiry || 0,
+        };
+      });
+      setSessions(transformed);
+      setTotalPages(Math.ceil((response.total || transformed.length) / SESSION_PER_PAGE));
+    } catch (err) {
+      onError?.('Failed to load sessions');
+    } finally {
+      setLoading(false);
+    }
+  }, [search, statusFilter, page, onError]);
+
+  const fetchStats = useCallback(async () => {
+    try {
+      const response = await adminAPI.sessions.getStats();
+      const bs = response.stats || response.statistics || response;
+      if (bs) {
+        setStats({
+          total_sessions: bs.total_sessions || 0,
+          active_sessions: bs.active_sessions || 0,
+          expired_sessions: bs.expired_sessions || 0,
+          unique_users: bs.unique_users || 0,
+          unique_ips: bs.unique_ips || 0,
+          latest_login: bs.newest_session || bs.latest_login || '',
+          earliest_login: bs.oldest_session || bs.earliest_login || '',
+        });
+      }
+    } catch (err) {
+      console.error('Failed to fetch session stats:', err);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    await Promise.all([fetchSessions(), fetchStats()]);
+  }, [fetchSessions, fetchStats]);
+
+  useEffect(() => {
+    if (active) {
+      fetchSessions();
+      fetchStats();
+    }
+  }, [active, search, statusFilter, page]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {
+    sessions,
+    stats,
+    loading,
+    search,
+    setSearch,
+    statusFilter,
+    setStatusFilter,
+    page,
+    setPage,
+    totalPages,
+    refresh,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract `useSessionsData` hook (sessions list/stats/filter/pagination + fetch) — removes 7 useStates
- Replace 6 dialog flags with `dialogReducer` discriminated union — removes 5 useStates
- Final useState count in SessionsTab.tsx: **16 → 3** (snackbar, messageText, sendingMessage)
- LOC: 421 → 364

## Why
SessionsTab triggered STATE_EXPLOSION (high severity) in the architecture audit. The state was mostly two clusters: a data-fetch cluster and a dialog-visibility cluster. Both have idiomatic React shapes (custom hook, reducer) so the refactor is mechanical and lossless.

## Files
- `front-end/src/features/admin/dashboard/useSessionsData.ts` (new)
- `front-end/src/features/admin/dashboard/sessionsTabDialogs.ts` (new)
- `front-end/src/features/admin/dashboard/SessionsTab.tsx` (refactored)

## Test plan
- [x] `vite build` succeeds
- [x] `tsc --noEmit` passes for affected files
- [x] Smoke test: open Sessions tab, verify sessions list loads, dialogs open/close, refresh button works
- [x] Verify search and filter still drive the data fetch
- [x] Verify pagination still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)