### PR TITLE
fix: maintenance file not cleaned up after failed build

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -12,7 +12,7 @@
     "clean:cache": "rm -rf node_modules/.vite dist .vite",
     "clean:all": "rm -rf node_modules dist package-lock.json && npm install --legacy-peer-deps --loglevel=error",
     "prebuild": "touch /var/www/orthodoxmetrics/maintenance.on",
-    "build": "node --max-old-space-size=4096 node_modules/vite/bin/vite.js build",
+    "build": "node --max-old-space-size=4096 node_modules/vite/bin/vite.js build; ret=$?; rm -f /var/www/orthodoxmetrics/maintenance.on; exit $ret",
     "postbuild": "rm -f /var/www/orthodoxmetrics/maintenance.on",
     "build:dev": "vite build --mode development",
     "preview": "vite preview --port 5175 --host 0.0.0.0",

--- a/server/src/routes/build.js
+++ b/server/src/routes/build.js
@@ -1148,6 +1148,9 @@ async function executeBuild(config, buildId) {
         ? '\n✅ Build completed successfully!' 
         : `\n❌ Build failed with exit code: ${code}`;
       
+      // Safety net: always remove maintenance file after build completes
+      try { require('fs').unlinkSync('/var/www/orthodoxmetrics/maintenance.on'); } catch { /* already removed */ }
+      
       resolve({
         success: success,
         output: output,
@@ -1156,6 +1159,9 @@ async function executeBuild(config, buildId) {
     });
     
     buildProcess.on('error', (error) => {
+      // Safety net: always remove maintenance file on spawn error
+      try { require('fs').unlinkSync('/var/www/orthodoxmetrics/maintenance.on'); } catch { /* already removed */ }
+      
       resolve({
         success: false,
         output: output + `\n❌ Failed to start build process: ${error.message}`,
@@ -1256,6 +1262,9 @@ async function executeBuildWithStreaming(config, buildId, onData) {
         ? '\n✅ Build completed successfully!' 
         : `\n❌ Build failed with exit code: ${code}`;
       
+      // Safety net: always remove maintenance file after build completes
+      try { require('fs').unlinkSync('/var/www/orthodoxmetrics/maintenance.on'); } catch { /* already removed */ }
+      
       onData(message);
       
       resolve({
@@ -1265,6 +1274,9 @@ async function executeBuildWithStreaming(config, buildId, onData) {
     });
     
     buildProcess.on('error', (error) => {
+      // Safety net: always remove maintenance file on spawn error
+      try { require('fs').unlinkSync('/var/www/orthodoxmetrics/maintenance.on'); } catch { /* already removed */ }
+      
       onData(`\n❌ Failed to start build process: ${error.message}`);
       resolve({
         success: false,


### PR DESCRIPTION
## Bug Fix — Stale Maintenance Page

### Problem
When a frontend build fails, the `/var/www/orthodoxmetrics/maintenance.on` file is never removed, leaving users stuck on the "Receiving Updates" page indefinitely.

### Root Cause
`front-end/package.json` uses npm lifecycle hooks:
- `prebuild`: creates maintenance file
- `postbuild`: removes maintenance file

**npm skips `postbuild` when the build command fails.** So any vite build failure leaves the file in place.

### Fix (two layers)
1. **`package.json` build script**: Always removes maintenance file via shell semicolon chain (`ret=$?; rm -f ...; exit $ret`), regardless of vite exit code
2. **`server/src/routes/build.js`**: Both `executeBuild` and `executeBuildWithStreaming` now remove the maintenance file in their `close`/`error` handlers as a safety net

### Immediate Action Needed
After merging, manually remove the stale file on prod:
```bash
rm -f /var/www/orthodoxmetrics/maintenance.on
```

### Files Changed (2)
- `front-end/package.json` — build script cleanup
- `server/src/routes/build.js` — safety net in 4 event handlers