### PR TITLE
OMD-164: Add OCR settings explanation tooltips

### DIFF
--- a/front-end/src/features/devel-tools/om-ocr/EnhancedOCRUploader/AdvancedOptionsPanel.tsx
+++ b/front-end/src/features/devel-tools/om-ocr/EnhancedOCRUploader/AdvancedOptionsPanel.tsx
@@ -11,14 +11,29 @@ import {
   Divider,
   Paper,
   Stack,
+  Tooltip,
 } from '@mui/material';
 import {
   IconChevronDown,
   IconChevronUp,
+  IconInfoCircle,
   IconSettings,
 } from '@tabler/icons-react';
 import RecordSchemaInfoPopover from '../components/RecordSchemaInfoPopover';
 import type { AdvancedOptionsPanelProps } from './types';
+
+/** Small inline info icon with a tooltip — used beside setting labels. */
+const InfoTip: React.FC<{ tip: string; ariaLabel: string }> = ({ tip, ariaLabel }) => (
+  <Tooltip title={tip} arrow placement="right">
+    <Box
+      component="span"
+      sx={{ display: 'inline-flex', color: 'text.secondary', cursor: 'help', ml: 0.5 }}
+      aria-label={ariaLabel}
+    >
+      <IconInfoCircle size={16} />
+    </Box>
+  </Tooltip>
+);
 
 const AdvancedOptionsPanel: React.FC<AdvancedOptionsPanelProps> = ({
   showAdvanced,
@@ -62,7 +77,13 @@ const AdvancedOptionsPanel: React.FC<AdvancedOptionsPanelProps> = ({
             }
             label={
               <Box>
-                <Typography variant="body2" fontWeight={500}>Auto-detect Language</Typography>
+                <Stack direction="row" alignItems="center">
+                  <Typography variant="body2" fontWeight={500}>Auto-detect Language</Typography>
+                  <InfoTip
+                    ariaLabel="Auto-detect language info"
+                    tip="Lets the engine identify the script and language per page. Recommended when uploading mixed-language ledgers. If all pages share one language, turning this OFF and setting 'OCR Language' explicitly improves accuracy and speed."
+                  />
+                </Stack>
                 <Typography variant="caption" color="text.secondary">
                   Automatically detect the language in record images
                 </Typography>
@@ -79,7 +100,13 @@ const AdvancedOptionsPanel: React.FC<AdvancedOptionsPanelProps> = ({
             }
             label={
               <Box>
-                <Typography variant="body2" fontWeight={500}>Force Grayscale Preprocessing</Typography>
+                <Stack direction="row" alignItems="center">
+                  <Typography variant="body2" fontWeight={500}>Force Grayscale Preprocessing</Typography>
+                  <InfoTip
+                    ariaLabel="Force grayscale info"
+                    tip="Drops color information before OCR. Improves accuracy for faded ink, yellowed paper, and low-contrast handwriting. Disable if your source has color-coded annotations you want preserved in the image preview."
+                  />
+                </Stack>
                 <Typography variant="caption" color="text.secondary">
                   Convert images to grayscale before OCR processing
                 </Typography>
@@ -96,7 +123,13 @@ const AdvancedOptionsPanel: React.FC<AdvancedOptionsPanelProps> = ({
             }
             label={
               <Box>
-                <Typography variant="body2" fontWeight={500}>Deskew Images Before OCR</Typography>
+                <Stack direction="row" alignItems="center">
+                  <Typography variant="body2" fontWeight={500}>Deskew Images Before OCR</Typography>
+                  <InfoTip
+                    ariaLabel="Deskew info"
+                    tip="Auto-rotates pages that were scanned at a slight angle. Strongly recommended — even a 2-3° tilt can reduce line detection accuracy significantly. Adds minor processing time per page."
+                  />
+                </Stack>
                 <Typography variant="caption" color="text.secondary">
                   Automatically correct skewed or rotated images
                 </Typography>
@@ -105,7 +138,13 @@ const AdvancedOptionsPanel: React.FC<AdvancedOptionsPanelProps> = ({
           />
 
           <Box>
-            <Typography variant="body2" fontWeight={500} sx={{ mb: 1 }}>OCR Language</Typography>
+            <Stack direction="row" alignItems="center" sx={{ mb: 1 }}>
+              <Typography variant="body2" fontWeight={500}>OCR Language</Typography>
+              <InfoTip
+                ariaLabel="OCR language info"
+                tip="Explicit language hint for the OCR engine. Overrides auto-detect when that toggle is off. Pick the primary language of the document — using the wrong language can cut accuracy in half on Cyrillic, Greek, or Romanian scripts."
+              />
+            </Stack>
             <FormControl sx={{ minWidth: 200 }}>
               <Select
                 value={settings.language}
@@ -147,9 +186,15 @@ const AdvancedOptionsPanel: React.FC<AdvancedOptionsPanelProps> = ({
 
           {/* Sticky Defaults Section */}
           <Box>
-            <Typography variant="body2" fontWeight={600} sx={{ mb: 2 }}>
-              Sticky Default Fields
-            </Typography>
+            <Stack direction="row" alignItems="center" sx={{ mb: 0.5 }}>
+              <Typography variant="body2" fontWeight={600}>
+                Sticky Default Fields
+              </Typography>
+              <InfoTip
+                ariaLabel="Sticky defaults info"
+                tip="When enabled for a record type, the field mapper is locked to that table's canonical columns and will not invent new fields. Leave ON for most users — turning OFF is only useful when experimenting with custom column schemas."
+              />
+            </Stack>
             <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
               Restrict field mapping to default database columns for each record type
             </Typography>

--- a/front-end/src/features/devel-tools/om-ocr/EnhancedOCRUploader/SettingsPanel.tsx
+++ b/front-end/src/features/devel-tools/om-ocr/EnhancedOCRUploader/SettingsPanel.tsx
@@ -14,13 +14,34 @@ import {
   RadioGroup,
   Select,
   FormLabel,
+  Tooltip,
 } from '@mui/material';
 import {
   IconChevronDown,
   IconChevronUp,
+  IconInfoCircle,
   IconSettings,
 } from '@tabler/icons-react';
 import type { SettingsPanelProps, ExtractionAction } from './types';
+
+/**
+ * Inline label with an info tooltip icon. Keeps FormLabel styling and
+ * attaches an explanation accessible via hover/tap.
+ */
+const LabelWithInfo: React.FC<{ label: string; tip: string }> = ({ label, tip }) => (
+  <FormLabel sx={{ mb: 1, fontWeight: 500, display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
+    {label}
+    <Tooltip title={tip} arrow placement="right">
+      <Box
+        component="span"
+        sx={{ display: 'inline-flex', color: 'text.secondary', cursor: 'help' }}
+        aria-label={`${label} info`}
+      >
+        <IconInfoCircle size={16} />
+      </Box>
+    </Tooltip>
+  </FormLabel>
+);
 
 const SettingsPanel: React.FC<SettingsPanelProps> = ({
   showAdvanced,
@@ -75,7 +96,10 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
 
           <Stack spacing={2.5}>
             <FormControl fullWidth>
-              <FormLabel sx={{ mb: 1, fontWeight: 500 }}>Transcription mode</FormLabel>
+              <LabelWithInfo
+                label="Transcription mode"
+                tip="Choose 'Exactly as written' to preserve original spelling — recommended for historical accuracy and archival transcription. Choose 'Fix spelling' when you want cleaner output for search and export, at the cost of losing the source's original wording."
+              />
               <Select
                 value={docSettings.transcriptionMode}
                 onChange={(e) => {
@@ -90,7 +114,10 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             </FormControl>
 
             <FormControl fullWidth>
-              <FormLabel sx={{ mb: 1, fontWeight: 500 }}>Text extraction scope</FormLabel>
+              <LabelWithInfo
+                label="Text extraction scope"
+                tip="'Extract all text' captures both printed and handwritten content (recommended). 'Handwritten only' attempts to skip printed header/footer text — note this mode is experimental and not yet supported by the current engine."
+              />
               <Select
                 value={docSettings.textExtractionScope}
                 onChange={(e) => {
@@ -109,7 +136,10 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             </FormControl>
 
             <FormControl fullWidth>
-              <FormLabel sx={{ mb: 1, fontWeight: 500 }}>Formatting mode</FormLabel>
+              <LabelWithInfo
+                label="Formatting mode"
+                tip="Applies light post-processing to line breaks, spacing, and paragraph structure for better human readability. Does not change the words themselves."
+              />
               <Select
                 value={docSettings.formattingMode}
                 onChange={(e) => {
@@ -128,9 +158,20 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
 
         {/* Action Selector */}
         <Box>
-          <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 2 }}>
-            Choose an action
-          </Typography>
+          <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" fontWeight={600}>
+              Choose an action
+            </Typography>
+            <Tooltip
+              title="Controls how OCR output is structured. 'Full Text' is the default and works for most ledger pages. Table and Custom Data extraction are experimental and currently disabled."
+              arrow
+              placement="right"
+            >
+              <Box component="span" sx={{ display: 'inline-flex', color: 'text.secondary', cursor: 'help' }} aria-label="Action info">
+                <IconInfoCircle size={16} />
+              </Box>
+            </Tooltip>
+          </Stack>
           <RadioGroup
             value={extractionAction}
             onChange={(e) => setExtractionAction(e.target.value as ExtractionAction)}


### PR DESCRIPTION
## Summary
- Adds info-icon tooltips next to each setting in the OCR upload SettingsPanel and AdvancedOptionsPanel.
- Tooltips explain what each setting does, when to use it, and its impact on accuracy/speed — so church admins don't have to guess at what options like "Force Grayscale" or "Deskew" mean.
- Uses `Tooltip` from MUI and a small `IconInfoCircle` from tabler icons with `cursor: help` and an ARIA label for screen readers.

## Fields covered
- **SettingsPanel**: Transcription mode, Text extraction scope, Formatting mode, Choose an action
- **AdvancedOptionsPanel**: Auto-detect Language, Force Grayscale, Deskew, OCR Language, Sticky Default Fields

## Test plan
- [x] `vite build` succeeds
- [x] Visit Enhanced OCR Uploader, expand settings and advanced options, hover each info icon to verify tooltip text
- [x] Keyboard/ARIA: tab to icon, confirm aria-label is read

Tracked via OMD-164.