### PR TITLE
OMD-166: Add empty states with illustrations for OCR pages

### DIFF
--- a/front-end/src/features/devel-tools/om-ocr/components/ProcessedImagesTable.tsx
+++ b/front-end/src/features/devel-tools/om-ocr/components/ProcessedImagesTable.tsx
@@ -47,8 +47,10 @@ import {
   IconAlertCircle,
   IconEyeOff,
   IconTrash,
-  IconPlayerPlay
+  IconPlayerPlay,
+  IconFileText,
 } from '@tabler/icons-react';
+import EmptyState from '@/shared/ui/EmptyState';
 import type { OCRJobRow, OCRJobDetail, RecordType } from '../types/ocrJob';
 
 interface ProcessedImagesTableProps {
@@ -418,10 +420,12 @@ export const ProcessedImagesTable: React.FC<ProcessedImagesTableProps> = ({
               <TableBody>
                 {jobs.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
-                      <Typography color="text.secondary">
-                        No processed images yet
-                      </Typography>
+                    <TableCell colSpan={7} sx={{ border: 0, p: 0 }}>
+                      <EmptyState
+                        illustration={<IconFileText size={56} stroke={1.5} />}
+                        title="No processed images yet"
+                        description="Upload a scanned ledger image to start OCR. Completed jobs will appear here with a preview and the extracted text."
+                      />
                     </TableCell>
                   </TableRow>
                 ) : (

--- a/front-end/src/features/devel-tools/om-ocr/components/workbench/UnifiedJobsList.tsx
+++ b/front-end/src/features/devel-tools/om-ocr/components/workbench/UnifiedJobsList.tsx
@@ -45,7 +45,10 @@ import {
   IconEye,
   IconArchive,
   IconAlertTriangle,
+  IconFileText,
+  IconSearch,
 } from '@tabler/icons-react';
+import EmptyState from '@/shared/ui/EmptyState';
 import type { OCRJobRow } from '../../types/ocrJob';
 
 interface UnifiedJobsListProps {
@@ -359,10 +362,26 @@ const UnifiedJobsList: React.FC<UnifiedJobsListProps> = ({
               </TableRow>
             ) : sortedJobs.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={colCount} align="center" sx={{ py: 4 }}>
-                  <Typography variant="body2" color="text.secondary">
-                    {jobs.length === 0 ? 'No processed images yet' : 'No jobs to display'}
-                  </Typography>
+                <TableCell colSpan={colCount} sx={{ border: 0, p: 0 }}>
+                  {jobs.length === 0 ? (
+                    <EmptyState
+                      illustration={<IconFileText size={56} stroke={1.5} />}
+                      title="No OCR jobs yet"
+                      description="Upload a scanned record image to begin extraction. Processed jobs will appear here with their status, score, and actions."
+                      actionLabel="Upload records"
+                      onAction={() => {
+                        const base = window.location.pathname.replace(/\/workbench.*$/, '');
+                        window.location.href = `${base}/upload`;
+                      }}
+                    />
+                  ) : (
+                    <EmptyState
+                      size="compact"
+                      illustration={<IconSearch size={40} stroke={1.5} />}
+                      title="No jobs match your filters"
+                      description="Try clearing filters or changing the hide-by-status toggle to see more jobs."
+                    />
+                  )}
                 </TableCell>
               </TableRow>
             ) : (

--- a/front-end/src/features/devel-tools/om-ocr/pages/OmOcrStudioPage/ImageHistoryPanel.tsx
+++ b/front-end/src/features/devel-tools/om-ocr/pages/OmOcrStudioPage/ImageHistoryPanel.tsx
@@ -29,6 +29,7 @@ import {
   IconSortAscending,
 } from '@tabler/icons-react';
 import { apiClient } from '@/shared/lib/axiosInstance';
+import EmptyState from '@/shared/ui/EmptyState';
 import type { OcrJob } from './types';
 
 // ─── Constants ──────────────────────────────────────────────────────────────────
@@ -183,9 +184,11 @@ const ImageHistoryPanel: React.FC<ImageHistoryPanelProps> = ({ churchId, refresh
 
   if (jobs.length === 0) {
     return (
-      <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
-        No OCR jobs found. Upload images to get started.
-      </Typography>
+      <EmptyState
+        illustration={<IconPhoto size={56} stroke={1.5} />}
+        title="No OCR history yet"
+        description="This church has no processed records. Upload baptism, marriage, or funeral ledger images to see their history here."
+      />
     );
   }
 

--- a/front-end/src/shared/ui/EmptyState.tsx
+++ b/front-end/src/shared/ui/EmptyState.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Box, Button, Stack, Typography, useTheme, alpha } from '@mui/material';
+
+/**
+ * EmptyState — friendly empty-state placeholder.
+ *
+ * Shows a soft illustration, a short title, a supporting description, and
+ * an optional call-to-action button. Use anywhere a list, table, or queue
+ * has no items yet to give users a clear next step instead of a bare
+ * "No results" line.
+ */
+export interface EmptyStateProps {
+  /** Optional illustration — either a React node (e.g. an icon component) or an image src. */
+  illustration?: React.ReactNode;
+  /** Main heading, e.g. "No OCR jobs yet". */
+  title: string;
+  /** Supporting paragraph that explains what the user can do next. */
+  description?: string;
+  /** Optional primary action label. If omitted the button is not rendered. */
+  actionLabel?: string;
+  /** Callback invoked when the action button is clicked. */
+  onAction?: () => void;
+  /** Size preset. `compact` is suited for table rows / sidebar sections, `default` for full-page empties. */
+  size?: 'compact' | 'default';
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({
+  illustration,
+  title,
+  description,
+  actionLabel,
+  onAction,
+  size = 'default',
+}) => {
+  const theme = useTheme();
+  const isCompact = size === 'compact';
+  return (
+    <Stack
+      alignItems="center"
+      spacing={isCompact ? 1.25 : 2}
+      sx={{
+        py: isCompact ? 3 : 6,
+        px: 2,
+        textAlign: 'center',
+        color: 'text.secondary',
+      }}
+    >
+      {illustration && (
+        <Box
+          aria-hidden
+          sx={{
+            width: isCompact ? 96 : 160,
+            height: isCompact ? 96 : 160,
+            borderRadius: '50%',
+            bgcolor: alpha(theme.palette.primary.main, 0.08),
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: theme.palette.primary.main,
+          }}
+        >
+          {illustration}
+        </Box>
+      )}
+      <Typography variant={isCompact ? 'subtitle1' : 'h6'} fontWeight={600} color="text.primary">
+        {title}
+      </Typography>
+      {description && (
+        <Typography
+          variant={isCompact ? 'caption' : 'body2'}
+          sx={{ maxWidth: isCompact ? 320 : 420, lineHeight: 1.55 }}
+        >
+          {description}
+        </Typography>
+      )}
+      {actionLabel && onAction && (
+        <Button variant="contained" onClick={onAction} size={isCompact ? 'small' : 'medium'}>
+          {actionLabel}
+        </Button>
+      )}
+    </Stack>
+  );
+};
+
+export default EmptyState;


### PR DESCRIPTION
## Summary
- New shared `EmptyState` component (illustration + title + description + optional CTA, compact/default sizes) at `front-end/src/shared/ui/EmptyState.tsx`
- Applied to three OCR surfaces so users see a friendly placeholder with a clear next step instead of bare text:
  - **UnifiedJobsList** — `IconFileText` + "Upload records" CTA when no jobs exist; compact `IconSearch` variant when filters return nothing
  - **ImageHistoryPanel** — `IconPhoto` + history copy
  - **ProcessedImagesTable** — `IconFileText` + processed-images copy

## Test plan
- [x] Open OCR Studio with no jobs — verify illustrated empty state with CTA
- [x] Apply filters that match nothing — verify compact filtered empty state
- [x] Open Image History panel with no items — verify illustration + copy
- [x] Open Processed Images table with no rows — verify illustration + copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)