### PR TITLE
OMD-382: Add OCR statistics widget to church dashboard

### DIFF
--- a/front-end/src/features/dashboard/ModernDashboard.tsx
+++ b/front-end/src/features/dashboard/ModernDashboard.tsx
@@ -11,6 +11,7 @@ import TypeDistributionChart from './widgets/TypeDistributionChart';
 import RecentActivityList from './widgets/RecentActivityList';
 import YearOverYearCard from './widgets/YearOverYearCard';
 import CompletenessGauge from './widgets/CompletenessGauge';
+import OcrStatsCard from './widgets/OcrStatsCard';
 
 interface DashboardData {
   counts: { baptisms: number; marriages: number; funerals: number; total: number };
@@ -107,6 +108,11 @@ const Modern = () => {
           {/* Top row: 4 count cards */}
           <Grid2 size={12}>
             <SacramentCountCards counts={data.counts} yearOverYear={data.yearOverYear} />
+          </Grid2>
+
+          {/* OCR digitization widget */}
+          <Grid2 size={12}>
+            <OcrStatsCard churchId={activeChurchId} />
           </Grid2>
 
           {/* Middle row: bar chart + donut */}

--- a/front-end/src/features/dashboard/widgets/OcrStatsCard.tsx
+++ b/front-end/src/features/dashboard/widgets/OcrStatsCard.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import { Box, Paper, Skeleton, Typography, useTheme } from '@mui/material';
+import Grid2 from '@/components/compat/Grid2';
+import {
+  IconScan,
+  IconCalendarStats,
+  IconClipboardCheck,
+} from '@tabler/icons-react';
+import { apiClient } from '@/api/utils/axiosInstance';
+
+interface OcrStats {
+  totalDigitized: number;
+  pagesThisMonth: number;
+  pendingReview: number;
+  monthLabel: string;
+}
+
+interface Props {
+  churchId: number | null;
+}
+
+const tileMeta = [
+  {
+    key: 'totalDigitized' as const,
+    label: 'Total OCR Records',
+    icon: IconScan,
+    color: '#3949ab',
+  },
+  {
+    key: 'pagesThisMonth' as const,
+    label: 'Pages This Month',
+    icon: IconCalendarStats,
+    color: '#039be5',
+  },
+  {
+    key: 'pendingReview' as const,
+    label: 'Pending Review',
+    icon: IconClipboardCheck,
+    color: '#fb8c00',
+  },
+];
+
+const OcrStatsCard = ({ churchId }: Props) => {
+  const theme = useTheme();
+  const [stats, setStats] = useState<OcrStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!churchId) {
+      setStats(null);
+      return;
+    }
+    let cancelled = false;
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await apiClient.get<any>(`/church/${churchId}/ocr/stats`);
+        if (!cancelled) setStats(res.data || res);
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err?.response?.data?.error || err?.message || 'Failed to load OCR stats');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [churchId]);
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: 'divider',
+        bgcolor: theme.palette.mode === 'dark' ? 'background.paper' : '#fff',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h6" fontWeight={600}>
+          OCR Digitization
+        </Typography>
+        {stats?.monthLabel && (
+          <Typography variant="caption" color="text.secondary">
+            {stats.monthLabel}
+          </Typography>
+        )}
+      </Box>
+
+      {error && (
+        <Typography variant="body2" color="error">
+          {error}
+        </Typography>
+      )}
+
+      {!error && (
+        <Grid2 container spacing={2}>
+          {tileMeta.map(({ key, label, icon: Icon, color }) => (
+            <Grid2 key={key} size={{ xs: 12, sm: 4 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  p: 2,
+                  borderRadius: 2,
+                  bgcolor: `${color}0F`,
+                  border: '1px solid',
+                  borderColor: `${color}33`,
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 44,
+                    height: 44,
+                    borderRadius: 2,
+                    bgcolor: `${color}1F`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                  }}
+                >
+                  <Icon size={22} color={color} />
+                </Box>
+                <Box>
+                  {loading ? (
+                    <Skeleton variant="text" width={60} height={32} />
+                  ) : (
+                    <Typography variant="h5" fontWeight={700} sx={{ lineHeight: 1.1 }}>
+                      {(stats?.[key] ?? 0).toLocaleString()}
+                    </Typography>
+                  )}
+                  <Typography variant="caption" color="text.secondary">
+                    {label}
+                  </Typography>
+                </Box>
+              </Box>
+            </Grid2>
+          ))}
+        </Grid2>
+      )}
+    </Paper>
+  );
+};
+
+export default OcrStatsCard;

--- a/server/src/routes/ocr/index.ts
+++ b/server/src/routes/ocr/index.ts
@@ -76,7 +76,13 @@ export function mountOcrRoutes(app: any, upload: any) {
   const reviewRouter = require('./review');
   app.use('/api/church/:churchId/ocr', reviewRouter);
 
-  console.log('✅ [OCR] All OCR routes mounted (admin + 6 church-scoped modules)');
+  // -------------------------------------------------------------------------
+  // 8. Church OCR statistics (dashboard widget)
+  // -------------------------------------------------------------------------
+  const statsRouter = require('./stats');
+  app.use('/api/church/:churchId/ocr', statsRouter);
+
+  console.log('✅ [OCR] All OCR routes mounted (admin + 7 church-scoped modules)');
 }
 
 // Re-export processOcrJobAsync from legacy module for feeder worker compatibility

--- a/server/src/routes/ocr/stats.ts
+++ b/server/src/routes/ocr/stats.ts
@@ -1,0 +1,74 @@
+/**
+ * Church OCR Statistics Routes
+ * Lightweight aggregate counts for the church admin dashboard widget.
+ * Mounted at /api/church/:churchId/ocr/stats
+ */
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+import { promisePool, resolveChurchDb } from './helpers';
+
+// GET /api/church/:churchId/ocr/stats
+router.get('/stats', async (req: any, res: any) => {
+  try {
+    const churchId = parseInt(req.params.churchId);
+    if (!Number.isFinite(churchId)) {
+      return res.status(400).json({ error: 'Invalid churchId' });
+    }
+
+    // Resolve church DB for fused-draft counts
+    const resolved = await resolveChurchDb(churchId);
+    if (!resolved) return res.status(404).json({ error: 'Church not found' });
+    const { db } = resolved;
+
+    // 1. Total OCR jobs successfully processed for this church (platform DB)
+    const [totalRows] = await promisePool.query(
+      `SELECT COUNT(*) AS n
+         FROM ocr_jobs
+        WHERE church_id = ?
+          AND status IN ('completed', 'complete')`,
+      [churchId]
+    );
+    const totalDigitized = Number(totalRows?.[0]?.n || 0);
+
+    // 2. Pages processed in the current calendar month (platform DB)
+    const [monthRows] = await promisePool.query(
+      `SELECT COUNT(*) AS n
+         FROM ocr_jobs
+        WHERE church_id = ?
+          AND created_at >= DATE_FORMAT(NOW(), '%Y-%m-01')
+          AND created_at <  DATE_FORMAT(NOW() + INTERVAL 1 MONTH, '%Y-%m-01')`,
+      [churchId]
+    );
+    const pagesThisMonth = Number(monthRows?.[0]?.n || 0);
+
+    // 3. Records pending review (church DB — fused drafts not yet committed)
+    let pendingReview = 0;
+    try {
+      const [pendingRows] = await db.query(
+        `SELECT COUNT(*) AS n
+           FROM ocr_fused_drafts
+          WHERE workflow_status IN ('draft', 'in_review')`
+      );
+      pendingReview = Number(pendingRows?.[0]?.n || 0);
+    } catch (e: any) {
+      // ocr_fused_drafts may not exist on older church DBs — treat as 0
+      console.warn(`[OCR Stats] ocr_fused_drafts query skipped: ${e.message}`);
+    }
+
+    // Human-readable month label, e.g. "April 2026"
+    const now = new Date();
+    const monthLabel = now.toLocaleString('en-US', { month: 'long', year: 'numeric' });
+
+    res.json({
+      totalDigitized,
+      pagesThisMonth,
+      pendingReview,
+      monthLabel,
+    });
+  } catch (error: any) {
+    console.error('[OCR Stats] Error:', error);
+    res.status(500).json({ error: 'Failed to load OCR stats', message: error.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- New backend endpoint `GET /api/church/:churchId/ocr/stats` returning total OCR records, pages processed this calendar month, and records pending review (church-scoped, mounted as 8th OCR sub-router).
- New `OcrStatsCard` dashboard widget with three colored tiles + skeleton loading + inline error display.
- Inserted into `ModernDashboard.tsx` between the sacrament count cards and the by-year chart.

## Test plan
- [x] Log in as church_admin and view dashboard — verify the OCR widget loads with three tiles
- [x] Verify totals match `SELECT COUNT(*) FROM ocr_jobs WHERE church_id=? AND status='completed'`
- [x] Verify "pages this month" matches jobs created in current calendar month
- [x] Verify "pending review" matches `ocr_fused_drafts` rows in `draft`/`in_review`
- [x] Verify graceful handling on a church DB without `ocr_fused_drafts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)