### PR TITLE
OMD-874: Fix parseDate ISO YYYY-MM-DD misparse for 2000-2099

### DIFF
--- a/server/src/services/__tests__/parseDate.test.ts
+++ b/server/src/services/__tests__/parseDate.test.ts
@@ -48,29 +48,21 @@ assertEq(parseDate(true), null, 'boolean → null (non-string)');
 // ============================================================================
 // ISO YYYY-MM-DD
 //
-// BUG (documented, see follow-up): the parser tries the (\d{1,2})-(\d{1,2})-
-// (\d{2,4}) pattern BEFORE the (\d{4})-(\d{1,2})-(\d{1,2}) pattern. For ISO
-// dates like "2020-05-12" the first pattern incorrectly matches "20-05-12"
-// → DD=20, MM=05, YY=12 → 2012-05-20. Only ISO dates whose first two YYYY
-// digits are >12 (so DD=>12 fails validation) reach the YYYY pattern. This
-// affects all dates in years 1300-2099 with leading two digits 13-20...
+// Fixed in OMD-874: parser now tries YYYY-MM-DD before DD/MM/YY, so ISO
+// dates in 2000-2099 parse correctly (previously the YY-pattern would
+// greedily match the suffix and produce wrong dates).
 // ============================================================================
-console.log('\n── ISO YYYY-MM-DD (parser order quirk) ───────────────────');
+console.log('\n── ISO YYYY-MM-DD ────────────────────────────────────────');
 
-// Years where first two digits > 12 (1300-1999, 21xx) successfully match
-// the YYYY pattern after the DD/MM/YY pattern fails validation.
-assertEq(parseDate('1985-01-01'), '1985-01-01', '1985 → first 2 digits >12 → YYYY pattern wins');
-assertEq(parseDate('1999-12-31'), '1999-12-31', '1999 NYE → YYYY pattern wins');
-assertEq(parseDate('1800-01-01'), '1800-01-01', '1800 → YYYY pattern wins');
-assertEq(parseDate('2100-12-31'), '2100-12-31', '2100 → YYYY pattern wins');
-
-// BUG: dates in 2000-2099 are misinterpreted because "20" is a valid day.
-// "2020-05-12" is parsed as DD=20/MM=05/YY=12 → 2012-05-20
-assertEq(parseDate('2020-05-12'), '2012-05-20', 'BUG: 2020-05-12 misparsed as 20/05/12 → 2012-05-20');
-assertEq(parseDate('2024-02-29'), '2029-02-24', 'BUG: 2024-02-29 misparsed as 24/02/29');
-
-// "1850-06-15" → first=18 >12, day=18, mm=50 → invalid → tries pattern 2 → ✓
-assertEq(parseDate('1850-06-15'), '1850-06-15', '1850 → first pattern fails, YYYY wins');
+assertEq(parseDate('2020-05-12'), '2020-05-12', 'YYYY-MM-DD straight (2020s)');
+assertEq(parseDate('2024-02-29'), '2024-02-29', 'leap year 2024');
+assertEq(parseDate('1985-01-01'), '1985-01-01', 'New Year ISO');
+assertEq(parseDate('1999-12-31'), '1999-12-31', 'NYE ISO');
+assertEq(parseDate('1800-01-01'), '1800-01-01', '1800 ISO (lower bound)');
+assertEq(parseDate('2100-12-31'), '2100-12-31', '2100 ISO (upper bound)');
+assertEq(parseDate('1850-06-15'), '1850-06-15', '1850 ISO');
+assertEq(parseDate('2020/05/12'), '2020-05-12', 'YYYY/MM/DD with slashes');
+assertEq(parseDate('  2020-05-12  '), '2020-05-12', 'leading/trailing whitespace trimmed');
 
 // ============================================================================
 // Unambiguous US format (MM/DD/YYYY where DD > 12)
@@ -129,9 +121,8 @@ assertEq(parseDate('5-25-2020'), '2020-05-25', 'MM-DD-YYYY with dashes (DD>12)')
 // ============================================================================
 console.log('\n── Embedded in surrounding text ──────────────────────────');
 
-// BUG: same ISO order quirk applies even with surrounding label text
-assertEq(parseDate('Date: 2020-05-12'), '2012-05-20', 'BUG: ISO embedded after label hits same order bug');
-assertEq(parseDate('Date: 1985-06-15'), '1985-06-15', 'pre-2000 ISO embedded works');
+assertEq(parseDate('Date: 2020-05-12'), '2020-05-12', 'ISO embedded after label (2020s)');
+assertEq(parseDate('Date: 1985-06-15'), '1985-06-15', 'pre-2000 ISO embedded');
 assertEq(parseDate('Born 25/12/1985 in Boston'), '1985-12-25', 'EU embedded in sentence');
 assertEq(parseDate('  on 5/25/2020.'), '2020-05-25', 'US embedded with whitespace');
 
@@ -178,13 +169,17 @@ assertEq(parseDate('05-12'), null, 'M-D without year → null (gap)');
 // ============================================================================
 console.log('\n── Range round-trip ──────────────────────────────────────');
 
-// Round-trip only works for years where the first two digits exceed 12
-// (so the buggy DD/MM/YY pattern fails validation and the YYYY pattern
-// is reached). Limited to pre-2000 / post-2099 inputs.
+// Round-trip across the full supported range now that OMD-874 reordered
+// the regex patterns so YYYY-MM-DD is tried before DD/MM/YY.
 const samples: Array<[string, string]> = [
   ['1800-01-01', '1800-01-01'],
-  ['2100-12-31', '2100-12-31'],
+  ['1850-06-15', '1850-06-15'],
+  ['1920-11-03', '1920-11-03'],
   ['1992-04-15', '1992-04-15'],
+  ['2000-01-01', '2000-01-01'],
+  ['2020-05-12', '2020-05-12'],
+  ['2099-12-31', '2099-12-31'],
+  ['2100-12-31', '2100-12-31'],
   ['1700-06-15', null as any], // year < 1800 → null
 ];
 for (const [input, expected] of samples) {

--- a/server/src/services/churchRecordEntityExtractor.js
+++ b/server/src/services/churchRecordEntityExtractor.js
@@ -755,10 +755,13 @@ class ChurchRecordEntityExtractor {
         
         const cleaned = dateText.trim();
         
-        // Try various date formats common in Orthodox registries
+        // Try various date formats common in Orthodox registries.
+        // ORDER MATTERS: YYYY-MM-DD must come first, otherwise the second
+        // pattern would greedily match "20-05-12" inside "2020-05-12" and
+        // misinterpret it as DD/MM/YY (see OMD-874).
         const patterns = [
-            /(\d{1,2})[-\/](\d{1,2})[-\/](\d{2,4})/,  // MM/DD/YY or DD/MM/YY
-            /(\d{4})[-\/](\d{1,2})[-\/](\d{1,2})/     // YYYY/MM/DD
+            /(\d{4})[-\/](\d{1,2})[-\/](\d{1,2})/,    // YYYY/MM/DD (ISO)
+            /(\d{1,2})[-\/](\d{1,2})[-\/](\d{2,4})/   // MM/DD/YY or DD/MM/YY
         ];
         
         for (const pattern of patterns) {


### PR DESCRIPTION
## Summary
- ChurchRecordEntityExtractor.parseDate had its regex patterns in the wrong order: DD/MM/YY was tried before YYYY/MM/DD, so an ISO date like \`2020-05-12\` matched the first pattern as \`20-05-12\` → 2012-05-20.
- Affected ALL OCR records with ISO dates between 2000-2099. Pre-2000/post-2099 worked by accident (validation rejected the bogus YY parse).
- Reorder so YYYY/MM/DD is tried first; update OMD-147 tests to remove the BUG markers.

## Stacked PR
This PR is stacked on top of #474 (OMD-147 parseDate tests). It updates the tests added there to assert the correct behavior. Merge #474 first, then rebase this onto main.

## Test plan
- [x] \`npx tsx server/src/services/__tests__/parseDate.test.ts\` → 56 passed, 0 failed
- [x] All previously documented BUG cases now pass with correct expected output
- [x] Round-trip range expanded to 1800-2100 inclusive

🤖 Generated with [Claude Code](https://claude.com/claude-code)