### PR TITLE
OMD-893: Add unit tests for utils/formatTimestamp + utils/tokenUtils

### DIFF
--- a/server/src/utils/__tests__/formatTimestamp.test.ts
+++ b/server/src/utils/__tests__/formatTimestamp.test.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unit tests for utils/formatTimestamp.js (OMD-893)
+ *
+ * Tiny pure helpers wrapping dayjs.
+ *
+ * Run: npx tsx server/src/utils/__tests__/formatTimestamp.test.ts
+ */
+
+const { formatTimestamp, formatTimestampUser, formatRelativeTime } = require('../formatTimestamp');
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: any, message: string): void {
+  if (cond) { console.log(`  PASS: ${message}`); passed++; }
+  else { console.error(`  FAIL: ${message}`); failed++; }
+}
+
+function assertEq<T>(actual: T, expected: T, message: string): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) { console.log(`  PASS: ${message}`); passed++; }
+  else {
+    console.error(`  FAIL: ${message}\n         expected: ${e}\n         actual:   ${a}`);
+    failed++;
+  }
+}
+
+// ============================================================================
+// formatTimestamp
+// ============================================================================
+console.log('\n── formatTimestamp ───────────────────────────────────────');
+
+// Falsy inputs return ''
+assertEq(formatTimestamp(null), '', 'null → empty string');
+assertEq(formatTimestamp(undefined), '', 'undefined → empty string');
+assertEq(formatTimestamp(''), '', 'empty string → empty string');
+assertEq(formatTimestamp(0), '', 'zero → empty string');
+
+// Date object
+const d = new Date('2025-09-15T12:34:56Z');
+const formatted = formatTimestamp(d);
+assert(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(formatted), 'date → YYYY-MM-DD HH:mm:ss');
+
+// String input
+const fromStr = formatTimestamp('2025-09-15T12:34:56Z');
+assert(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(fromStr), 'iso string → YYYY-MM-DD HH:mm:ss');
+
+// Specific date check (year extracted)
+assert(formatTimestamp('2025-01-01T00:00:00Z').startsWith('20'), 'starts with century');
+assert(formatTimestamp('2025-09-15T12:00:00Z').includes('2025'), 'contains year');
+
+// ============================================================================
+// formatTimestampUser
+// ============================================================================
+console.log('\n── formatTimestampUser ───────────────────────────────────');
+
+assertEq(formatTimestampUser(null), '', 'null → empty');
+assertEq(formatTimestampUser(undefined), '', 'undefined → empty');
+assertEq(formatTimestampUser(''), '', 'empty → empty');
+
+const userFmt = formatTimestampUser(new Date('2025-09-15T12:00:00Z'));
+// Format: 'MMM D, YYYY h:mm A' — e.g. "Sep 15, 2025 12:00 PM"
+assert(/^[A-Z][a-z]{2} \d{1,2}, \d{4} \d{1,2}:\d{2} [AP]M$/.test(userFmt), `user format pattern (got "${userFmt}")`);
+assert(userFmt.includes('2025'), 'user format includes year');
+
+// ============================================================================
+// formatRelativeTime
+// ============================================================================
+console.log('\n── formatRelativeTime ────────────────────────────────────');
+
+assertEq(formatRelativeTime(null), '', 'null → empty');
+assertEq(formatRelativeTime(undefined), '', 'undefined → empty');
+assertEq(formatRelativeTime(''), '', 'empty → empty');
+
+// "a few seconds ago" or similar for now
+const justNow = formatRelativeTime(new Date());
+assert(justNow.length > 0, 'now produces non-empty string');
+assert(justNow.includes('ago') || justNow.includes('seconds') || justNow.includes('second'), `now is recent (got "${justNow}")`);
+
+// Past date
+const longAgo = formatRelativeTime(new Date('2020-01-01'));
+assert(longAgo.includes('ago') || longAgo.includes('year'), `2020 is "ago" or "year" (got "${longAgo}")`);
+
+// Future date — dayjs returns "in X" form
+const future = formatRelativeTime(new Date(Date.now() + 86400_000 * 365));
+assert(future.includes('in') || future.includes('year'), `future is "in" or "year" (got "${future}")`);
+
+// ============================================================================
+// Summary
+// ============================================================================
+console.log(`\n──────────────────────────────────────────────────────────`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/server/src/utils/__tests__/tokenUtils.test.ts
+++ b/server/src/utils/__tests__/tokenUtils.test.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unit tests for utils/tokenUtils.js (OMD-893)
+ *
+ * Tiny pure helpers wrapping crypto.
+ *
+ * Run: npx tsx server/src/utils/__tests__/tokenUtils.test.ts
+ */
+
+const { generateToken, hashToken, verifyToken } = require('../tokenUtils');
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: any, message: string): void {
+  if (cond) { console.log(`  PASS: ${message}`); passed++; }
+  else { console.error(`  FAIL: ${message}`); failed++; }
+}
+
+function assertEq<T>(actual: T, expected: T, message: string): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) { console.log(`  PASS: ${message}`); passed++; }
+  else {
+    console.error(`  FAIL: ${message}\n         expected: ${e}\n         actual:   ${a}`);
+    failed++;
+  }
+}
+
+// ============================================================================
+// generateToken
+// ============================================================================
+console.log('\n── generateToken ─────────────────────────────────────────');
+
+const t1 = generateToken();
+const t2 = generateToken();
+
+assertEq(typeof t1, 'string', 'returns string');
+assertEq(t1.length, 64, '32 bytes hex → 64 chars');
+assertEq(t2.length, 64, 't2 also 64 chars');
+assert(/^[0-9a-f]{64}$/.test(t1), 'lowercase hex format');
+assert(t1 !== t2, 'consecutive tokens differ');
+
+// Spot-check uniqueness across many generations
+const seen = new Set<string>();
+for (let i = 0; i < 200; i++) {
+  seen.add(generateToken());
+}
+assertEq(seen.size, 200, '200 generated → 200 unique');
+
+// ============================================================================
+// hashToken
+// ============================================================================
+console.log('\n── hashToken ─────────────────────────────────────────────');
+
+const h1 = hashToken('hello');
+const h2 = hashToken('hello');
+const h3 = hashToken('world');
+
+assertEq(typeof h1, 'string', 'returns string');
+assertEq(h1.length, 64, 'sha256 hex → 64 chars');
+assert(/^[0-9a-f]{64}$/.test(h1), 'lowercase hex format');
+assertEq(h1, h2, 'deterministic: same input → same hash');
+assert(h1 !== h3, 'different input → different hash');
+
+// Known SHA-256 of "hello"
+assertEq(
+  hashToken('hello'),
+  '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+  'sha256("hello") matches known value'
+);
+
+// Empty string
+assertEq(
+  hashToken(''),
+  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+  'sha256("") matches known value'
+);
+
+// ============================================================================
+// verifyToken
+// ============================================================================
+console.log('\n── verifyToken ───────────────────────────────────────────');
+
+const token = generateToken();
+const hash = hashToken(token);
+
+assertEq(verifyToken(token, hash), true, 'matching token/hash → true');
+assertEq(verifyToken('wrong', hash), false, 'wrong token → false');
+assertEq(verifyToken(token, 'deadbeef'), false, 'wrong hash → false');
+assertEq(verifyToken('hello', hashToken('hello')), true, 'manual hello/hash → true');
+assertEq(verifyToken('Hello', hashToken('hello')), false, 'case-sensitive: Hello vs hello → false');
+
+// Roundtrip with multiple tokens
+for (let i = 0; i < 10; i++) {
+  const tk = generateToken();
+  const hs = hashToken(tk);
+  assertEq(verifyToken(tk, hs), true, `roundtrip ${i + 1}`);
+}
+
+// ============================================================================
+// Summary
+// ============================================================================
+console.log(`\n──────────────────────────────────────────────────────────`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- Bundles tests for two tiny pure helper modules
- 20 tests for `utils/formatTimestamp.js` (3 dayjs formatters)
- 28 tests for `utils/tokenUtils.js` (3 crypto helpers, including known SHA-256 values)
- Pure helpers — no DB, no I/O

## Test plan
- [x] `npx tsx server/src/utils/__tests__/formatTimestamp.test.ts` → 20 passed, 0 failed
- [x] `npx tsx server/src/utils/__tests__/tokenUtils.test.ts` → 28 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)