### PR TITLE
OMD-904: Add unit tests for safeRequire and pathResolver

### DIFF
--- a/server/src/utils/__tests__/pathResolver.test.ts
+++ b/server/src/utils/__tests__/pathResolver.test.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unit tests for utils/pathResolver.ts (OMD-904) — sync exports only
+ *
+ * Covers the pure synchronous exports that don't depend on exec/fs:
+ *   - isSambaPath           — host substring + mount point prefix
+ *   - getMountPoint         — constant
+ *   - getBaseSourcePath     — local vs remote branch
+ *   - buildSnapshotPath     — path.join
+ *   - CONFIG                — exported constants object
+ *
+ * Out of scope (require exec/fs mocking):
+ *   - isMounted, verifySambaMount, resolvePath, getMountInfo
+ *
+ * Constants under test (matched by source):
+ *   REMOTE_SAMBA_HOST = '192.168.1.221'
+ *   REMOTE_SAMBA_PATH = '/var/refactor-src'
+ *   MOUNT_POINT       = '/mnt/refactor-remote'
+ *
+ * Run: npx tsx server/src/utils/__tests__/pathResolver.test.ts
+ */
+
+import {
+  isSambaPath,
+  getMountPoint,
+  getBaseSourcePath,
+  buildSnapshotPath,
+  CONFIG
+} from '../pathResolver';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: any, message: string): void {
+  if (cond) { console.log(`  PASS: ${message}`); passed++; }
+  else { console.error(`  FAIL: ${message}`); failed++; }
+}
+
+function assertEq<T>(actual: T, expected: T, message: string): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) { console.log(`  PASS: ${message}`); passed++; }
+  else {
+    console.error(`  FAIL: ${message}\n         expected: ${e}\n         actual:   ${a}`);
+    failed++;
+  }
+}
+
+// ============================================================================
+// CONFIG
+// ============================================================================
+console.log('\n── CONFIG ────────────────────────────────────────────────');
+
+assertEq(CONFIG.REMOTE_SAMBA_HOST, '192.168.1.221', 'REMOTE_SAMBA_HOST');
+assertEq(CONFIG.REMOTE_SAMBA_PATH, '/var/refactor-src', 'REMOTE_SAMBA_PATH');
+assertEq(CONFIG.REMOTE_SAMBA_FULL, '192.168.1.221:/var/refactor-src', 'REMOTE_SAMBA_FULL');
+assertEq(CONFIG.MOUNT_POINT, '/mnt/refactor-remote', 'MOUNT_POINT');
+
+// ============================================================================
+// isSambaPath
+// ============================================================================
+console.log('\n── isSambaPath ───────────────────────────────────────────');
+
+// Empty/falsy → false
+assertEq(isSambaPath(''), false, 'empty → false');
+assertEq(isSambaPath(null as any), false, 'null → false');
+assertEq(isSambaPath(undefined as any), false, 'undefined → false');
+
+// Path containing the host substring → true
+assertEq(isSambaPath('192.168.1.221:/some/share'), true, 'host:path → true');
+assertEq(
+  isSambaPath('//192.168.1.221/share/folder'),
+  true,
+  'UNC-style with host → true'
+);
+
+// Path under mount point → true
+assertEq(isSambaPath('/mnt/refactor-remote'), true, 'exact mount point');
+assertEq(isSambaPath('/mnt/refactor-remote/sub/dir'), true, 'subdir of mount');
+assertEq(
+  isSambaPath('/mnt/refactor-remote/09-2025/prod'),
+  true,
+  'snapshot path under mount'
+);
+
+// Local paths → false
+assertEq(isSambaPath('/var/www/orthodoxmetrics/prod'), false, 'local /var path');
+assertEq(isSambaPath('/tmp/test'), false, '/tmp');
+assertEq(isSambaPath('relative/path'), false, 'relative path');
+assertEq(isSambaPath('/mnt/other-mount'), false, 'different mount → false');
+
+// ============================================================================
+// getMountPoint
+// ============================================================================
+console.log('\n── getMountPoint ─────────────────────────────────────────');
+
+assertEq(getMountPoint(), '/mnt/refactor-remote', 'no arg');
+assertEq(getMountPoint('whatever'), '/mnt/refactor-remote', 'arg ignored (constant)');
+assertEq(getMountPoint(''), '/mnt/refactor-remote', 'empty arg');
+
+// ============================================================================
+// getBaseSourcePath
+// ============================================================================
+console.log('\n── getBaseSourcePath ─────────────────────────────────────');
+
+assertEq(getBaseSourcePath('remote'), '/mnt/refactor-remote', 'remote → mount point');
+assertEq(
+  getBaseSourcePath('local'),
+  '/var/www/orthodoxmetrics/prod/refactor-src',
+  'local → hardcoded local path'
+);
+
+// ============================================================================
+// buildSnapshotPath
+// ============================================================================
+console.log('\n── buildSnapshotPath ─────────────────────────────────────');
+
+assertEq(
+  buildSnapshotPath('/mnt/refactor-remote', '09-2025'),
+  '/mnt/refactor-remote/09-2025/prod',
+  'remote base + snapshot'
+);
+assertEq(
+  buildSnapshotPath('/var/www/orthodoxmetrics/prod/refactor-src', '01-2024'),
+  '/var/www/orthodoxmetrics/prod/refactor-src/01-2024/prod',
+  'local base + snapshot'
+);
+
+// path.join normalizes — trailing slash handled
+assertEq(
+  buildSnapshotPath('/base/', '12-2025'),
+  '/base/12-2025/prod',
+  'trailing slash normalized'
+);
+
+// ============================================================================
+// Summary
+// ============================================================================
+console.log(`\n──────────────────────────────────────────────────────────`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/server/src/utils/__tests__/safeRequire.test.ts
+++ b/server/src/utils/__tests__/safeRequire.test.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unit tests for utils/safeRequire.js (OMD-904)
+ *
+ * Tiny pure module: safeRequire(modulePath, fallbackFactory, moduleName?)
+ * - Returns require()'d module on success
+ * - On MODULE_NOT_FOUND: returns fallbackFactory(), warns once per moduleName
+ * - On other errors: re-throws
+ *
+ * Run: npx tsx server/src/utils/__tests__/safeRequire.test.ts
+ */
+
+const { safeRequire } = require('../safeRequire');
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: any, message: string): void {
+  if (cond) { console.log(`  PASS: ${message}`); passed++; }
+  else { console.error(`  FAIL: ${message}`); failed++; }
+}
+
+function assertEq<T>(actual: T, expected: T, message: string): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) { console.log(`  PASS: ${message}`); passed++; }
+  else {
+    console.error(`  FAIL: ${message}\n         expected: ${e}\n         actual:   ${a}`);
+    failed++;
+  }
+}
+
+// ── Capture console.warn so we can verify dedup behavior ──────────────────
+const warnLog: string[] = [];
+const origWarn = console.warn;
+console.warn = (...args: any[]) => { warnLog.push(args.join(' ')); };
+
+// ============================================================================
+// Successful require
+// ============================================================================
+console.log('\n── safeRequire: successful require ───────────────────────');
+
+// 'path' is always available — built-in node module
+const pathMod = safeRequire('path', () => ({ stub: true }), 'path');
+assertEq(typeof pathMod.join, 'function', 'real module returned (path.join exists)');
+assertEq((pathMod as any).stub, undefined, 'fallback NOT used for real module');
+
+// fs-extra also available in repo
+const fsMod = safeRequire('fs-extra', () => ({ stub: true }), 'fs-extra');
+assertEq(typeof fsMod.pathExists, 'function', 'fs-extra loaded');
+
+// ============================================================================
+// MODULE_NOT_FOUND fallback
+// ============================================================================
+console.log('\n── safeRequire: MODULE_NOT_FOUND fallback ────────────────');
+
+warnLog.length = 0;
+
+const stub1 = safeRequire(
+  './does-not-exist-zzz-1',
+  () => ({ stub: 1, name: 'fallback1' }),
+  'missing-module-1'
+);
+assertEq(stub1.stub, 1, 'fallback returned');
+assertEq(stub1.name, 'fallback1', 'fallback name');
+assertEq(warnLog.length, 1, 'warned once on first miss');
+assert(warnLog[0].includes('does-not-exist-zzz-1'), 'warning includes path');
+assert(warnLog[0].includes('SafeRequire'), 'warning has SafeRequire tag');
+
+// Second call with same moduleName → no new warning
+const stub2 = safeRequire(
+  './does-not-exist-zzz-1',
+  () => ({ stub: 2 }),
+  'missing-module-1'
+);
+assertEq(stub2.stub, 2, 'second call still returns fallback');
+assertEq(warnLog.length, 1, 'warning deduped (still 1)');
+
+// Different moduleName → new warning
+safeRequire(
+  './does-not-exist-zzz-2',
+  () => ({}),
+  'missing-module-2'
+);
+assertEq(warnLog.length, 2, 'new moduleName → new warning');
+
+// fallbackFactory called fresh every time (not cached)
+let factoryCallCount = 0;
+const factory = () => { factoryCallCount++; return { count: factoryCallCount }; };
+safeRequire('./does-not-exist-zzz-3', factory, 'missing-module-3');
+safeRequire('./does-not-exist-zzz-3', factory, 'missing-module-3');
+assertEq(factoryCallCount, 2, 'factory called on each invocation (no caching)');
+
+// ============================================================================
+// moduleName defaults to modulePath
+// ============================================================================
+console.log('\n── safeRequire: moduleName default ───────────────────────');
+
+warnLog.length = 0;
+
+// No moduleName arg — should use modulePath as the dedup key
+safeRequire('./does-not-exist-zzz-4', () => ({}));
+assertEq(warnLog.length, 1, 'warned once');
+
+safeRequire('./does-not-exist-zzz-4', () => ({}));
+assertEq(warnLog.length, 1, 'deduped using modulePath as key');
+
+// ============================================================================
+// Non-MODULE_NOT_FOUND errors are re-thrown
+// ============================================================================
+console.log('\n── safeRequire: non-MODULE_NOT_FOUND re-thrown ───────────');
+
+// Use a real file that throws on require — write a tiny temp module that
+// throws synchronously. The error.code will not be MODULE_NOT_FOUND.
+const fs = require('fs');
+const path = require('path');
+const tmpDir = '/tmp';
+const tmpFile = path.join(tmpDir, `safeRequire-test-${Date.now()}.js`);
+fs.writeFileSync(tmpFile, 'throw new Error("intentional test error");');
+
+let caught: Error | null = null;
+try {
+  safeRequire(tmpFile, () => ({ stub: true }), 'will-throw');
+} catch (e: any) {
+  caught = e;
+}
+assert(caught !== null, 'non-MODULE_NOT_FOUND error re-thrown');
+assert(
+  caught !== null && caught.message.includes('intentional test error'),
+  'original error message preserved'
+);
+
+// Cleanup
+fs.unlinkSync(tmpFile);
+
+// ============================================================================
+// Restore console.warn and exit
+// ============================================================================
+console.warn = origWarn;
+
+console.log(`\n──────────────────────────────────────────────────────────`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- 40 unit tests across two small pure utilities
- safeRequire: 16 tests covering all branches
- pathResolver: 24 tests covering sync exports only

## safeRequire coverage
- Successful require returns the real module (verified with `path`, `fs-extra`)
- `MODULE_NOT_FOUND` triggers `fallbackFactory()`
- Warnings deduped per `moduleName` via the `warnedModules` Set
- `moduleName` defaults to `modulePath` when omitted
- `fallbackFactory` called fresh on each invocation (no caching)
- Non-`MODULE_NOT_FOUND` errors are re-thrown unchanged

## pathResolver coverage (sync exports only)
- `CONFIG` constants match (`192.168.1.221`, `/var/refactor-src`, `/mnt/refactor-remote`)
- `isSambaPath`: host substring detection, mount-point prefix detection, falsy/local rejection
- `getMountPoint`: returns the mount point constant regardless of arg
- `getBaseSourcePath`: `'remote'` → mount point, `'local'` → hardcoded local path
- `buildSnapshotPath`: joins base + snapshot ID + `'prod'` correctly

## Out of scope
The async exports (`isMounted`, `verifySambaMount`, `resolvePath`, `getMountInfo`) depend on `exec` and `fs.pathExists`, requiring child_process / fs mocking. They are deliberately not covered by this backfill.

## Test plan
- [x] `npx tsx server/src/utils/__tests__/safeRequire.test.ts` — 16 passed, 0 failed
- [x] `npx tsx server/src/utils/__tests__/pathResolver.test.ts` — 24 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)