### PR TITLE
OMD-906: Fix logger import in churchSettings (latent crash)

### DIFF
--- a/server/src/utils/churchSettings.js
+++ b/server/src/utils/churchSettings.js
@@ -4,7 +4,7 @@
  * Preserves unknown keys and handles NULL/invalid JSON gracefully
  */
 
-const { logger } = require('./logger');
+const logger = require('./logger');
 
 /**
  * Parse settings from database (LONGTEXT) to object


### PR DESCRIPTION
## Summary
- One-line fix for a latent crash in `server/src/utils/churchSettings.js`
- Discovered while writing unit tests for OMD-905 (PR #504)
- Error paths in `parseSettings` would crash on invalid JSON or non-object values

## Root cause
\`churchSettings.js\` had:
\`\`\`js
const { logger } = require('./logger');
\`\`\`
But \`logger.js\` exports the instance directly:
\`\`\`js
module.exports = new Logger();
\`\`\`
There is no \`.logger\` property on the Logger instance, so destructuring yielded \`undefined\`. On the happy path nothing broke because no logger calls fired, but error paths called \`logger.warn(...)\` and crashed:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'warn')
    at parseSettings (server/src/utils/churchSettings.js:29:12)
\`\`\`

## Fix
Single-line change:
\`\`\`diff
- const { logger } = require('./logger');
+ const logger = require('./logger');
\`\`\`

## Impact
Any church record with malformed JSON in the \`settings\` LONGTEXT column would have crashed on parse. The function was supposed to gracefully fall back to \`{}\`, log a warning, and continue — that's now what it actually does.

## Verification
\`\`\`bash
node -e \"
  const cs = require('./server/src/utils/churchSettings');
  console.log(cs.parseSettings('not json'));      // {}
  console.log(cs.parseSettings('[1,2,3]'));       // {}
  console.log(cs.parseSettings('null'));          // {}
\"
\`\`\`
All three error paths now return \`{}\` and emit a WARN to the logger instead of crashing.

## Test plan
- [x] Manual node script exercising all 3 broken error paths (invalid JSON, array, null)
- [x] Tests in PR #504 (OMD-905) cover these paths via require.cache stub
- [x] Once both PRs merge, the test stub becomes unnecessary but is harmless

🤖 Generated with [Claude Code](https://claude.com/claude-code)