### PR TITLE
OMD-1271: add /api/work-sessions/summary alias + legacy migration

### DIFF
--- a/server/database/migrations/2026-04-11_migrate_omai_work_sessions.sql
+++ b/server/database/migrations/2026-04-11_migrate_omai_work_sessions.sql
@@ -1,0 +1,73 @@
+-- OMD-1271: Unify Start Work timer
+--
+-- Migrate legacy rows from omai_db.omai_work_sessions into
+-- orthodoxmetrics_db.work_sessions so the single-source-of-truth table has
+-- the full history. After this runs, omai_db.omai_work_sessions becomes a
+-- read-only legacy table; new sessions are written to work_sessions only.
+--
+-- Field mapping:
+--   omai_work_sessions.stopped_at   -> work_sessions.ended_at
+--   omai_work_sessions.start_source -> work_sessions.source_system (default 'omai')
+--   omai_work_sessions.context_json -> work_sessions.start_context
+--   omai_work_sessions.manual_notes -> work_sessions.summary_note
+--   omai_work_sessions.stop_reason  -> work_sessions.end_context (wrapped as JSON)
+--   status 'stopped'                -> 'completed'
+--   status 'active'                 -> 'active' (preserved — see note below)
+--
+-- NOTE: Any rows with status='active' here would belong to currently running
+-- sessions in OMAI's legacy table. Since the new Berry frontend switches to
+-- /api/work-sessions/* after this migration runs, any such in-flight OMAI
+-- session is converted to an active row in work_sessions and the unified
+-- timer will pick it up on next page load.
+--
+-- This migration is idempotent via a "migration_source" marker in
+-- start_context.migrated_from so re-running it skips already-migrated rows.
+
+INSERT INTO orthodoxmetrics_db.work_sessions (
+  user_id,
+  source_system,
+  started_at,
+  ended_at,
+  duration_seconds,
+  status,
+  start_context,
+  end_context,
+  summary_note,
+  created_at,
+  updated_at
+)
+SELECT
+  o.user_id,
+  COALESCE(NULLIF(o.start_source, ''), 'omai')                         AS source_system,
+  o.started_at,
+  o.stopped_at                                                         AS ended_at,
+  o.duration_seconds,
+  CASE o.status
+    WHEN 'stopped' THEN 'completed'
+    WHEN 'active'  THEN 'active'
+    ELSE o.status
+  END                                                                  AS status,
+  JSON_OBJECT(
+    'migrated_from', 'omai_work_sessions',
+    'legacy_id',     o.id,
+    'original',      IFNULL(o.context_json, JSON_OBJECT())
+  )                                                                    AS start_context,
+  CASE WHEN o.stop_reason IS NOT NULL
+       THEN JSON_OBJECT('stop_reason', o.stop_reason)
+       ELSE NULL
+  END                                                                  AS end_context,
+  o.manual_notes                                                       AS summary_note,
+  o.created_at,
+  o.updated_at
+FROM omai_db.omai_work_sessions o
+WHERE NOT EXISTS (
+  SELECT 1 FROM orthodoxmetrics_db.work_sessions ws
+  WHERE JSON_EXTRACT(ws.start_context, '$.migrated_from') = 'omai_work_sessions'
+    AND JSON_EXTRACT(ws.start_context, '$.legacy_id')     = o.id
+);
+
+-- Optional sanity output (run manually if desired):
+-- SELECT status, COUNT(*) FROM orthodoxmetrics_db.work_sessions GROUP BY status;
+-- SELECT JSON_EXTRACT(start_context, '$.legacy_id') legacy_id, source_system, status, started_at, ended_at
+--   FROM orthodoxmetrics_db.work_sessions
+--   WHERE JSON_EXTRACT(start_context, '$.migrated_from') = 'omai_work_sessions';

--- a/server/src/routes/work-sessions.ts
+++ b/server/src/routes/work-sessions.ts
@@ -454,6 +454,105 @@ router.get('/stats', requireAuth, async (req: Request, res: Response) => {
   }
 });
 
+/**
+ * GET /api/work-sessions/summary
+ * Compact today + week totals for the header Start Work control.
+ * Returns the shape the Berry (OMAI) WorkSessionControl component expects,
+ * so both frontends can share this single endpoint.
+ *
+ * Response:
+ *   {
+ *     today: { total_seconds, sessions, active_session_seconds },
+ *     week:  { total_seconds, sessions, days_worked, avg_session_seconds, week_start, week_end }
+ *   }
+ */
+router.get('/summary', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+    const pool = getAppPool();
+
+    // Today boundaries (server local time)
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
+    const todayEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+
+    // Monday-based week boundaries
+    const dayOfWeek = now.getDay();
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    const monday = new Date(now);
+    monday.setDate(now.getDate() + mondayOffset);
+    monday.setHours(0, 0, 0, 0);
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    sunday.setHours(23, 59, 59, 999);
+    const weekStart = monday.toISOString().slice(0, 10);
+    const weekEnd = sunday.toISOString().slice(0, 10);
+
+    // Today: completed sessions only
+    const [todayRows]: any = await pool.query(
+      `SELECT COUNT(*) AS sessions,
+              COALESCE(SUM(duration_seconds), 0) AS total_seconds
+       FROM work_sessions
+       WHERE user_id = ? AND status = 'completed'
+         AND started_at >= ? AND started_at <= ?`,
+      [userId, todayStart, todayEnd]
+    );
+
+    // Active session (contributes live elapsed to today + week totals)
+    const [activeRows]: any = await pool.query(
+      `SELECT started_at FROM work_sessions
+       WHERE user_id = ? AND status = 'active' LIMIT 1`,
+      [userId]
+    );
+    const activeSeconds = activeRows.length > 0
+      ? Math.max(0, Math.floor((Date.now() - new Date(activeRows[0].started_at).getTime()) / 1000))
+      : 0;
+
+    // Week: completed sessions
+    const [weekRows]: any = await pool.query(
+      `SELECT COUNT(*) AS sessions,
+              COALESCE(SUM(duration_seconds), 0) AS total_seconds,
+              COUNT(DISTINCT DATE(started_at)) AS days_worked
+       FROM work_sessions
+       WHERE user_id = ? AND status = 'completed'
+         AND DATE(started_at) >= ? AND DATE(started_at) <= ?`,
+      [userId, weekStart, weekEnd]
+    );
+
+    const todaySessions = Number(todayRows[0].sessions) + (activeRows.length > 0 ? 1 : 0);
+    const todayTotal = Number(todayRows[0].total_seconds) + activeSeconds;
+
+    const weekCompletedSessions = Number(weekRows[0].sessions);
+    const weekSessionsIncludingActive = weekCompletedSessions + (activeRows.length > 0 ? 1 : 0);
+    const weekTotalWithActive = Number(weekRows[0].total_seconds) + activeSeconds;
+    const weekDaysWorked = Number(weekRows[0].days_worked)
+      + (Number(todayRows[0].sessions) === 0 && activeRows.length > 0 ? 1 : 0);
+
+    return res.json({
+      today: {
+        total_seconds: todayTotal,
+        sessions: todaySessions,
+        active_session_seconds: activeSeconds,
+      },
+      week: {
+        total_seconds: weekTotalWithActive,
+        sessions: weekSessionsIncludingActive,
+        days_worked: weekDaysWorked,
+        avg_session_seconds: weekSessionsIncludingActive > 0
+          ? Math.round(weekTotalWithActive / weekSessionsIncludingActive)
+          : 0,
+        week_start: weekStart,
+        week_end: weekEnd,
+      },
+    });
+  } catch (error: any) {
+    console.error('Error fetching summary:', error);
+    return res.status(500).json({ error: 'Failed to fetch summary' });
+  }
+});
+
 // ============================================================================
 // Weekly Report Endpoints
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds `GET /api/work-sessions/summary` returning `{today, week}` totals in the shape Berry's `WorkSessionControl` expects
- Adds idempotent migration copying legacy rows from `omai_db.omai_work_sessions` into `orthodoxmetrics_db.work_sessions`
- Companion to **OMD-1270** on the omai repo (Berry frontend switch + `/api/work-timer/*` deprecation)

## Why

Start Work currently logs sessions separately in two tables (`work_sessions` vs `omai_work_sessions`), so the same user gets two parallel timers — one for OM, one for OMAI. Unifying to a single table is the correct long-term fix. Nginx already routes `/api/work-sessions/*` to port 3001, so both frontends can share it.

## Test plan

- [x] Deploy and hit `GET /api/work-sessions/summary` with session cookie → returns `{today, week}` shape
- [x] Run migration → verify rows from `omai_work_sessions` land in `work_sessions` with `source_system='omai'`
- [x] Re-run migration → verify no duplicates (idempotency via `start_context.migrated_from`)
- [x] After OMD-1270 deploys: start timer in OM, navigate to OMAI Berry, confirm the running timer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)