### PR TITLE
OMD-1272: Fix Sign In button invisibility in light-primary themes

### DIFF
--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -7,30 +7,22 @@
 /* Load Tailwind config for custom values */
 @config "../tailwind.config.js";
 
-/* Fix MUI button text visibility - Tailwind preflight sets color:inherit which breaks MUI buttons */
+/* Fix MUI button text visibility — Tailwind preflight sets color:inherit which
+   breaks MUI buttons. For contained buttons, honor MUI's per-button
+   --variant-containedColor (which MUI sets from the palette contrastText), so
+   themes with a light primary (e.g. WHITE_THEME #F5F5F0) still render readable
+   text instead of white-on-cream. */
 .MuiButton-root {
   color: inherit !important;
 }
-.MuiButton-root.MuiButton-contained {
-  color: #fff !important;
-}
-.MuiButton-root.MuiButton-containedPrimary {
-  color: #fff !important;
-}
-.MuiButton-root.MuiButton-containedSecondary {
-  color: #fff !important;
-}
-.MuiButton-root.MuiButton-containedSuccess {
-  color: #fff !important;
-}
-.MuiButton-root.MuiButton-containedError {
-  color: #fff !important;
-}
-.MuiButton-root.MuiButton-containedWarning {
-  color: #fff !important;
-}
+.MuiButton-root.MuiButton-contained,
+.MuiButton-root.MuiButton-containedPrimary,
+.MuiButton-root.MuiButton-containedSecondary,
+.MuiButton-root.MuiButton-containedSuccess,
+.MuiButton-root.MuiButton-containedError,
+.MuiButton-root.MuiButton-containedWarning,
 .MuiButton-root.MuiButton-containedInfo {
-  color: #fff !important;
+  color: var(--variant-containedColor, #fff) !important;
 }
 .MuiButton-root.MuiButton-outlined,
 .MuiButton-root.MuiButton-text {


### PR DESCRIPTION
## Summary

- The global `.MuiButton-root.MuiButton-containedPrimary { color: #fff !important }` override in `front-end/src/index.css` was forcing white button text in every theme.
- Under `WHITE_THEME` (primary `#F5F5F0` cream with `contrastText: #1a1a1a`), this made the Sign In button render white-on-cream — invisible in both light and dark modes.
- Replaced the hardcoded `#fff` with `var(--variant-containedColor, #fff)` so each button uses MUI's per-button variable (which MUI sets from `palette.contrastText`). Themes with a dark primary still get white text (fallback); themes with a light primary finally get readable dark text.
- Consolidated eight separate per-color `!important` overrides into a single rule.

## Root cause

Tailwind preflight sets `button { color: inherit }`, which broke MUI buttons — hence the original override. But hardcoding `#fff` made it theme-blind. MUI already emits `--variant-containedColor` per button from the active palette; pointing the override at that variable restores theming while still beating Tailwind.

## Test plan

- [x] Deploy via `om-deploy.sh fe`
- [x] Navigate to `/auth/login` in dark mode — Sign In button computed `color: rgb(26,26,26)` on `bg: rgb(245,245,240)` (was `rgb(255,255,255)` before)
- [x] Switch to light mode, reload — same result, button readable
- [x] Admin spot-check on a theme with a dark primary (e.g. `BLUE_THEME`) to confirm white text still works there

🤖 Generated with [Claude Code](https://claude.com/claude-code)