### PR TITLE
OMD-1294: fix sdlc-automation workflow terminology

### DIFF
--- a/.github/workflows/sdlc-automation.yml
+++ b/.github/workflows/sdlc-automation.yml
@@ -1,19 +1,24 @@
 # ════════════════════════════════════════════════════════════════
-# SDLC Status Sync — Auto-update OM Daily pipeline from Git events
+# SDLC Status Sync — Auto-update OMAI Daily pipeline from Git events
 # ════════════════════════════════════════════════════════════════
 #
-# Git-to-Status Mapping:
-#   1. Backlog      → Task creation (manual — only manual step)
-#   2. In Progress  → Branch created (via start-work endpoint)
-#   3. Review & QA  → PR opened (non-draft)
-#   4. Staging      → PR approved
-#   5. Done         → PR merged into main
+# Git-to-Status Mapping (canonical 8-status model):
+#   1. Backlog      → Task created via API (agent or human)
+#   2. In Progress  → Branch created (start-work endpoint)
+#   3. Self Review  → Agent signals completion (agent-complete endpoint)
+#   4. Review       → PR opened (non-draft)
+#   5. Staging      → PR approved
+#   6. Done         → PR merged into main
 #
-# Branch naming convention: type/omd-taskID/date/slug
-#   Examples: feature/omd-636/2026-04-01/migration-logic, fix/omd-637/2026-04-01/login-redirect
-#   Legacy format also supported: feat/636-migration-logic
+# Branch naming convention: <type>/<work-item-id>/<yyyy-mm-dd>/<slug>
+#   Types: feature | fix | chore
+#   Examples:
+#     feature/omd-636/2026-04-01/migration-logic
+#     fix/omd-637/2026-04-01/login-redirect
+#     chore/omd-638/2026-04-01/update-deps
+#   Legacy format still recognized: feat/636-slug, fix/637-slug
 #
-# The webhook at /api/om-daily/webhooks/github handles the DB updates.
+# The webhook at /api/omai-daily/webhooks/github handles the DB updates.
 # This workflow provides additional GitHub-side automation (labels, comments).
 # ════════════════════════════════════════════════════════════════
 
@@ -53,13 +58,13 @@ jobs:
             echo "task_id=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
             echo "branch_type=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
             echo "has_task=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Task ID: ${BASH_REMATCH[2]}, Type: ${BASH_REMATCH[1]}"
+            echo "✅ Task ID: OMD-${BASH_REMATCH[2]}, Type: ${BASH_REMATCH[1]}"
           # Legacy format: feat/636-description
           elif [[ "$BRANCH" =~ ^(feat|fix|patch|chore)/([0-9]+)- ]]; then
             echo "task_id=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
             echo "branch_type=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
             echo "has_task=true" >> "$GITHUB_OUTPUT"
-            echo "✅ (legacy) Task ID: ${BASH_REMATCH[2]}, Type: ${BASH_REMATCH[1]}"
+            echo "✅ (legacy) Task ID: OMD-${BASH_REMATCH[2]}, Type: ${BASH_REMATCH[1]}"
           else
             echo "has_task=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ No task ID found in branch name"
@@ -122,15 +127,15 @@ jobs:
       needs.extract-task.outputs.has_task == 'true' &&
       github.event.action == 'opened'
     steps:
-      - name: Add OM Daily task link comment
+      - name: Add OMAI Daily task link comment
         run: |
           TASK_ID="${{ needs.extract-task.outputs.task_id }}"
-          BODY="🔗 **OM Daily Task:** #${TASK_ID}
-          📋 **SDLC Stage:** Review & QA
+          BODY="🔗 **OMAI Daily Task:** OMD-${TASK_ID}
+          📋 **SDLC Stage:** Review
           🌿 **Branch Type:** ${{ needs.extract-task.outputs.branch_type }}
 
           ---
-          _This PR is tracked by the OM Daily SDLC pipeline._
+          _This PR is tracked by the OMAI Daily SDLC pipeline._
           _Status will auto-update: Review → Staging (on approval) → Done (on merge)._"
 
           gh pr comment ${{ github.event.pull_request.number }} \
@@ -192,7 +197,7 @@ jobs:
           All tasks in this milestone have been completed and verified on beta.
 
           ---
-          _Auto-created by OM Daily SDLC pipeline._
+          _Auto-created by OMAI Daily SDLC pipeline._
           _Merging this PR will deploy to production._" \
             2>&1) || true
 


### PR DESCRIPTION
## Summary

Terminology cleanup on prod-current's `.github/workflows/sdlc-automation.yml`. Branch regex already matched the canonical format, so no functional regex change is needed here — only display/text fixes.

- Replace "Review & QA" with canonical "Review" (8-status model)
- Show `OMD-NNN` in PR comments instead of bare `#NNN`
- Rename "OM Daily" → "OMAI Daily" throughout (the underlying product name)
- Refresh header comment (agents can create items; Self Review is the agent-complete stage)

## Test plan

- [x] Open any PR on a canonical branch → comment shows `OMD-NNN` and stage `Review`