### PR TITLE
OMD-1296: fix isDarkMode ReferenceError on Records pages

### DIFF
--- a/front-end/src/features/records-centralized/components/records/RecordsPage.tsx
+++ b/front-end/src/features/records-centralized/components/records/RecordsPage.tsx
@@ -242,6 +242,7 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
 
   // Theme hook for dark mode detection
   const theme = useTheme();
+  const isDarkMode = theme.palette.mode === 'dark';
 
   // Toast helper functions
   const showToast = useCallback((message: string, severity: 'success' | 'error' | 'info' = 'success') => {


### PR DESCRIPTION
## Summary

`RecordsPage.tsx` referenced `isDarkMode` in four places (lines 819, 863, 909, 923) but only called `useTheme()` — never derived the flag. Every sacrament route (`/portal/records/{baptism,marriage,funeral}`) crashed into `RecordsRouteErrorBoundary` at runtime with `ReferenceError: isDarkMode is not defined`.

Fix: add `const isDarkMode = theme.palette.mode === 'dark';` right after the `useTheme()` call.

Tracks OMD-1296.

## Test plan

- [x] `/portal/records/baptism` renders without the Records Page Error boundary
- [x] Same for `/portal/records/marriage` and `/portal/records/funeral`
- [x] Dark mode styling applies correctly to StandardRecordsTable