### PR TITLE
OMD-1297: fix /assets static path pointing to wrong directory

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1449,7 +1449,8 @@ app.use('/church-branding', express.static(path.resolve(__dirname, '../storage/c
 
 // Serve static assets with long cache (hashed filenames are immutable)
 // Vite produces hashed filenames like assets/index-abc123.js, so these can be cached forever
-app.use('/assets', express.static(path.resolve(__dirname, 'assets'), {
+// __dirname is server/dist at runtime; assets live in front-end/dist/assets
+app.use('/assets', express.static(path.join(prodRoot, 'front-end/dist/assets'), {
   maxAge: '1y', // 1 year cache for hashed assets (immutable)
   immutable: true, // Mark as immutable for better caching
   etag: true,


### PR DESCRIPTION
## Summary
- Fixed `express.static` mount for `/assets` — was resolving to `server/dist/assets` (nonexistent) instead of `front-end/dist/assets` where Vite outputs hashed chunks
- This caused all dynamically imported modules to 404, returning `index.html` (text/html) instead of JS, breaking the entire frontend with: `Failed to fetch dynamically imported module`

## Root Cause
Line 1452 in `server/src/index.ts`:
```js
// Before (broken): resolves to server/dist/assets — doesn't exist
app.use('/assets', express.static(path.resolve(__dirname, 'assets'), { ... }));

// After (fixed): uses prodRoot to resolve to front-end/dist/assets
app.use('/assets', express.static(path.join(prodRoot, 'front-end/dist/assets'), { ... }));
```

## Test plan
- [x] Verified `curl -sI http://127.0.0.1:3001/assets/PublicLayout-DCaUELGN.js` returns `Content-Type: application/javascript` (was returning `text/html`)
- [x] Verified site loads in browser — login page renders correctly with all assets
- [x] Hotfixed prod `dist/index.js` and restarted backend for immediate recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)