### PR TITLE
OMD-1298: clean up sidebar menu for migrated/removed features

### DIFF
--- a/front-end/src/layouts/full/vertical/sidebar/MenuItems.ts
+++ b/front-end/src/layouts/full/vertical/sidebar/MenuItems.ts
@@ -344,18 +344,6 @@ const Menuitems: MenuitemsType[] = [
     children: [
       {
         id: uniqueId(),
-        title: 'OMAI Lab',
-        icon: IconRocket,
-        href: '/sandbox/ai-lab',
-      },
-      {
-        id: uniqueId(),
-        title: 'Project Generator',
-        icon: IconEdit,
-        href: '/sandbox/project-generator',
-      },
-      {
-        id: uniqueId(),
         title: 'AI Admin Panel',
         icon: IconRocket,
         href: '/admin/ai',
@@ -369,7 +357,6 @@ const Menuitems: MenuitemsType[] = [
     ],
   },
 
-  // Berry Components section removed — CRM, Calendar, Map, Cards prototypes retired
   // ========================================================================
   // DEVELOPER TOOLS (super_admin only)
   // ========================================================================
@@ -425,7 +412,6 @@ const Menuitems: MenuitemsType[] = [
         icon: IconTool,
         href: '/devel-tools/refactor-console',
       },
-      // API Explorer — migrated to OMAI (OMD-1283)
       {
         id: uniqueId(),
         title: 'OM Permission Center',


### PR DESCRIPTION
## Summary
- Removed **OMAI Lab** (`/sandbox/ai-lab`) — route doesn't exist
- Removed **Project Generator** (`/sandbox/project-generator`) — route doesn't exist
- Removed orphan comment for API Explorer migration (already done in OMD-1283)
- Removed orphan comment for retired Berry Components section

AI & Automation section retains the two real items (AI Admin Panel, Code Change Detection).

## Test plan
- [x] Verified all remaining menu hrefs have corresponding route definitions
- [x] Verified no imports became unused after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)