### PR TITLE
OMD-1303: add test-omd-1302.sh to run OMD-1302 test plan and store results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ yarn-debug.log*
 .env
 .env.*
 *.env
+# Allow .env.example templates to be tracked (no secrets, just documented var names).
+!**/.env.example
 # --- Secrets & certificates (specific file types, not broad name matches) ---
 **/*.pem
 **/*.crt
@@ -160,7 +162,8 @@ followup.txt
 reports/
 prod-backup/
 front-end/server/
-server/scripts/
+# server/scripts/ is tracked — contains build tooling required for fresh clones.
+# Local backups under server/scripts/backups/ are still ignored (see earlier rule).
 .snapshots/
 .branch-notes.json
 
@@ -168,8 +171,10 @@ server/scripts/
 orthodoxmetrics.com
 inner-orthodoxmetrics.com
 
-# Scripts live in /var/omai-ops/scripts/orthodoxmetrics/ (outside repo)
-scripts/
+# Root-level scripts/ currently lives outside the repo (in /var/omai-ops/scripts/orthodoxmetrics/).
+# Anchored with a leading slash so this only ignores the root dir and does NOT
+# match server/scripts/ (which is tracked for build tooling).
+/scripts/
 
 # Docs live in /var/omai-ops/docs/orthodoxmetrics/ (outside repo)
 docs/

--- a/front-end/.env.example
+++ b/front-end/.env.example
@@ -1,0 +1,44 @@
+# OrthodoxMetrics Frontend Environment Configuration — Template
+#
+# Copy this file to `.env` in the same directory (front-end/.env) and fill in
+# the real values. `.env` is gitignored and must never be committed.
+#
+# All variables are baked into the Vite bundle at build time. Do NOT put
+# server-side secrets here. Only values safe to expose in the browser belong
+# in VITE_* variables.
+
+# --- API ---
+
+# Base path the frontend uses for API calls. Under normal deployments this is
+# a relative path so nginx can reverse-proxy /api to the backend. Override only
+# when the frontend runs on a different origin than the backend.
+VITE_API_BASE=/api
+
+# Absolute API base URL. Leave empty for relative routing via VITE_API_BASE.
+# Use this when the frontend is served from a different origin than the API
+# (e.g., local dev hitting a remote staging backend).
+VITE_API_BASE_URL=
+
+# --- Runtime flags ---
+
+# true in development/staging, false in production builds.
+VITE_DEV_MODE=true
+
+# Session idle timeout on the client, in milliseconds. 3600000 = 1 hour.
+VITE_SESSION_TIMEOUT=3600000
+
+# --- Debug toggles (set false in production) ---
+
+# Log authentication state transitions to the browser console.
+VITE_DEBUG_AUTH=false
+
+# Log API requests and responses to the browser console.
+VITE_DEBUG_API=false
+
+# --- Third-party keys ---
+
+# Mapbox public access token for the map component (Berry UI). Public tokens
+# are URL-referrer scoped on Mapbox's side and safe to ship in the bundle, but
+# each environment should use its own to keep usage metering clean.
+# Get one at https://account.mapbox.com/access-tokens/
+VITE_APP_MAPBOX_ACCESS_TOKEN=pk.your-mapbox-public-token-here

--- a/server/scripts/build-all.js
+++ b/server/scripts/build-all.js
@@ -1,0 +1,553 @@
+#!/usr/bin/env node
+
+/**
+ * Build script that builds both backend and frontend in parallel,
+ * then restarts PM2 orthodox-backend service.
+ * 
+ * Professional output presentation with --verbose and --quiet modes.
+ */
+
+// Load .env file before anything else (so build-event-emitter can access OM_BUILD_EVENT_TOKEN)
+try {
+    const dotenv = require('dotenv');
+    const path = require('path');
+    const fs = require('fs');
+    const envPath = path.join(__dirname, '..', '.env');
+    if (fs.existsSync(envPath)) {
+        const result = dotenv.config({ path: envPath });
+        if (result.error) {
+            console.warn('⚠️  Failed to load .env file:', result.error.message);
+        } else {
+            // Verify token was loaded
+            const token = process.env.OM_BUILD_EVENT_TOKEN;
+            if (token) {
+                // Token loaded successfully - trim any whitespace/quotes
+                process.env.OM_BUILD_EVENT_TOKEN = token.trim().replace(/^["']|["']$/g, '');
+            }
+        }
+    } else {
+        console.warn('⚠️  .env file not found at:', envPath);
+    }
+} catch (e) {
+    // dotenv not available - continue without it
+    console.warn('⚠️  dotenv not available:', e.message);
+}
+
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const path = require('path');
+const fs = require('fs');
+const buildHistory = require('./build-history');
+const BuildProgress = require('./build-progress');
+const BuildPresenter = require('./build-presenter');
+const buildEmitter = require('./build-event-emitter');
+
+const execAsync = promisify(exec);
+
+const SERVER_DIR = __dirname + '/..';
+const FRONTEND_DIR = path.join(SERVER_DIR, '..', 'front-end');
+const OM_NFO_PATH = path.join(__dirname, 'om.nfo');
+
+/**
+ * Parse CLI arguments
+ * Uses --om-verbose to avoid npm loglevel conflicts
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  return {
+    verbose: args.includes('--om-verbose'),
+    quiet: args.includes('--om-quiet'),
+    noProgress: args.includes('--om-no-progress'),
+    noBanner: args.includes('--no-banner'),
+    noAnim: args.includes('--om-no-anim')
+  };
+}
+
+/**
+ * Spinner state and animation
+ */
+const spinnerState = {
+  interval: null,
+  frameIndex: 0,
+  currentStageName: '',
+  stageStartTime: null,
+  buildStartTime: null,
+  enabled: false
+};
+
+/**
+ * Spinner frames (Unicode dots)
+ */
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/**
+ * Start the animated spinner
+ */
+function startSpinner(args) {
+  // Only animate if TTY, not quiet, not noAnim
+  if (!process.stdout.isTTY || args.quiet || args.noAnim) {
+    spinnerState.enabled = false;
+    return;
+  }
+  
+  spinnerState.enabled = true;
+  spinnerState.buildStartTime = Date.now();
+  spinnerState.frameIndex = 0;
+  
+  spinnerState.interval = setInterval(() => {
+    if (!spinnerState.enabled) return;
+    
+    const frame = SPINNER_FRAMES[spinnerState.frameIndex % SPINNER_FRAMES.length];
+    spinnerState.frameIndex++;
+    
+    const totalElapsed = ((Date.now() - spinnerState.buildStartTime) / 1000).toFixed(1);
+    const stageName = spinnerState.currentStageName || 'Initializing';
+    
+    // Calculate terminal width (default to 80 if not available)
+    const cols = process.stdout.columns || 80;
+    const statusLine = ` ${frame}  Running: ${stageName}   (elapsed ${totalElapsed}s)`;
+    const padding = ' '.repeat(Math.max(0, cols - statusLine.length - 1));
+    
+    process.stdout.write(`\r${statusLine}${padding}`);
+  }, 100);
+}
+
+/**
+ * Stop the animated spinner and clear the line
+ */
+function stopSpinner() {
+  if (spinnerState.interval) {
+    clearInterval(spinnerState.interval);
+    spinnerState.interval = null;
+  }
+  
+  if (spinnerState.enabled) {
+    // Clear the spinner line
+    const cols = process.stdout.columns || 80;
+    process.stdout.write('\r' + ' '.repeat(cols - 1) + '\r');
+  }
+  
+  spinnerState.enabled = false;
+}
+
+/**
+ * Update the current stage name for the spinner
+ */
+function updateSpinnerStage(stageName) {
+  spinnerState.currentStageName = stageName;
+  spinnerState.stageStartTime = Date.now();
+}
+
+/**
+ * Run command with buffered output (no live printing in default mode)
+ */
+async function runCommand(command, cwd, label, presenter, progress = null, stageResults = null) {
+  const startTime = Date.now();
+  
+  // Update spinner with current stage name
+  updateSpinnerStage(label);
+  
+  // Emit stage_started event
+  await buildEmitter.stageStarted(label).catch(() => {});
+  
+  try {
+    // Buffer all output - don't print live in default mode
+    const { stdout, stderr } = await execAsync(command, { 
+      cwd,
+      maxBuffer: 10 * 1024 * 1024 // 10MB buffer for large outputs
+    });
+    
+    const buildTime = (Date.now() - startTime) / 1000;
+    const durationMs = Math.round(buildTime * 1000);
+    const fullOutput = (stdout || '') + (stderr || '');
+    
+    // Emit stage_completed event
+    await buildEmitter.stageCompleted(label, durationMs).catch(() => {});
+    
+    // Record warnings
+    presenter.recordWarnings(label, fullOutput);
+    
+    // Print output only in verbose mode
+    if (presenter.verbose) {
+      presenter.printCommandOutput(label, stdout, false);
+      if (stderr && stderr.trim()) {
+        presenter.printCommandOutput(label, stderr, false);
+      }
+    }
+    
+    // Record stage result for table
+    if (stageResults) {
+      stageResults.push({
+        name: label,
+        status: 'Completed',
+        durationSec: buildTime
+      });
+    }
+    
+    return { 
+      success: true, 
+      output: stdout, 
+      stderr: stderr || '', 
+      buildTime,
+      fullOutput 
+    };
+  } catch (error) {
+    const buildTime = (Date.now() - startTime) / 1000;
+    const errorOutput = (error.stdout || '') + (error.stderr || '');
+    
+    // Record failed stage for table
+    if (stageResults) {
+      stageResults.push({
+        name: label,
+        status: 'Failed',
+        durationSec: buildTime
+      });
+    }
+    
+    // Print error summary (always show failures)
+    presenter.printErrorSummary(error, label, errorOutput);
+    
+    throw { ...error, buildTime, output: errorOutput };
+  }
+}
+
+/**
+ * Build backend with buffered output
+ */
+async function buildBackend(presenter, progress, stageIndices, stageResults) {
+  const backendChanges = buildHistory.getBackendChanges();
+  const totalBackendTime = { value: 0 };
+  let backendOutput = '';
+  
+  // Stage 1: Clean
+  const cleanResult = await runCommand(
+    'npm run build:clean', 
+    SERVER_DIR, 
+    'Backend Clean', 
+    presenter, 
+    progress,
+    stageResults
+  );
+  totalBackendTime.value += cleanResult.buildTime || 0;
+  backendOutput += cleanResult.fullOutput || '';
+  if (progress && stageIndices.clean !== undefined) {
+    progress.updateStep(stageIndices.clean, true);
+  }
+  
+  // Stage 2: TypeScript Compilation
+  const tsResult = await runCommand(
+    'npm run build:ts', 
+    SERVER_DIR, 
+    'Backend TypeScript', 
+    presenter, 
+    progress,
+    stageResults
+  );
+  totalBackendTime.value += tsResult.buildTime || 0;
+  backendOutput += tsResult.fullOutput || '';
+  if (progress && stageIndices.ts !== undefined) {
+    progress.updateStep(stageIndices.ts, true);
+  }
+  
+  // Stage 3: Copy Files
+  const copyResult = await runCommand(
+    'npm run build:copy', 
+    SERVER_DIR, 
+    'Backend Copy', 
+    presenter, 
+    progress,
+    stageResults
+  );
+  totalBackendTime.value += copyResult.buildTime || 0;
+  backendOutput += copyResult.fullOutput || '';
+  if (progress && stageIndices.copy !== undefined) {
+    progress.updateStep(stageIndices.copy, true);
+  }
+  
+  // Stage 4: Verify Build
+  const verifyResult = await runCommand(
+    'npm run build:verify', 
+    SERVER_DIR, 
+    'Backend Verify', 
+    presenter, 
+    progress,
+    stageResults
+  );
+  totalBackendTime.value += verifyResult.buildTime || 0;
+  backendOutput += verifyResult.fullOutput || '';
+  if (progress && stageIndices.verify !== undefined) {
+    progress.updateStep(stageIndices.verify, true);
+  }
+  
+  // Record build with changes
+  buildHistory.recordBuild('backend', {
+    ...backendChanges,
+    buildTime: totalBackendTime.value
+  }, totalBackendTime.value, true);
+  
+  return { 
+    success: true, 
+    buildTime: totalBackendTime.value,
+    files: backendChanges
+  };
+}
+
+/**
+ * Build frontend with buffered output
+ */
+async function buildFrontend(presenter, progress, stepIndex, stageResults) {
+  if (!fs.existsSync(FRONTEND_DIR)) {
+    throw new Error(`Frontend directory not found: ${FRONTEND_DIR}`);
+  }
+  
+  const frontendChanges = buildHistory.getFrontendChanges();
+  
+  const result = await runCommand(
+    'npm run build', 
+    FRONTEND_DIR, 
+    'Frontend Build', 
+    presenter, 
+    progress,
+    stageResults
+  );
+  
+  // Print Vite summary only in verbose mode (otherwise shown in table)
+  if (presenter.verbose) {
+    const viteSummary = presenter.extractViteSummary(result.fullOutput);
+    presenter.printViteSummary(viteSummary);
+  }
+  
+  if (progress && stepIndex !== undefined) {
+    progress.updateStep(stepIndex, true);
+  }
+  
+  // Record build with changes
+  const buildTime = result.buildTime || 0;
+  buildHistory.recordBuild('frontend', {
+    ...frontendChanges,
+    buildTime
+  }, buildTime, result.success !== false);
+  
+  return {
+    ...result,
+    files: frontendChanges
+  };
+}
+
+/**
+ * Restart PM2 with buffered output
+ */
+async function restartPM2(presenter, progress, stepIndex, stageResults) {
+  const stageStartTime = Date.now();
+  
+  // Emit stage_started for PM2 Restart
+  await buildEmitter.stageStarted('PM2 Restart').catch(() => {});
+  
+  try {
+    const result = await runCommand(
+      'pm2 restart orthodox-backend', 
+      SERVER_DIR, 
+      'PM2 Restart', 
+      presenter, 
+      progress,
+      stageResults
+    );
+    
+    if (progress && stepIndex !== undefined) {
+      progress.updateStep(stepIndex, true);
+    }
+    
+    // Emit stage_completed for PM2 Restart
+    const durationMs = Date.now() - stageStartTime;
+    await buildEmitter.stageCompleted('PM2 Restart', durationMs).catch(() => {});
+    
+    return result;
+  } catch (error) {
+    // Emit stage failure
+    const durationMs = Date.now() - stageStartTime;
+    await buildEmitter.emit('stage_completed', {
+      stage: 'PM2 Restart',
+      message: error.message || 'PM2 restart failed',
+      durationMs
+    }).catch(() => {});
+    throw error;
+  }
+}
+
+/**
+ * Main build function
+ */
+async function main() {
+  const args = parseArgs();
+  const presenter = new BuildPresenter({
+    verbose: args.verbose,
+    quiet: args.quiet,
+    showProgress: !args.noProgress
+  });
+  
+  presenter.printHeader();
+  
+  const startTime = Date.now();
+  
+  // Emit build_started event and start heartbeat
+  try {
+    await buildEmitter.startBuild({
+      command: process.argv.join(' '),
+      env: process.env.NODE_ENV || 'production'
+    });
+  } catch (err) {
+    console.warn('⚠️  Failed to emit build_started event (non-fatal):', err.message);
+  }
+  
+  // Initialize progress bar
+  const progress = args.noProgress ? null : new BuildProgress();
+  
+  // Backend stages (sequential)
+  const backendCleanIndex = progress ? progress.addStep('Backend Clean', 1) : null;
+  const backendTsIndex = progress ? progress.addStep('Backend TypeScript', 1) : null;
+  const backendCopyIndex = progress ? progress.addStep('Backend Copy', 1) : null;
+  const backendVerifyIndex = progress ? progress.addStep('Backend Verify', 1) : null;
+  
+  // Frontend stage (runs in parallel with backend)
+  const frontendIndex = progress ? progress.addStep('Frontend Build', 1) : null;
+  
+  // PM2 restart (runs after both complete)
+  const pm2Index = progress ? progress.addStep('PM2 Restart', 1) : null;
+  
+  const stageIndices = {
+    clean: backendCleanIndex,
+    ts: backendTsIndex,
+    copy: backendCopyIndex,
+    verify: backendVerifyIndex
+  };
+  
+  // Stage results collection
+  const stageResults = [];
+  
+  // Start animated spinner (if enabled)
+  startSpinner(args);
+  
+  // Print initial progress bar (0%) - only if not using spinner
+  if (!spinnerState.enabled) {
+    if (progress && presenter.showProgress && !args.quiet) {
+      process.stdout.write(`[${'░'.repeat(50)}] 0%`);
+      console.log(' Starting build process…');
+    } else if (!args.quiet && !progress) {
+      console.log('Starting build process…');
+    }
+  } else {
+    // For non-TTY, print a simple status line
+    if (!process.stdout.isTTY && !args.quiet) {
+      console.log('Starting build process…');
+    }
+  }
+  
+  try {
+    // Run backend stages sequentially and frontend build in parallel
+    const [backendResult, frontendResult] = await Promise.all([
+      buildBackend(presenter, progress, stageIndices, stageResults),
+      buildFrontend(presenter, progress, frontendIndex, stageResults)
+    ]);
+    
+    // Restart PM2 service after both builds complete
+    const pm2Result = await restartPM2(presenter, progress, pm2Index, stageResults);
+    
+    // Give backend a moment to fully start after PM2 restart
+    // PM2 restart command returns quickly, but backend needs time to bind to port
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    
+    // Stop spinner before printing final output
+    stopSpinner();
+    
+    // Clear progress bar and print stage table
+    if (progress && presenter.showProgress) {
+      progress.clear();
+    }
+    
+    // Print stage table
+    if (!args.quiet) {
+      presenter.printStageTable(stageResults);
+    }
+    
+    // Print final progress bar (100%) - only if not using spinner
+    if (!spinnerState.enabled) {
+      if (progress && presenter.showProgress && !args.quiet) {
+        process.stdout.write(`[${'█'.repeat(50)}] 100%`);
+        console.log(' Build & Deploy Complete');
+      } else if (!args.quiet && !progress) {
+        console.log('Build & Deploy Complete');
+      }
+    }
+    
+    const duration = (Date.now() - startTime) / 1000;
+    
+    // Record full build
+    const backendChanges = buildHistory.getBackendChanges();
+    const frontendChanges = buildHistory.getFrontendChanges();
+    buildHistory.recordBuild('full', {
+      changed: [...backendChanges.changed, ...frontendChanges.changed],
+      added: [...backendChanges.added, ...frontendChanges.added],
+      removed: [...backendChanges.removed, ...frontendChanges.removed]
+    }, duration, true);
+    
+    // Print warnings summary
+    presenter.printWarningsSummary();
+    
+    // Print build summary
+    presenter.printBuildSummary({
+      totalTime: duration,
+      backendTime: backendResult.buildTime,
+      frontendTime: frontendResult.buildTime,
+      pm2Time: pm2Result.buildTime,
+      backendFiles: backendResult.files,
+      frontendFiles: frontendResult.files
+    });
+    
+    // Print OM.nfo banner (unless --no-banner)
+    if (!args.noBanner) {
+      presenter.printOmNfo(OM_NFO_PATH);
+    }
+    
+    // Print build history
+    const history = buildHistory.getHistory(5);
+    presenter.printBuildHistory(history);
+    
+    // Emit build_completed event
+    try {
+      await buildEmitter.buildCompleted({
+        durationSeconds: duration
+      });
+    } catch (err) {
+      console.warn('⚠️  Failed to emit build_completed event (non-fatal):', err.message);
+    }
+    
+    process.exit(0);
+  } catch (error) {
+    const duration = (Date.now() - startTime) / 1000;
+    
+    // Emit build_failed event
+    try {
+      await buildEmitter.buildFailed(error, error.stage || null);
+    } catch (err) {
+      console.warn('⚠️  Failed to emit build_failed event (non-fatal):', err.message);
+    }
+    
+    // Stop spinner immediately on failure
+    stopSpinner();
+    
+    if (progress && presenter.showProgress) {
+      progress.clear();
+    }
+    
+    // Print stage table even on failure (shows which stages completed)
+    if (!args.quiet && stageResults.length > 0) {
+      presenter.printStageTable(stageResults);
+    }
+    
+    presenter.printErrorSummary(error, 'Build Process', error.output || error.message);
+    
+    process.exit(1);
+  }
+}
+
+main();

--- a/server/scripts/build-copy.js
+++ b/server/scripts/build-copy.js
@@ -1,0 +1,113 @@
+/*
+  Post-build copy step to make dist/ self-contained.
+  - Copies JS runtime modules that are not emitted by tsc
+  - Preserves directory structure under dist/
+*/
+
+const path = require('path');
+const fs = require('fs');
+const fse = require('fs-extra');
+
+const ROOT = path.resolve(__dirname, '..');
+const DIST = path.join(ROOT, 'dist');
+
+function exists(p) {
+  try { return fs.existsSync(p); } catch { return false; }
+}
+
+async function copyDir(srcRel, destRel, { filter } = {}) {
+  const src = path.join(ROOT, srcRel);
+  const dest = path.join(DIST, destRel);
+  if (!exists(src)) return; // nothing to copy
+  await fse.ensureDir(dest);
+  await fse.copy(src, dest, {
+    overwrite: true,
+    filter: (srcPath) => {
+      if (typeof filter === 'function') return filter(srcPath);
+      // default: exclude TypeScript sources from copy
+      return !srcPath.endsWith('.ts') && !srcPath.endsWith('.tsx');
+    }
+  });
+  console.log(`[build-copy] Copied ${srcRel} -> ${destRel}`);
+}
+
+async function copyFile(srcRel, destRel, { required = false } = {}) {
+  const src = path.join(ROOT, srcRel);
+  const dest = path.join(DIST, destRel);
+  if (!exists(src)) {
+    if (required) {
+      throw new Error(`Required file not found: ${srcRel}`);
+    }
+    return; // optional
+  }
+  await fse.ensureDir(path.dirname(dest));
+  await fse.copy(src, dest, { overwrite: true });
+  console.log(`[build-copy] Copied ${srcRel} -> ${destRel}`);
+}
+
+async function main() {
+  // Ensure dist exists
+  await fse.ensureDir(DIST);
+
+  // All source code now lives under src/. TypeScript files are compiled by tsc,
+  // but plain .js files need to be copied into dist/ since allowJs may be off.
+  // The dist/ layout mirrors src/ but without the src/ prefix:
+  //   src/routes/    -> dist/routes/
+  //   src/api/       -> dist/api/
+  //   src/middleware/ -> dist/middleware/
+  //   etc.
+
+  // Core JS modules from src/
+  await copyDir('src/api', 'api');
+  await copyDir('src/routes', 'routes');
+  await copyDir('src/middleware', 'middleware');
+  await copyDir('src/controllers', 'controllers');
+  await copyDir('src/services', 'services');
+  await copyDir('src/utils', 'utils');
+  await copyDir('src/config', 'config');
+  await copyDir('src/models', 'models');
+  await copyDir('src/dal', 'dal');
+  await copyDir('src/integrations', 'integrations');
+  await copyDir('src/webhooks', 'webhooks');
+  await copyDir('src/websockets', 'websockets');
+  await copyDir('src/certificates', 'certificates');
+  await copyDir('src/modules', 'modules');
+  await copyDir('src/ocr', 'ocr');
+  await copyDir('src/workers', 'workers');
+  await copyDir('src/features', 'features');
+  await copyDir('src/logs', 'logs');
+  await copyDir('src/agents', 'agents');
+  await copyDir('src/db', 'db');
+  await copyDir('src/maintenance', 'maintenance');
+
+  // Database schemas/migrations (not in src/, stays at root)
+  await copyDir('database', 'database');
+
+  // Verify critical files in dist/
+  const sessionFile = path.join(DIST, 'config/session.js');
+  if (!exists(sessionFile)) {
+    console.error('[build-copy] ❌ ERROR: dist/config/session.js not found after copy');
+  } else {
+    console.log('[build-copy] ✅ Verified dist/config/session.js exists');
+  }
+
+  const dbFile = path.join(DIST, 'config/db.js');
+  if (exists(dbFile)) {
+    const dbContent = fs.readFileSync(dbFile, 'utf8');
+    if (!dbContent.includes('getAppPool')) {
+      console.warn('[build-copy] ⚠️  WARNING: dist/config/db.js may not have getAppPool export');
+    } else {
+      console.log('[build-copy] ✅ Verified dist/config/db.js has getAppPool export');
+    }
+  }
+
+  // Static assets to serve from dist/assets
+  await copyDir('src/assets', 'assets', {
+    filter: () => true // copy everything under assets
+  });
+}
+
+main().catch((err) => {
+  console.error('[build-copy] Failed:', err);
+  process.exit(1);
+});

--- a/server/scripts/build-event-emitter.js
+++ b/server/scripts/build-event-emitter.js
@@ -1,0 +1,395 @@
+/**
+ * Build Event Emitter
+ * Utility for emitting build lifecycle events to the backend
+ * 
+ * Usage:
+ *   const emitter = require('./build-event-emitter');
+ *   await emitter.emit('build_started', { runId, env, origin, command, host, pid });
+ */
+
+const http = require('http');
+const https = require('https');
+const { v4: uuidv4 } = require('uuid');
+const os = require('os');
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+// Load .env file if it exists (for build scripts running outside of server context)
+// This runs when the module is first required, before the class is instantiated
+try {
+    const dotenv = require('dotenv');
+    const envPath = path.join(__dirname, '..', '.env');
+    if (fs.existsSync(envPath)) {
+        const result = dotenv.config({ path: envPath });
+        // dotenv.config() doesn't throw, but result.error indicates issues
+        if (result.error) {
+            console.warn('⚠️  [build-event-emitter] Failed to load .env:', result.error.message);
+        }
+    }
+} catch (e) {
+    // dotenv not available - use process.env as-is
+    // Don't warn here as build-all.js will handle it
+}
+
+class BuildEventEmitter {
+    constructor() {
+        this.runId = uuidv4();
+        this.baseUrl = process.env.OM_BUILD_EVENT_URL || 'http://127.0.0.1:3001';
+        // Read token from env (trim whitespace in case .env has spaces)
+        this.token = process.env.OM_BUILD_EVENT_TOKEN ? process.env.OM_BUILD_EVENT_TOKEN.trim() : null;
+        this.hostname = os.hostname();
+        this.pid = process.pid;
+        this.heartbeatInterval = null;
+        // Map NODE_ENV to database ENUM values ('prod', 'staging', 'dev')
+        const nodeEnv = process.env.NODE_ENV || 'production';
+        if (nodeEnv === 'production' || nodeEnv === 'prod') {
+            this.env = 'prod';
+        } else if (nodeEnv === 'staging' || nodeEnv === 'stage') {
+            this.env = 'staging';
+        } else {
+            this.env = 'dev'; // Default to 'dev' for development, test, etc.
+        }
+        this.origin = 'server'; // Can be overridden
+        this.command = process.argv.join(' '); // Full command line
+        this.startTime = Date.now();
+        
+        // Try to get git info (non-blocking)
+        this.gitInfo = this.getGitInfo();
+
+        // Auto-detect origin from script path
+        if (process.argv[1]) {
+            const scriptPath = process.argv[1];
+            if (scriptPath.includes('build-all.js')) {
+                this.origin = 'server';
+            } else if (scriptPath.includes('build-smart.js')) {
+                this.origin = 'server';
+            } else if (scriptPath.includes('build-harness.mjs')) {
+                this.origin = 'root-harness';
+            } else if (scriptPath.includes('front-end')) {
+                this.origin = 'frontend';
+            }
+        }
+    }
+
+    /**
+     * Get git information (repo, branch, commit)
+     * Returns null if git is not available or not in a git repo
+     */
+    getGitInfo() {
+        try {
+            const fs = require('fs');
+            // Find repo root (go up from current script location)
+            let repoRoot = __dirname;
+            for (let i = 0; i < 5; i++) {
+                if (fs.existsSync(path.join(repoRoot, '.git'))) {
+                    break;
+                }
+                repoRoot = path.dirname(repoRoot);
+            }
+
+            const repo = 'orthodoxmetrics'; // Hardcoded repo name
+            const branch = execSync('git rev-parse --abbrev-ref HEAD', { 
+                cwd: repoRoot, 
+                encoding: 'utf8',
+                stdio: ['ignore', 'pipe', 'ignore']
+            }).trim();
+            const commit = execSync('git rev-parse HEAD', { 
+                cwd: repoRoot, 
+                encoding: 'utf8',
+                stdio: ['ignore', 'pipe', 'ignore']
+            }).trim().substring(0, 7); // Short commit hash
+
+            return { repo, branch, commit };
+        } catch (error) {
+            // Git not available or not in repo - return null
+            return null;
+        }
+    }
+
+    /**
+     * Emit a build event
+     * @param {string} event - Event type
+     * @param {Object} data - Event data
+     * @returns {Promise<boolean>} Success status
+     */
+    async emit(event, data = {}) {
+        // Re-check token (in case .env was loaded after constructor)
+        // Also handle quotes/whitespace that might be in .env file
+        let token = process.env.OM_BUILD_EVENT_TOKEN;
+        if (token) {
+            token = token.trim().replace(/^["']|["']$/g, ''); // Remove quotes and whitespace
+        }
+        if (!token) {
+            // Only warn once per run to avoid spam
+            if (!this._tokenWarningShown) {
+                console.warn('⚠️  OM_BUILD_EVENT_TOKEN not set - build events disabled');
+                this._tokenWarningShown = true;
+            }
+            return false;
+        }
+        // Update token if it was loaded late or cleaned up
+        if (!this.token || this.token !== token) {
+            this.token = token;
+        }
+
+        const {
+            stage = null,
+            message = null,
+            durationMs = null,
+            repo = null,
+            branch = null,
+            commit = null
+        } = data;
+
+        // Use git info if available and not overridden
+        const gitInfo = this.gitInfo || {};
+        const finalRepo = repo || gitInfo.repo || null;
+        const finalBranch = branch || gitInfo.branch || null;
+        const finalCommit = commit || gitInfo.commit || null;
+
+        const eventData = {
+            runId: this.runId,
+            event,
+            env: this.env,
+            origin: this.origin,
+            command: this.command,
+            host: this.hostname,
+            pid: this.pid,
+            stage,
+            message,
+            durationMs,
+            ts: new Date().toISOString(),
+            repo: finalRepo,
+            branch: finalBranch,
+            commit: finalCommit
+        };
+
+        try {
+            const url = new URL(`${this.baseUrl}/api/internal/build-events`);
+            const isHttps = url.protocol === 'https:';
+            const httpModule = isHttps ? https : http;
+
+            const postData = JSON.stringify(eventData);
+
+            const options = {
+                hostname: url.hostname,
+                port: url.port || (isHttps ? 443 : 80),
+                path: url.pathname,
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Content-Length': Buffer.byteLength(postData),
+                    'X-OM-BUILD-TOKEN': this.token
+                },
+                timeout: 2000 // 2 second timeout (reduced to prevent build stalls)
+            };
+
+            return new Promise((resolve) => {
+                const req = httpModule.request(options, (res) => {
+                    let responseData = '';
+
+                    res.on('data', (chunk) => {
+                        responseData += chunk;
+                    });
+
+                    res.on('end', () => {
+                        // 204 No Content means build events are disabled (not an error)
+                        if (res.statusCode === 204) {
+                            // Silently treat as success (disabled is OK)
+                            resolve(true);
+                        } else if (res.statusCode >= 200 && res.statusCode < 300) {
+                            resolve(true);
+                        } else {
+                            // Warn once per run to prevent spam
+                            if (!this._buildEventWarningShown) {
+                                if (res.statusCode === 404) {
+                                    console.warn('⚠️  Build events unavailable (HTTP 404). Continuing without build-event reporting.');
+                                } else {
+                                    console.warn(`⚠️  Build event failed: ${res.statusCode} - ${responseData}`);
+                                }
+                                this._buildEventWarningShown = true;
+                            }
+                            resolve(false);
+                        }
+                    });
+                });
+
+                req.on('error', (error) => {
+                    console.warn(`⚠️  Build event error (non-fatal): ${error.message}`);
+                    resolve(false); // Don't fail build on event errors
+                });
+
+                req.on('timeout', () => {
+                    req.destroy();
+                    // Warn once per run to prevent spam
+                    if (!this._buildEventWarningShown) {
+                        console.warn('⚠️  Build event timeout (non-fatal). Continuing without build-event reporting.');
+                        this._buildEventWarningShown = true;
+                    }
+                    resolve(false);
+                });
+
+                req.write(postData);
+                req.end();
+            });
+        } catch (error) {
+            console.warn(`⚠️  Build event error (non-fatal): ${error.message}`);
+            return false;
+        }
+    }
+
+    /**
+     * Start heartbeat (emits heartbeat every 25 seconds)
+     */
+    startHeartbeat() {
+        if (this.heartbeatInterval) {
+            return; // Already started
+        }
+
+        // Emit initial heartbeat
+        this.emit('heartbeat').catch(() => {});
+
+        // Then emit every 25 seconds
+        this.heartbeatInterval = setInterval(() => {
+            this.emit('heartbeat').catch(() => {});
+        }, 25000);
+    }
+
+    /**
+     * Stop heartbeat
+     */
+    stopHeartbeat() {
+        if (this.heartbeatInterval) {
+            clearInterval(this.heartbeatInterval);
+            this.heartbeatInterval = null;
+        }
+    }
+
+    /**
+     * Emit build_started and start heartbeat
+     */
+    async startBuild(data = {}) {
+        await this.emit('build_started', data);
+        this.startHeartbeat();
+    }
+
+    /**
+     * Emit stage_started
+     */
+    async stageStarted(stage, message = null) {
+        await this.emit('stage_started', { stage, message });
+    }
+
+    /**
+     * Emit stage_completed
+     */
+    async stageCompleted(stage, durationMs, message = null) {
+        await this.emit('stage_completed', { stage, durationMs, message });
+    }
+
+    /**
+     * Wait for backend to be ready (health check)
+     * @param {number} maxRetries - Maximum retry attempts (default 10)
+     * @param {number} delayMs - Delay between retries in ms (default 1000)
+     * @returns {Promise<boolean>} True if backend is ready
+     */
+    async waitForBackend(maxRetries = 30, delayMs = 1000) {
+        const httpModule = http; // Assuming http for localhost
+        const url = new URL(`${this.baseUrl}/api/health`);
+        
+        for (let i = 0; i < maxRetries; i++) {
+            try {
+                const isReady = await new Promise((resolve) => {
+                    const req = httpModule.request({
+                        hostname: url.hostname,
+                        port: url.port || 3001,
+                        path: url.pathname,
+                        method: 'GET',
+                        timeout: 3000
+                    }, (res) => {
+                        let data = '';
+                        res.on('data', (chunk) => { data += chunk; });
+                        res.on('end', () => {
+                            resolve(res.statusCode === 200);
+                        });
+                    });
+                    
+                    req.on('error', () => resolve(false));
+                    req.on('timeout', () => {
+                        req.destroy();
+                        resolve(false);
+                    });
+                    req.end();
+                });
+                
+                if (isReady) {
+                    return true; // Backend is ready
+                }
+            } catch (e) {
+                // Continue to next retry
+            }
+            
+            // Wait before next retry (except on last attempt)
+            if (i < maxRetries - 1) {
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+            }
+        }
+        
+        return false; // Backend never became ready
+    }
+
+    /**
+     * Emit build_completed and stop heartbeat
+     * Waits for backend to be ready if needed
+     */
+    async buildCompleted(data = {}) {
+        this.stopHeartbeat();
+        const durationMs = Date.now() - this.startTime;
+        
+        // Wait for backend to be ready (in case PM2 just restarted)
+        // PM2 restart can take 5-10 seconds, so wait up to 30 seconds
+        const backendReady = await this.waitForBackend(30, 1000);
+        
+        if (!backendReady) {
+            console.warn('⚠️  Backend not ready after waiting, will retry event sending');
+        }
+        
+        // Retry sending the event up to 5 times with increasing delays
+        let success = false;
+        for (let attempt = 0; attempt < 5 && !success; attempt++) {
+            success = await this.emit('build_completed', { ...data, durationMs });
+            if (!success && attempt < 4) {
+                // Exponential backoff: 1s, 2s, 3s, 4s
+                const delay = (attempt + 1) * 1000;
+                await new Promise(resolve => setTimeout(resolve, delay));
+            }
+        }
+        
+        if (!success) {
+            console.warn('⚠️  Failed to send build_completed event after all retries');
+        }
+    }
+
+    /**
+     * Emit build_failed and stop heartbeat
+     */
+    async buildFailed(error, stage = null) {
+        this.stopHeartbeat();
+        const message = error?.message || error?.toString() || 'Build failed';
+        await this.emit('build_failed', { message, stage });
+    }
+
+    /**
+     * Get current runId
+     */
+    getRunId() {
+        return this.runId;
+    }
+}
+
+// Export singleton instance
+module.exports = new BuildEventEmitter();
+
+// Also export class for testing
+module.exports.BuildEventEmitter = BuildEventEmitter;

--- a/server/scripts/build-history.js
+++ b/server/scripts/build-history.js
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+
+/**
+ * Build History Logger
+ * Tracks build history with file changes for both backend and frontend
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const ROOT = path.resolve(__dirname, '..');
+const HISTORY_FILE = path.join(ROOT, 'build-history.json');
+const MAX_HISTORY_ENTRIES = 100; // Keep last 100 builds
+
+/**
+ * Get file hash for change detection
+ */
+function getFileHash(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const content = fs.readFileSync(filePath);
+    return crypto.createHash('md5').update(content).digest('hex');
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Get file stats
+ */
+function getFileStats(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return fs.statSync(filePath);
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Recursively find all files in a directory
+ */
+function findFiles(dir, baseDir = dir, extensions = ['.js', '.ts', '.tsx', '.jsx']) {
+  const files = [];
+  
+  if (!fs.existsSync(dir)) return files;
+  
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    const relPath = path.relative(baseDir, fullPath);
+    
+    // Skip node_modules, dist, .git, etc.
+    if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'dist') {
+      continue;
+    }
+    
+    if (entry.isDirectory()) {
+      files.push(...findFiles(fullPath, baseDir, extensions));
+    } else if (entry.isFile()) {
+      const ext = path.extname(entry.name).toLowerCase();
+      if (extensions.length === 0 || extensions.includes(ext)) {
+        files.push(relPath);
+      }
+    }
+  }
+  
+  return files;
+}
+
+/**
+ * Compare two file states and return changed files
+ */
+function compareFileStates(oldState, newState) {
+  const changed = [];
+  const added = [];
+  const removed = [];
+  
+  // Check for changed and removed files
+  for (const [file, hash] of Object.entries(oldState)) {
+    if (!(file in newState)) {
+      removed.push(file);
+    } else if (newState[file] !== hash) {
+      changed.push(file);
+    }
+  }
+  
+  // Check for added files
+  for (const file of Object.keys(newState)) {
+    if (!(file in oldState)) {
+      added.push(file);
+    }
+  }
+  
+  return { changed, added, removed };
+}
+
+/**
+ * Load build history
+ */
+function loadHistory() {
+  try {
+    if (fs.existsSync(HISTORY_FILE)) {
+      const content = fs.readFileSync(HISTORY_FILE, 'utf8');
+      return JSON.parse(content);
+    }
+  } catch (error) {
+    console.warn('⚠️  Could not load build history:', error.message);
+  }
+  
+  return {
+    builds: [],
+    lastState: {}
+  };
+}
+
+/**
+ * Save build history
+ */
+function saveHistory(history) {
+  try {
+    // Keep only last N builds
+    if (history.builds.length > MAX_HISTORY_ENTRIES) {
+      history.builds = history.builds.slice(-MAX_HISTORY_ENTRIES);
+    }
+    
+    fs.writeFileSync(HISTORY_FILE, JSON.stringify(history, null, 2), 'utf8');
+  } catch (error) {
+    console.error('❌ Failed to save build history:', error.message);
+  }
+}
+
+/**
+ * Get current file state for a directory
+ */
+function getFileState(dir, baseDir = dir, extensions = ['.js', '.ts']) {
+  const files = findFiles(dir, baseDir, extensions);
+  const state = {};
+  
+  for (const file of files) {
+    const fullPath = path.join(baseDir, file);
+    const hash = getFileHash(fullPath);
+    if (hash) {
+      state[file] = hash;
+    }
+  }
+  
+  return state;
+}
+
+/**
+ * Record a build
+ */
+function recordBuild(type, changedFiles, buildTime, success = true) {
+  const history = loadHistory();
+  const timestamp = new Date().toISOString();
+  
+  const buildRecord = {
+    id: `build-${Date.now()}`,
+    timestamp,
+    type, // 'backend', 'frontend', or 'full'
+    success,
+    buildTime, // in seconds
+    files: {
+      changed: changedFiles.changed || [],
+      added: changedFiles.added || [],
+      removed: changedFiles.removed || []
+    },
+    totalFiles: {
+      changed: (changedFiles.changed || []).length,
+      added: (changedFiles.added || []).length,
+      removed: (changedFiles.removed || []).length
+    }
+  };
+  
+  history.builds.push(buildRecord);
+  
+  // Update last state if build was successful
+  if (success && type === 'backend') {
+    history.lastState.backend = changedFiles.newState || {};
+  } else if (success && type === 'frontend') {
+    history.lastState.frontend = changedFiles.newState || {};
+  }
+  
+  saveHistory(history);
+  
+  return buildRecord;
+}
+
+/**
+ * Get changed files for backend
+ */
+function getBackendChanges() {
+  const history = loadHistory();
+  const lastState = history.lastState.backend || {};
+  
+  const currentState = getFileState(
+    path.join(ROOT, 'routes'),
+    path.join(ROOT, 'routes'),
+    ['.js']
+  );
+  
+  // Also check src directory for TypeScript files
+  const srcState = getFileState(
+    path.join(ROOT, 'src'),
+    path.join(ROOT, 'src'),
+    ['.ts', '.js']
+  );
+  
+  // Merge states
+  const newState = { ...currentState, ...srcState };
+  
+  const changes = compareFileStates(lastState, newState);
+  
+  return {
+    ...changes,
+    newState
+  };
+}
+
+/**
+ * Get changed files for frontend
+ */
+function getFrontendChanges() {
+  const history = loadHistory();
+  const lastState = history.lastState.frontend || {};
+  
+  const frontendRoot = path.join(ROOT, '..', 'front-end');
+  const currentState = getFileState(
+    path.join(frontendRoot, 'src'),
+    path.join(frontendRoot, 'src'),
+    ['.ts', '.tsx', '.js', '.jsx']
+  );
+  
+  const changes = compareFileStates(lastState, currentState);
+  
+  return {
+    ...changes,
+    newState: currentState
+  };
+}
+
+/**
+ * Display build history
+ */
+function displayHistory(limit = 10) {
+  const history = loadHistory();
+  const recentBuilds = history.builds.slice(-limit).reverse();
+  
+  console.log('\n📜 Build History (Last ' + limit + ' builds)\n');
+  console.log('═'.repeat(80));
+  
+  if (recentBuilds.length === 0) {
+    console.log('No build history found.\n');
+    return;
+  }
+  
+  for (const build of recentBuilds) {
+    const date = new Date(build.timestamp);
+    const status = build.success ? '✅' : '❌';
+    const typeIcon = build.type === 'backend' ? '🔧' : build.type === 'frontend' ? '🎨' : '🚀';
+    
+    console.log(`${status} ${typeIcon} ${build.type.toUpperCase()} - ${date.toLocaleString()}`);
+    console.log(`   Build time: ${build.buildTime.toFixed(2)}s`);
+    
+    const total = build.totalFiles.changed + build.totalFiles.added + build.totalFiles.removed;
+    if (total > 0) {
+      console.log(`   Files: ${build.totalFiles.changed} changed, ${build.totalFiles.added} added, ${build.totalFiles.removed} removed`);
+      
+      // Show first 5 changed files
+      if (build.files.changed.length > 0) {
+        const preview = build.files.changed.slice(0, 5);
+        preview.forEach(file => console.log(`      - ${file}`));
+        if (build.files.changed.length > 5) {
+          console.log(`      ... and ${build.files.changed.length - 5} more`);
+        }
+      }
+    } else {
+      console.log(`   Files: No changes detected`);
+    }
+    
+    console.log('');
+  }
+  
+  console.log('═'.repeat(80) + '\n');
+}
+
+// CLI interface
+if (require.main === module) {
+  const command = process.argv[2];
+  
+  if (command === 'history' || command === 'show') {
+    const limit = parseInt(process.argv[3]) || 10;
+    displayHistory(limit);
+  } else if (command === 'backend-changes') {
+    const changes = getBackendChanges();
+    console.log(JSON.stringify(changes, null, 2));
+  } else if (command === 'frontend-changes') {
+    const changes = getFrontendChanges();
+    console.log(JSON.stringify(changes, null, 2));
+  } else {
+    console.log('Usage:');
+    console.log('  node build-history.js history [limit]  - Show build history');
+    console.log('  node build-history.js backend-changes  - Get backend file changes');
+    console.log('  node build-history.js frontend-changes  - Get frontend file changes');
+  }
+}
+
+/**
+ * Get history data (without printing)
+ */
+function getHistory(limit = 10) {
+  const history = loadHistory();
+  const recentBuilds = history.builds.slice(-limit).reverse();
+  
+  return recentBuilds.map(build => ({
+    type: build.type,
+    timestamp: build.timestamp,
+    buildTime: build.buildTime,
+    success: build.success,
+    files: {
+      changed: build.totalFiles.changed,
+      added: build.totalFiles.added,
+      removed: build.totalFiles.removed
+    }
+  }));
+}
+
+module.exports = {
+  recordBuild,
+  getBackendChanges,
+  getFrontendChanges,
+  displayHistory,
+  loadHistory,
+  getHistory
+};
+

--- a/server/scripts/build-presenter.js
+++ b/server/scripts/build-presenter.js
@@ -1,0 +1,384 @@
+#!/usr/bin/env node
+
+/**
+ * Build Output Presenter
+ * 
+ * Handles all terminal output formatting for professional build presentation
+ */
+
+class BuildPresenter {
+  constructor(options = {}) {
+    this.verbose = options.verbose || false;
+    this.quiet = options.quiet || false;
+    this.showProgress = options.showProgress !== false;
+    this.warnings = [];
+    this.stages = [];
+  }
+
+  /**
+   * Print header banner
+   */
+  printHeader() {
+    if (this.quiet) return;
+    
+    console.log('═══════════════════════════════════════════════════════════');
+    console.log('  OrthodoxMetrics - Full Build & Deploy');
+    console.log('═══════════════════════════════════════════════════════════\n');
+  }
+
+  /**
+   * Print stage table (replaces individual stage start/end lines)
+   */
+  printStageTable(stageResults) {
+    if (this.quiet) return;
+    
+    console.log('───────────────────────────────────────────────────────────');
+    console.log('Stage                          Status        Duration');
+    console.log('───────────────────────────────────────────────────────────');
+    
+    for (const stage of stageResults) {
+      const statusText = stage.status === 'Completed' ? '✓ Completed' : '✗ Failed';
+      const durationText = `${stage.durationSec.toFixed(2)}s`.padStart(8);
+      const stageName = stage.name.padEnd(30);
+      const status = statusText.padEnd(12);
+      
+      console.log(`${stageName}${status}${durationText}`);
+    }
+    
+    console.log('───────────────────────────────────────────────────────────');
+  }
+
+  /**
+   * Print command output (only in verbose mode or on failure)
+   */
+  printCommandOutput(stageName, output, isError = false) {
+    if (isError || this.verbose) {
+      if (output && output.trim()) {
+        // Filter out npm verbose headers
+        const filtered = this.filterNpmNoise(output);
+        
+        if (isError) {
+          // For errors, show last 120 lines
+          const lines = filtered.split('\n');
+          const lastLines = lines.slice(-120).join('\n');
+          console.error(`\n[${stageName}] Output (last 120 lines):`);
+          console.error(lastLines);
+        } else {
+          console.log(`\n[${stageName}] Output:\n${filtered}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Filter npm verbose loglevel noise
+   */
+  filterNpmNoise(output) {
+    if (!output) return output;
+    
+    const lines = output.split('\n');
+    const filtered = lines.filter(line => {
+      // Remove npm verbose headers
+      if (line.startsWith('npm verbose')) return false;
+      if (line.startsWith('npm info using')) return false;
+      if (line.startsWith('npm info ok')) return false;
+      if (line.startsWith('npm verbose logfile')) return false;
+      if (line.startsWith('npm verbose title')) return false;
+      if (line.startsWith('npm verbose argv')) return false;
+      if (line.startsWith('npm verbose cwd')) return false;
+      if (line.startsWith('npm verbose os')) return false;
+      if (line.startsWith('npm verbose node')) return false;
+      if (line.startsWith('npm verbose npm')) return false;
+      if (line.startsWith('npm verbose exit')) return false;
+      return true;
+    });
+    
+    return filtered.join('\n');
+  }
+
+  /**
+   * Record warnings from output
+   */
+  recordWarnings(stageName, output) {
+    if (!output) return;
+
+    const warnings = [];
+    const lines = output.split('\n');
+
+    // Detect common warnings
+    for (const line of lines) {
+      if (line.includes('Browserslist: browsers data (caniuse-lite) is')) {
+        warnings.push({
+          type: 'browserslist',
+          message: 'Browserslist data is outdated',
+          suggestion: 'Run: npx update-browserslist-db@latest'
+        });
+      } else if (line.includes('Some chunks are larger than 500 kB')) {
+        warnings.push({
+          type: 'chunk-size',
+          message: 'Large chunk size detected',
+          suggestion: 'Consider code-splitting or manual chunking'
+        });
+      } else if (line.includes('npm WARN') && !line.includes('npm WARN deprecated')) {
+        // Only record non-deprecation warnings
+        const match = line.match(/npm WARN (.+)/);
+        if (match) {
+          warnings.push({
+            type: 'npm-warn',
+            message: match[1].trim(),
+            suggestion: null
+          });
+        }
+      }
+    }
+
+    if (warnings.length > 0) {
+      this.warnings.push({
+        stage: stageName,
+        warnings: warnings
+      });
+    }
+  }
+
+  /**
+   * Print warnings summary (compact format)
+   */
+  printWarningsSummary() {
+    if (this.warnings.length === 0) return;
+
+    let totalWarnings = 0;
+    const uniqueWarnings = [];
+    const shownTypes = new Set();
+
+    for (const stageWarnings of this.warnings) {
+      for (const warning of stageWarnings.warnings) {
+        totalWarnings++;
+        if (!shownTypes.has(warning.type)) {
+          shownTypes.add(warning.type);
+          uniqueWarnings.push(warning);
+        }
+      }
+    }
+
+    console.log(`\n⚠ Warnings (${totalWarnings})`);
+    for (const warning of uniqueWarnings.slice(0, 5)) {
+      const hint = warning.suggestion ? ` (${warning.suggestion})` : '';
+      console.log(`- ${warning.message}${hint}`);
+    }
+    if (totalWarnings > uniqueWarnings.length && !this.verbose) {
+      console.log(`- ... ${totalWarnings - uniqueWarnings.length} more (use --om-verbose for details)`);
+    }
+  }
+
+  /**
+   * Print build summary (compact format)
+   */
+  printBuildSummary(results) {
+    const totalTime = results.totalTime || 0;
+    const backendTime = results.backendTime || 0;
+    const frontendTime = results.frontendTime || 0;
+    const pm2Time = results.pm2Time || 0;
+    
+    console.log(`\n📊 Build Summary`);
+    console.log(`Total: ${totalTime.toFixed(2)}s | Backend: ${backendTime.toFixed(2)}s | Frontend: ${frontendTime.toFixed(2)}s | PM2: ${pm2Time.toFixed(2)}s`);
+    
+    // Only show file changes if there were any
+    const backendTotal = results.backendFiles ? 
+      (results.backendFiles.changed || 0) + (results.backendFiles.added || 0) + (results.backendFiles.removed || 0) : 0;
+    const frontendTotal = results.frontendFiles ? 
+      (results.frontendFiles.changed || 0) + (results.frontendFiles.added || 0) + (results.frontendFiles.removed || 0) : 0;
+    
+    if (backendTotal > 0 || frontendTotal > 0) {
+      const parts = [];
+      if (backendTotal > 0) {
+        const { changed = 0, added = 0, removed = 0 } = results.backendFiles;
+        parts.push(`Backend: ${backendTotal} (${changed}M/${added}A/${removed}D)`);
+      }
+      if (frontendTotal > 0) {
+        const { changed = 0, added = 0, removed = 0 } = results.frontendFiles;
+        parts.push(`Frontend: ${frontendTotal} (${changed}M/${added}A/${removed}D)`);
+      }
+      console.log(`Files: ${parts.join(' | ')}`);
+    }
+  }
+
+  /**
+   * Print OM.nfo banner (single divider style)
+   */
+  printOmNfo(omNfoPath) {
+    try {
+      const fs = require('fs');
+      if (fs.existsSync(omNfoPath)) {
+        const banner = fs.readFileSync(omNfoPath, 'utf8');
+        console.log('\n═══════════════════════════════════════════════════════════');
+        console.log(banner);
+        console.log('═══════════════════════════════════════════════════════════');
+      }
+    } catch (error) {
+      // Silently fail if om.nfo doesn't exist
+    }
+  }
+
+  /**
+   * Print build history (compressed single-line format)
+   */
+  printBuildHistory(history) {
+    if (this.quiet) return;
+    
+    if (!history || history.length === 0) {
+      return;
+    }
+    
+    console.log('\n📜 Build History');
+    for (const build of history) {
+      const icon = build.success ? '✅' : '❌';
+      const type = build.type.toUpperCase().padEnd(9);
+      const date = new Date(build.timestamp).toISOString().replace('T', ' ').substring(0, 19);
+      const time = `${build.buildTime.toFixed(2)}s`.padStart(8);
+      
+      let line = `${icon} ${type} ${date} ${time}`;
+      
+      // Only add file info if there were changes
+      if (build.files) {
+        const { changed = 0, added = 0, removed = 0 } = build.files;
+        const total = changed + added + removed;
+        if (total > 0) {
+          line += ` (${total} files: ${changed}M/${added}A/${removed}D)`;
+        } else {
+          line += ` (no changes)`;
+        }
+      }
+      
+      console.log(line);
+    }
+  }
+
+  /**
+   * Print error summary
+   */
+  printErrorSummary(error, stageName, output) {
+    console.error('\n═══════════════════════════════════════════════════════════');
+    console.error(`  ❌ Build Failed: ${stageName}`);
+    console.error('═══════════════════════════════════════════════════════════\n');
+    
+    console.error(`Error: ${error.message || error}`);
+    
+    if (output) {
+      this.printCommandOutput(stageName, output, true);
+    }
+    
+    if (!this.verbose) {
+      console.error('\n💡 Re-run with --verbose to see full output');
+    }
+    
+    console.error('\n═══════════════════════════════════════════════════════════');
+  }
+
+  /**
+   * Extract summary from Vite output (for non-verbose mode)
+   */
+  extractViteSummary(output) {
+    if (!output) return null;
+    
+    const lines = output.split('\n');
+    const summary = {
+      modulesTransformed: null,
+      buildTime: null,
+      distSize: null
+    };
+    
+    for (const line of lines) {
+      // Match "✓ 24345 modules transformed."
+      if (line.includes('modules transformed')) {
+        const match = line.match(/(\d+)\s+modules transformed/);
+        if (match) summary.modulesTransformed = parseInt(match[1].replace(/,/g, ''));
+      }
+      // Match "✓ built in 1m 11s"
+      if (line.includes('built in')) {
+        const match = line.match(/built in ([\d.]+m\s*[\d.]+s|[\d.]+s)/);
+        if (match) summary.buildTime = match[1].trim();
+      }
+    }
+    
+    return summary;
+  }
+
+  /**
+   * Get dist directory size
+   */
+  getDistSize(distPath) {
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      
+      if (!fs.existsSync(distPath)) return null;
+      
+      let totalSize = 0;
+      
+      function calculateSize(dir) {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            calculateSize(fullPath);
+          } else {
+            const stats = fs.statSync(fullPath);
+            totalSize += stats.size;
+          }
+        }
+      }
+      
+      calculateSize(distPath);
+      return totalSize;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  /**
+   * Format bytes to human readable
+   */
+  formatBytes(bytes) {
+    if (!bytes || bytes === 0) return null;
+    const gb = bytes / (1024 * 1024 * 1024);
+    if (gb >= 1) {
+      return `${gb.toFixed(2)} GB`;
+    }
+    const mb = bytes / (1024 * 1024);
+    return `${mb.toFixed(2)} MB`;
+  }
+
+  /**
+   * Print Vite summary (non-verbose mode)
+   */
+  printViteSummary(summary, distPath = null) {
+    if (!summary || this.verbose) return;
+    
+    if (summary.modulesTransformed) {
+      console.log(`  ✓ ${summary.modulesTransformed.toLocaleString()} modules transformed`);
+    }
+    if (summary.buildTime) {
+      console.log(`  ✓ Built in ${summary.buildTime}`);
+    }
+    
+    // Calculate and show dist/ size only
+    if (distPath) {
+      const distSize = this.getDistSize(distPath);
+      if (distSize !== null) {
+        const formatted = this.formatBytes(distSize);
+        if (formatted) {
+          console.log(`  ✓ Dist size: ${formatted}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Print backend summary (removed - stages print individually)
+   */
+  printBackendSummary(summary) {
+    // Removed to avoid duplication - each stage prints its own completion line
+  }
+}
+
+module.exports = BuildPresenter;

--- a/server/scripts/build-progress.js
+++ b/server/scripts/build-progress.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Progress Bar Utility for Build Scripts
+ * 
+ * Provides a simple ASCII progress bar that updates in real-time
+ */
+
+class BuildProgress {
+  constructor(totalSteps = 100) {
+    this.totalSteps = totalSteps;
+    this.currentStep = 0;
+    this.barWidth = 50;
+    this.startTime = Date.now();
+    this.steps = [];
+    this.currentStageName = '';
+  }
+
+  /**
+   * Add a step to track
+   */
+  addStep(name, weight = 1) {
+    this.steps.push({ name, weight, completed: false });
+    return this.steps.length - 1;
+  }
+
+  /**
+   * Update progress for a specific step
+   */
+  updateStep(stepIndex, completed = true) {
+    if (stepIndex >= 0 && stepIndex < this.steps.length) {
+      this.steps[stepIndex].completed = completed;
+      this._updateProgress();
+    }
+  }
+
+  /**
+   * Set overall progress percentage (0-100)
+   */
+  setProgress(percentage) {
+    this.currentStep = Math.max(0, Math.min(100, percentage));
+    this._render();
+  }
+
+  /**
+   * Increment progress by a percentage
+   */
+  increment(percentage) {
+    this.currentStep = Math.max(0, Math.min(100, this.currentStep + percentage));
+    this._render();
+  }
+
+  /**
+   * Calculate progress based on completed steps
+   */
+  _updateProgress() {
+    const totalWeight = this.steps.reduce((sum, step) => sum + step.weight, 0);
+    const completedWeight = this.steps
+      .filter(step => step.completed)
+      .reduce((sum, step) => sum + step.weight, 0);
+    
+    if (totalWeight > 0) {
+      this.currentStep = (completedWeight / totalWeight) * 100;
+    }
+    this._render();
+  }
+
+  /**
+   * Set the current stage name
+   */
+  setStage(stageName) {
+    this.currentStageName = stageName;
+    this._render();
+  }
+
+  /**
+   * Render the progress bar (on its own line, no stage text)
+   */
+  _render() {
+    const percentage = Math.round(this.currentStep);
+    const filled = Math.round((this.currentStep / 100) * this.barWidth);
+    const empty = this.barWidth - filled;
+    
+    const bar = '█'.repeat(filled) + '░'.repeat(empty);
+    
+    // Print on its own line with newline
+    console.log(`[${bar}] ${percentage}%`);
+  }
+
+  /**
+   * Complete the progress bar (just render, no message)
+   */
+  complete(message = 'Complete') {
+    this.currentStep = 100;
+    this._render();
+    // Message is printed separately, just render the bar
+  }
+
+  /**
+   * Clear the progress bar line
+   */
+  clear() {
+    process.stdout.write('\r' + ' '.repeat(80) + '\r');
+  }
+}
+
+module.exports = BuildProgress;

--- a/server/scripts/build-smart.js
+++ b/server/scripts/build-smart.js
@@ -1,0 +1,806 @@
+#!/usr/bin/env node
+
+/**
+ * Smart Build Script
+ * 
+ * Analyzes changed files and only rebuilds what's necessary.
+ * Skips expensive clean steps when safe.
+ * Professional output with progress bars and spinners.
+ * 
+ * Usage:
+ *   node scripts/build-smart.js           # Smart build
+ *   node scripts/build-smart.js --restart  # Smart build + restart PM2 if backend rebuilt
+ *   node scripts/build-smart.js --om-verbose  # Show detailed output
+ *   node scripts/build-smart.js --om-quiet    # Minimal output
+ */
+
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const path = require('path');
+const fs = require('fs');
+const buildHistory = require('./build-history');
+const BuildProgress = require('./build-progress');
+const BuildPresenter = require('./build-presenter');
+
+const execAsync = promisify(exec);
+
+const SERVER_DIR = __dirname + '/..';
+const REPO_ROOT = path.resolve(SERVER_DIR, '..');
+const FRONTEND_DIR = path.join(REPO_ROOT, 'front-end');
+const OM_NFO_PATH = path.join(__dirname, 'om.nfo');
+
+/**
+ * Parse CLI arguments
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  return {
+    restart: args.includes('--restart'),
+    verbose: args.includes('--om-verbose'),
+    quiet: args.includes('--om-quiet'),
+    noProgress: args.includes('--om-no-progress'),
+    noBanner: args.includes('--no-banner'),
+    noAnim: args.includes('--om-no-anim')
+  };
+}
+
+/**
+ * Spinner state and animation
+ */
+const spinnerState = {
+  interval: null,
+  frameIndex: 0,
+  currentStageName: '',
+  stageStartTime: null,
+  buildStartTime: null,
+  enabled: false
+};
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+function startSpinner(args) {
+  if (!process.stdout.isTTY || args.quiet || args.noAnim) {
+    spinnerState.enabled = false;
+    return;
+  }
+  
+  spinnerState.enabled = true;
+  spinnerState.buildStartTime = Date.now();
+  spinnerState.frameIndex = 0;
+  
+  spinnerState.interval = setInterval(() => {
+    if (!spinnerState.enabled) return;
+    
+    const frame = SPINNER_FRAMES[spinnerState.frameIndex % SPINNER_FRAMES.length];
+    spinnerState.frameIndex++;
+    
+    const totalElapsed = ((Date.now() - spinnerState.buildStartTime) / 1000).toFixed(1);
+    const stageName = spinnerState.currentStageName || 'Analyzing';
+    
+    const cols = process.stdout.columns || 80;
+    const statusLine = ` ${frame}  ${stageName}   (elapsed ${totalElapsed}s)`;
+    const padding = ' '.repeat(Math.max(0, cols - statusLine.length - 1));
+    
+    process.stdout.write(`\r${statusLine}${padding}`);
+  }, 100);
+}
+
+function stopSpinner() {
+  if (spinnerState.interval) {
+    clearInterval(spinnerState.interval);
+    spinnerState.interval = null;
+  }
+  
+  if (spinnerState.enabled) {
+    const cols = process.stdout.columns || 80;
+    process.stdout.write('\r' + ' '.repeat(cols - 1) + '\r');
+  }
+  
+  spinnerState.enabled = false;
+}
+
+function updateSpinnerStage(stageName) {
+  spinnerState.currentStageName = stageName;
+  spinnerState.stageStartTime = Date.now();
+}
+
+// Thresholds
+const FAST_BUILD_THRESHOLD = 5; // If <= 5 files changed, use fast paths
+
+// Force full build patterns
+const FORCE_FULL_PATTERNS = [
+  /^server\/scripts\//,
+  /^server\/tsconfig\.json$/,
+  /^server\/package.*\.json$/,
+  /^front-end\/vite\.config/,
+  /^front-end\/package.*\.json$/,
+  /^package.*\.json$/,
+  /^package-lock\.json$/,
+  /^\.github\//,
+  /^tools\//
+];
+
+// Backend runtime directories (need copy step)
+const BACKEND_RUNTIME_DIRS = [
+  'routes',
+  'middleware',
+  'controllers',
+  'dal',
+  'database',
+  'config'
+];
+
+/**
+ * Get changed files from git (fallback if build history unavailable)
+ */
+async function getChangedFilesFromGit() {
+  try {
+    const { stdout } = await execAsync('git diff --name-only HEAD~1..HEAD', {
+      cwd: REPO_ROOT,
+      maxBuffer: 10 * 1024 * 1024
+    });
+    
+    return stdout.trim().split('\n').filter(f => f.length > 0);
+  } catch (error) {
+    // Git not available or no previous commit
+    return [];
+  }
+}
+
+/**
+ * Get changed files from build history or git
+ */
+async function getChangedFiles() {
+  const history = buildHistory.loadHistory();
+  
+  // Try to get from last build state
+  const backendChanges = buildHistory.getBackendChanges();
+  const frontendChanges = buildHistory.getFrontendChanges();
+  
+  const allChanged = [
+    ...backendChanges.changed.map(f => `server/${f}`),
+    ...backendChanges.added.map(f => `server/${f}`),
+    ...backendChanges.removed.map(f => `server/${f}`),
+    ...frontendChanges.changed.map(f => `front-end/${f}`),
+    ...frontendChanges.added.map(f => `front-end/${f}`),
+    ...frontendChanges.removed.map(f => `front-end/${f}`)
+  ];
+  
+  // If no changes detected from history, try git as fallback
+  if (allChanged.length === 0) {
+    return await getChangedFilesFromGit();
+  }
+  
+  return allChanged;
+}
+
+/**
+ * Classify changed files into categories
+ */
+function classifyChanges(changedFiles) {
+  const backend = [];
+  const frontend = [];
+  let forceFull = false;
+  
+  for (const file of changedFiles) {
+    // Check force-full patterns first
+    const matchesForceFull = FORCE_FULL_PATTERNS.some(pattern => pattern.test(file));
+    if (matchesForceFull) {
+      forceFull = true;
+      continue;
+    }
+    
+    // Classify by path
+    if (file.startsWith('server/')) {
+      backend.push(file);
+    } else if (file.startsWith('front-end/')) {
+      frontend.push(file);
+    } else if (file.startsWith('docs/') || file.startsWith('scripts/')) {
+      // Root-level scripts/docs don't require rebuild
+      continue;
+    } else {
+      // Unknown root-level changes - force full build for safety
+      forceFull = true;
+    }
+  }
+  
+  return {
+    backend,
+    frontend,
+    forceFull,
+    total: changedFiles.length
+  };
+}
+
+/**
+ * Determine if backend needs full clean build
+ */
+function needsBackendClean(changes) {
+  // Force full if dependencies changed
+  const hasPackageChanges = changes.some(f => 
+    f.includes('package.json') || f.includes('package-lock.json')
+  );
+  
+  if (hasPackageChanges) {
+    return true;
+  }
+  
+  // Force full if tsconfig changed
+  if (changes.some(f => f.includes('tsconfig.json'))) {
+    return true;
+  }
+  
+  return false;
+}
+
+/**
+ * Determine if only TypeScript files changed (can use incremental)
+ */
+function onlyTypeScriptChanged(changes) {
+  if (changes.length === 0) return false;
+  
+  return changes.every(f => {
+    // Remove server/ prefix if present
+    const relPath = f.startsWith('server/') ? f.replace(/^server\//, '') : f;
+    // Check if it's a TypeScript file in src/
+    if (relPath.startsWith('src/') && (relPath.endsWith('.ts') || relPath.endsWith('.tsx'))) {
+      return true;
+    }
+    return false;
+  });
+}
+
+/**
+ * Determine if runtime files changed (need copy step)
+ */
+function runtimeFilesChanged(changes) {
+  return changes.some(f => {
+    // Remove server/ prefix if present
+    const relPath = f.startsWith('server/') ? f.replace(/^server\//, '') : f;
+    return BACKEND_RUNTIME_DIRS.some(dir => relPath.startsWith(dir + '/') || relPath === dir);
+  });
+}
+
+/**
+ * Determine if frontend needs clean build
+ */
+function needsFrontendClean(changes) {
+  // Force clean if dependencies or vite config changed
+  return changes.some(f => 
+    f.includes('package.json') || 
+    f.includes('package-lock.json') ||
+    f.includes('vite.config')
+  );
+}
+
+/**
+ * Run command with buffered output and progress tracking
+ */
+async function runCommand(command, cwd, label, presenter, stageResults = null) {
+  const startTime = Date.now();
+  
+  // Update spinner with current stage name
+  updateSpinnerStage(label);
+  
+  try {
+    const { stdout, stderr } = await execAsync(command, { 
+      cwd,
+      maxBuffer: 10 * 1024 * 1024
+    });
+    
+    const buildTime = (Date.now() - startTime) / 1000;
+    const fullOutput = (stdout || '') + (stderr || '');
+    
+    // Record warnings
+    if (presenter) {
+      presenter.recordWarnings(label, fullOutput);
+    }
+    
+    // Print output only in verbose mode
+    if (presenter && presenter.verbose) {
+      presenter.printCommandOutput(label, stdout, false);
+      if (stderr && stderr.trim()) {
+        presenter.printCommandOutput(label, stderr, false);
+      }
+    }
+    
+    // Record stage result for table
+    if (stageResults) {
+      stageResults.push({
+        name: label,
+        status: 'Completed',
+        durationSec: buildTime
+      });
+    }
+    
+    return { 
+      success: true, 
+      output: stdout, 
+      stderr: stderr || '', 
+      buildTime,
+      fullOutput 
+    };
+  } catch (error) {
+    const buildTime = (Date.now() - startTime) / 1000;
+    const errorOutput = (error.stdout || '') + (error.stderr || '');
+    
+    // Record failed stage for table
+    if (stageResults) {
+      stageResults.push({
+        name: label,
+        status: 'Failed',
+        durationSec: buildTime
+      });
+    }
+    
+    // Print error summary
+    if (presenter) {
+      presenter.printErrorSummary(error, label, errorOutput);
+    }
+    
+    throw { ...error, buildTime, output: errorOutput };
+  }
+}
+
+/**
+ * Build backend with smart strategy
+ */
+async function buildBackendSmart(changes, classification, presenter, progress, stageIndices, stageResults) {
+  const backendChanges = buildHistory.getBackendChanges();
+  
+  let buildType = 'full';
+  let totalTime = 0;
+  
+  if (needsBackendClean(changes)) {
+    // Full clean build required - run all stages
+    buildType = 'full-clean';
+    
+    // Stage 1: Clean
+    const cleanResult = await runCommand('npm run build:clean', SERVER_DIR, 'Backend Clean', presenter, stageResults);
+    totalTime += cleanResult.buildTime || 0;
+    if (progress && stageIndices.clean !== undefined) {
+      progress.updateStep(stageIndices.clean, true);
+    }
+    
+    // Stage 2: TypeScript
+    const tsResult = await runCommand('npm run build:ts', SERVER_DIR, 'Backend TypeScript', presenter, stageResults);
+    totalTime += tsResult.buildTime || 0;
+    if (progress && stageIndices.ts !== undefined) {
+      progress.updateStep(stageIndices.ts, true);
+    }
+    
+    // Stage 3: Copy
+    const copyResult = await runCommand('npm run build:copy', SERVER_DIR, 'Backend Copy', presenter, stageResults);
+    totalTime += copyResult.buildTime || 0;
+    if (progress && stageIndices.copy !== undefined) {
+      progress.updateStep(stageIndices.copy, true);
+    }
+    
+    // Stage 4: Verify
+    const verifyResult = await runCommand('npm run build:verify', SERVER_DIR, 'Backend Verify', presenter, stageResults);
+    totalTime += verifyResult.buildTime || 0;
+    if (progress && stageIndices.verify !== undefined) {
+      progress.updateStep(stageIndices.verify, true);
+    }
+    
+  } else if (onlyTypeScriptChanged(changes) && !runtimeFilesChanged(changes)) {
+    // Only TS files changed - incremental compile only
+    buildType = 'incremental-ts';
+    
+    // Skip clean
+    if (stageResults) {
+      stageResults.push({ name: 'Backend Clean', status: 'Skipped', durationSec: 0 });
+    }
+    if (progress && stageIndices.clean !== undefined) {
+      progress.updateStep(stageIndices.clean, true);
+    }
+    
+    // Stage: TypeScript
+    const tsResult = await runCommand('npm run build:ts', SERVER_DIR, 'Backend TypeScript', presenter, stageResults);
+    totalTime += tsResult.buildTime || 0;
+    if (progress && stageIndices.ts !== undefined) {
+      progress.updateStep(stageIndices.ts, true);
+    }
+    
+    // Skip copy
+    if (stageResults) {
+      stageResults.push({ name: 'Backend Copy', status: 'Skipped', durationSec: 0 });
+    }
+    if (progress && stageIndices.copy !== undefined) {
+      progress.updateStep(stageIndices.copy, true);
+    }
+    
+    // Stage: Verify
+    const verifyResult = await runCommand('npm run build:verify', SERVER_DIR, 'Backend Verify', presenter, stageResults);
+    totalTime += verifyResult.buildTime || 0;
+    if (progress && stageIndices.verify !== undefined) {
+      progress.updateStep(stageIndices.verify, true);
+    }
+    
+  } else if (runtimeFilesChanged(changes)) {
+    // Runtime files changed - need copy step
+    const nonTsChanges = changes.filter(f => {
+      const relPath = f.startsWith('server/') ? f.replace(/^server\//, '') : f;
+      return !relPath.startsWith('src/') || (!relPath.endsWith('.ts') && !relPath.endsWith('.tsx'));
+    });
+    
+    if (nonTsChanges.length > 0 && nonTsChanges.every(f => runtimeFilesChanged([f])) && !onlyTypeScriptChanged(changes)) {
+      // Copy only (no TS changes)
+      buildType = 'copy-only';
+      
+      // Skip clean
+      if (stageResults) {
+        stageResults.push({ name: 'Backend Clean', status: 'Skipped', durationSec: 0 });
+      }
+      if (progress && stageIndices.clean !== undefined) {
+        progress.updateStep(stageIndices.clean, true);
+      }
+      
+      // Skip TypeScript
+      if (stageResults) {
+        stageResults.push({ name: 'Backend TypeScript', status: 'Skipped', durationSec: 0 });
+      }
+      if (progress && stageIndices.ts !== undefined) {
+        progress.updateStep(stageIndices.ts, true);
+      }
+      
+      // Stage: Copy
+      const copyResult = await runCommand('npm run build:copy', SERVER_DIR, 'Backend Copy', presenter, stageResults);
+      totalTime += copyResult.buildTime || 0;
+      if (progress && stageIndices.copy !== undefined) {
+        progress.updateStep(stageIndices.copy, true);
+      }
+      
+      // Stage: Verify
+      const verifyResult = await runCommand('npm run build:verify', SERVER_DIR, 'Backend Verify', presenter, stageResults);
+      totalTime += verifyResult.buildTime || 0;
+      if (progress && stageIndices.verify !== undefined) {
+        progress.updateStep(stageIndices.verify, true);
+      }
+    } else {
+      // Mixed runtime + TS - full build but no clean
+      buildType = 'full-no-clean';
+      
+      // Skip clean
+      if (stageResults) {
+        stageResults.push({ name: 'Backend Clean', status: 'Skipped', durationSec: 0 });
+      }
+      if (progress && stageIndices.clean !== undefined) {
+        progress.updateStep(stageIndices.clean, true);
+      }
+      
+      // Stage: TypeScript
+      const tsResult = await runCommand('npm run build:ts', SERVER_DIR, 'Backend TypeScript', presenter, stageResults);
+      totalTime += tsResult.buildTime || 0;
+      if (progress && stageIndices.ts !== undefined) {
+        progress.updateStep(stageIndices.ts, true);
+      }
+      
+      // Stage: Copy
+      const copyResult = await runCommand('npm run build:copy', SERVER_DIR, 'Backend Copy', presenter, stageResults);
+      totalTime += copyResult.buildTime || 0;
+      if (progress && stageIndices.copy !== undefined) {
+        progress.updateStep(stageIndices.copy, true);
+      }
+      
+      // Stage: Verify
+      const verifyResult = await runCommand('npm run build:verify', SERVER_DIR, 'Backend Verify', presenter, stageResults);
+      totalTime += verifyResult.buildTime || 0;
+      if (progress && stageIndices.verify !== undefined) {
+        progress.updateStep(stageIndices.verify, true);
+      }
+    }
+  } else {
+    // Default: full build without clean
+    buildType = 'full-no-clean';
+    
+    // Skip clean
+    if (stageResults) {
+      stageResults.push({ name: 'Backend Clean', status: 'Skipped', durationSec: 0 });
+    }
+    if (progress && stageIndices.clean !== undefined) {
+      progress.updateStep(stageIndices.clean, true);
+    }
+    
+    // Stage: TypeScript
+    const tsResult = await runCommand('npm run build:ts', SERVER_DIR, 'Backend TypeScript', presenter, stageResults);
+    totalTime += tsResult.buildTime || 0;
+    if (progress && stageIndices.ts !== undefined) {
+      progress.updateStep(stageIndices.ts, true);
+    }
+    
+    // Stage: Copy
+    const copyResult = await runCommand('npm run build:copy', SERVER_DIR, 'Backend Copy', presenter, stageResults);
+    totalTime += copyResult.buildTime || 0;
+    if (progress && stageIndices.copy !== undefined) {
+      progress.updateStep(stageIndices.copy, true);
+    }
+    
+    // Stage: Verify
+    const verifyResult = await runCommand('npm run build:verify', SERVER_DIR, 'Backend Verify', presenter, stageResults);
+    totalTime += verifyResult.buildTime || 0;
+    if (progress && stageIndices.verify !== undefined) {
+      progress.updateStep(stageIndices.verify, true);
+    }
+  }
+  
+  // Record build
+  buildHistory.recordBuild('backend', {
+    ...backendChanges,
+    buildTime: totalTime
+  }, totalTime, true);
+  
+  return { 
+    success: true, 
+    buildTime: totalTime, 
+    buildType,
+    files: backendChanges
+  };
+}
+
+/**
+ * Build frontend with smart strategy
+ */
+async function buildFrontendSmart(changes, classification, presenter, progress, stepIndex, stageResults) {
+  if (!fs.existsSync(FRONTEND_DIR)) {
+    throw new Error(`Frontend directory not found: ${FRONTEND_DIR}`);
+  }
+  
+  const frontendChanges = buildHistory.getFrontendChanges();
+  
+  let buildCommand;
+  let buildType = 'full';
+  
+  if (needsFrontendClean(changes)) {
+    buildCommand = 'npm run build:clean';
+    buildType = 'full-clean';
+  } else {
+    buildCommand = 'npm run build';
+    buildType = 'incremental';
+  }
+  
+  const result = await runCommand(buildCommand, FRONTEND_DIR, 'Frontend Build', presenter, stageResults);
+  
+  if (progress && stepIndex !== undefined) {
+    progress.updateStep(stepIndex, true);
+  }
+  
+  // Record build
+  const buildTime = result.buildTime || 0;
+  buildHistory.recordBuild('frontend', {
+    ...frontendChanges,
+    buildTime
+  }, buildTime, result.success !== false);
+  
+  return { 
+    ...result, 
+    buildType,
+    files: frontendChanges
+  };
+}
+
+/**
+ * Restart PM2 service
+ */
+async function restartPM2(presenter, progress, stepIndex, stageResults) {
+  const result = await runCommand('pm2 restart orthodox-backend', SERVER_DIR, 'PM2 Restart', presenter, stageResults);
+  
+  if (progress && stepIndex !== undefined) {
+    progress.updateStep(stepIndex, true);
+  }
+  
+  return result;
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  const args = parseArgs();
+  
+  const presenter = new BuildPresenter({
+    verbose: args.verbose,
+    quiet: args.quiet,
+    showProgress: !args.noProgress
+  });
+  
+  // Print custom header for smart build
+  if (!args.quiet) {
+    console.log('═══════════════════════════════════════════════════════════');
+    console.log('  OrthodoxMetrics - Smart Build');
+    console.log('═══════════════════════════════════════════════════════════\n');
+  }
+  
+  const startTime = Date.now();
+  
+  // Stage results collection
+  const stageResults = [];
+  
+  try {
+    // Get changed files
+    updateSpinnerStage('Analyzing changes');
+    const changedFiles = await getChangedFiles();
+    
+    if (changedFiles.length === 0) {
+      if (!args.quiet) {
+        console.log('✅ No changes detected. Nothing to build.\n');
+      }
+      process.exit(0);
+    }
+    
+    // Classify changes
+    const classification = classifyChanges(changedFiles);
+    
+    if (!args.quiet) {
+      console.log('📊 Change Analysis:');
+      console.log(`   Total files: ${classification.total} | Backend: ${classification.backend.length} | Frontend: ${classification.frontend.length}`);
+      if (classification.forceFull) {
+        console.log('   ⚠️  Force full build (config/scripts changed)');
+      }
+      console.log('');
+    }
+    
+    // Decision logic
+    let buildBackend = false;
+    let buildFrontend = false;
+    
+    if (classification.forceFull) {
+      buildBackend = true;
+      buildFrontend = true;
+    } else {
+      if (classification.backend.length > 0) buildBackend = true;
+      if (classification.frontend.length > 0) buildFrontend = true;
+      
+      // Safety fallback
+      if (!buildBackend && !buildFrontend && changedFiles.length > 0) {
+        buildBackend = true;
+        buildFrontend = true;
+        classification.forceFull = true;
+      }
+    }
+    
+    if (!buildBackend && !buildFrontend) {
+      if (!args.quiet) {
+        console.log('✅ No builds needed.\n');
+      }
+      process.exit(0);
+    }
+    
+    // Print build decision
+    if (!args.quiet) {
+      const buildParts = [];
+      if (buildBackend) buildParts.push('Backend');
+      if (buildFrontend) buildParts.push('Frontend');
+      console.log(`🎯 Building: ${buildParts.join(' + ')}\n`);
+    }
+    
+    // Initialize progress bar
+    const progress = args.noProgress ? null : new BuildProgress();
+    
+    // Add steps based on what we're building
+    const stageIndices = {};
+    let frontendIndex = null;
+    let pm2Index = null;
+    
+    if (buildBackend) {
+      stageIndices.clean = progress ? progress.addStep('Backend Clean', 1) : null;
+      stageIndices.ts = progress ? progress.addStep('Backend TypeScript', 1) : null;
+      stageIndices.copy = progress ? progress.addStep('Backend Copy', 1) : null;
+      stageIndices.verify = progress ? progress.addStep('Backend Verify', 1) : null;
+    }
+    
+    if (buildFrontend) {
+      frontendIndex = progress ? progress.addStep('Frontend Build', 1) : null;
+    }
+    
+    if (args.restart && buildBackend) {
+      pm2Index = progress ? progress.addStep('PM2 Restart', 1) : null;
+    }
+    
+    // Start animated spinner
+    startSpinner(args);
+    
+    // Execute builds
+    let backendResult = null;
+    let frontendResult = null;
+    
+    if (buildBackend && buildFrontend) {
+      // Build both in parallel
+      [backendResult, frontendResult] = await Promise.all([
+        buildBackendSmart(classification.backend, classification, presenter, progress, stageIndices, stageResults),
+        buildFrontendSmart(classification.frontend, classification, presenter, progress, frontendIndex, stageResults)
+      ]);
+    } else if (buildBackend) {
+      backendResult = await buildBackendSmart(classification.backend, classification, presenter, progress, stageIndices, stageResults);
+    } else if (buildFrontend) {
+      frontendResult = await buildFrontendSmart(classification.frontend, classification, presenter, progress, frontendIndex, stageResults);
+    }
+    
+    // Restart PM2 if requested and backend was rebuilt
+    let pm2Result = null;
+    if (args.restart && backendResult && backendResult.success) {
+      pm2Result = await restartPM2(presenter, progress, pm2Index, stageResults);
+      
+      // Give backend a moment to fully start
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+    
+    // Stop spinner before printing final output
+    stopSpinner();
+    
+    // Clear progress bar
+    if (progress && presenter.showProgress) {
+      progress.clear();
+    }
+    
+    // Print stage table
+    if (!args.quiet && stageResults.length > 0) {
+      presenter.printStageTable(stageResults);
+    }
+    
+    const duration = (Date.now() - startTime) / 1000;
+    
+    // Record full build if both were built
+    if (backendResult && frontendResult) {
+      const backendChanges = buildHistory.getBackendChanges();
+      const frontendChanges = buildHistory.getFrontendChanges();
+      buildHistory.recordBuild('full', {
+        changed: [...backendChanges.changed, ...frontendChanges.changed],
+        added: [...backendChanges.added, ...frontendChanges.added],
+        removed: [...backendChanges.removed, ...frontendChanges.removed]
+      }, duration, true);
+    }
+    
+    // Print warnings summary
+    presenter.printWarningsSummary();
+    
+    // Print build summary
+    presenter.printBuildSummary({
+      totalTime: duration,
+      backendTime: backendResult ? backendResult.buildTime : 0,
+      frontendTime: frontendResult ? frontendResult.buildTime : 0,
+      pm2Time: pm2Result ? pm2Result.buildTime : 0,
+      backendFiles: backendResult ? backendResult.files : null,
+      frontendFiles: frontendResult ? frontendResult.files : null
+    });
+    
+    // Print OM.nfo banner
+    if (!args.noBanner) {
+      presenter.printOmNfo(OM_NFO_PATH);
+    }
+    
+    // Print build history
+    const history = buildHistory.getHistory(5);
+    presenter.printBuildHistory(history);
+    
+    if (!args.quiet) {
+      console.log('\n═══════════════════════════════════════════════════════════');
+      console.log(`  ✅ Smart Build Complete! (${duration.toFixed(2)}s)`);
+      console.log('═══════════════════════════════════════════════════════════\n');
+    }
+    
+    process.exit(0);
+  } catch (error) {
+    const duration = (Date.now() - startTime) / 1000;
+    
+    // Stop spinner on failure
+    stopSpinner();
+    
+    // Print stage table even on failure
+    if (!args.quiet && stageResults.length > 0) {
+      presenter.printStageTable(stageResults);
+    }
+    
+    presenter.printErrorSummary(error, 'Smart Build', error.output || error.message);
+    
+    if (!args.quiet) {
+      console.error('\n═══════════════════════════════════════════════════════════');
+      console.error(`  ❌ Smart Build Failed! (${duration.toFixed(2)}s)`);
+      console.error('═══════════════════════════════════════════════════════════\n');
+    }
+    
+    process.exit(1);
+  }
+}
+
+main();

--- a/server/scripts/build-verbose.js
+++ b/server/scripts/build-verbose.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Verbose Build Script
+ * Shows detailed progress like deploy-config-updates.sh
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// ANSI color codes
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  red: '\x1b[31m',
+};
+
+function log(color, message) {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function separator(color = 'green') {
+  log(color, '━'.repeat(70));
+}
+
+function runCommand(cmd, description) {
+  try {
+    console.log();
+    execSync(cmd, { stdio: 'inherit' });
+    return true;
+  } catch (error) {
+    log('red', `✗ ${description} failed`);
+    return false;
+  }
+}
+
+function checkFile(filePath, description) {
+  const fullPath = path.join(__dirname, '..', filePath);
+  if (fs.existsSync(fullPath)) {
+    log('green', `✓ ${description}`);
+    return true;
+  } else {
+    log('red', `✗ ${description}`);
+    return false;
+  }
+}
+
+async function build() {
+  separator('green');
+  log('green', '  OrthodoxMetrics Backend - Verbose Build');
+  separator('green');
+  console.log();
+
+  // Step 1: Clean
+  log('yellow', '1/7 Cleaning previous build...');
+  if (!runCommand('npm run build:clean', 'Clean')) {
+    process.exit(1);
+  }
+  log('green', '✓ Build directory cleaned');
+  console.log();
+
+  // Step 2: TypeScript compilation
+  log('yellow', '2/7 Compiling TypeScript...');
+  if (!runCommand('npm run build:ts', 'TypeScript compilation')) {
+    process.exit(1);
+  }
+  log('green', '✓ TypeScript compiled successfully');
+  console.log();
+
+  // Step 3: Copy assets
+  log('yellow', '3/7 Copying assets and resources...');
+  if (!runCommand('npm run build:copy', 'Copy assets')) {
+    process.exit(1);
+  }
+  log('green', '✓ Assets copied');
+  console.log();
+
+  // Step 4: Post-build library
+  log('yellow', '4/7 Running post-build library tasks...');
+  if (!runCommand('npm run build:post-library', 'Post-build library')) {
+    process.exit(1);
+  }
+  log('green', '✓ Library tasks completed');
+  console.log();
+
+  // Step 5: Verify build
+  log('yellow', '5/7 Verifying build output...');
+  if (!runCommand('npm run build:verify', 'Build verification')) {
+    process.exit(1);
+  }
+  log('green', '✓ Build verification passed');
+  console.log();
+
+  // Step 6: Import checks
+  log('yellow', '6/7 Checking imports...');
+  if (!runCommand('npm run build:verify:imports', 'Import verification')) {
+    process.exit(1);
+  }
+  log('green', '✓ Import checks passed');
+  console.log();
+
+  // Step 7: Flush sessions
+  log('yellow', '7/7 Flushing sessions...');
+  if (!runCommand('npm run build:flush-sessions', 'Session flush')) {
+    process.exit(1);
+  }
+  log('green', '✓ Sessions flushed');
+  console.log();
+
+  // Verify critical files
+  separator('blue');
+  log('blue', '  Verifying Critical Files');
+  separator('blue');
+  console.log();
+
+  checkFile('dist/index.js', 'Main entry point (dist/index.js)');
+  checkFile('dist/config/index.js', 'Config module (dist/config/index.js)');
+  checkFile('dist/config/schema.js', 'Config schema (dist/config/schema.js)');
+  checkFile('dist/config/redact.js', 'Config redact (dist/config/redact.js)');
+  checkFile('dist/routes/library.js', 'Library routes (dist/routes/library.js)');
+  console.log();
+
+  // Success summary
+  separator('green');
+  log('green', '  Build Complete!');
+  separator('green');
+  console.log();
+  
+  log('blue', 'Build artifacts:');
+  console.log('  • Compiled files: dist/');
+  console.log('  • Entry point: dist/index.js');
+  console.log('  • Config module: dist/config/');
+  console.log();
+  
+  log('yellow', 'Next steps:');
+  console.log('  1. Restart backend: pm2 restart orthodox-backend');
+  console.log('  2. Check logs: pm2 logs orthodox-backend --lines 30');
+  console.log('  3. Test endpoints:');
+  console.log('     - curl http://127.0.0.1:3001/api/system/health');
+  console.log('     - curl http://127.0.0.1:3001/api/library/files');
+  console.log();
+}
+
+// Run the build
+build().catch(error => {
+  console.error();
+  log('red', '✗ Build failed with error:');
+  console.error(error);
+  process.exit(1);
+});

--- a/server/scripts/fix-router-exports.js
+++ b/server/scripts/fix-router-exports.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Fix Router Exports
+ * 
+ * Ensures churchOcrRoutes.js has both ES module and CommonJS exports
+ * This script should be run after TypeScript compilation
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const routerFile = path.join(__dirname, '../dist/routes/churchOcrRoutes.js');
+
+console.log('Fixing router exports in:', routerFile);
+
+if (!fs.existsSync(routerFile)) {
+  console.log('⏭️  Router file not found (removed during refactor), skipping');
+  process.exit(0);
+}
+
+let content = fs.readFileSync(routerFile, 'utf8');
+
+// Check if module.exports already exists
+if (content.includes('module.exports = router;')) {
+  console.log('✅ module.exports already present');
+  process.exit(0);
+}
+
+// Find the exports.default line and add module.exports after it
+const exportPattern = /exports\.default\s*=\s*router\s*;/;
+if (!exportPattern.test(content)) {
+  console.error('❌ Could not find exports.default = router;');
+  process.exit(1);
+}
+
+// Replace exports.default = router; with both exports
+// IMPORTANT: Avoid overwriting module.exports entirely to prevent circular dependency issues
+// The compiled code already has exports.default = router from TypeScript
+// We just need to ensure module.exports.default is set for CommonJS compatibility
+// DO NOT use module.exports = router as it overwrites the entire exports object
+const exportLine = 'exports.default = router;';
+if (content.includes(exportLine)) {
+  // Check if module.exports assignment already exists
+  if (!content.includes('module.exports = router;')) {
+    // Add module.exports.default only (don't overwrite module.exports)
+    content = content.replace(
+      exportLine,
+      `${exportLine}\n// CommonJS compatibility: set default without overwriting module.exports\n// This avoids circular dependency warnings\nmodule.exports.default = router;\n// For direct require() compatibility, also set module.exports if it's empty\nif (!module.exports || Object.keys(module.exports).length === 0 || module.exports === exports) {\n    module.exports = router;\n}\n`
+    );
+  }
+}
+
+fs.writeFileSync(routerFile, content, 'utf8');
+console.log('✅ Added module.exports to router file');

--- a/server/scripts/flush-sessions.js
+++ b/server/scripts/flush-sessions.js
@@ -1,0 +1,36 @@
+/**
+ * Flush all sessions from MySQL on build.
+ * Prevents stale/poisoned sessions from surviving a dist rebuild.
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+// Load .env from server root
+const envPath = path.resolve(__dirname, '..', '.env');
+if (fs.existsSync(envPath)) {
+  require('dotenv').config({ path: envPath });
+}
+
+const mysql = require('mysql2/promise');
+
+async function main() {
+  const connection = await mysql.createConnection({
+    host: process.env.AUTH_DB_HOST || process.env.DB_HOST || 'localhost',
+    user: process.env.AUTH_DB_USER || process.env.DB_USER || 'orthodoxapps',
+    password: process.env.AUTH_DB_PASSWORD || process.env.DB_PASSWORD,
+    database: process.env.AUTH_DB_NAME || process.env.AUTH_DB || process.env.DB_NAME || 'orthodoxmetrics_db',
+    port: parseInt(process.env.AUTH_DB_PORT || process.env.DB_PORT || '3306'),
+  });
+
+  const [result] = await connection.execute('DELETE FROM sessions');
+  const count = result.affectedRows || 0;
+  console.log(`[flush-sessions] Cleared ${count} session(s) from database`);
+
+  await connection.end();
+}
+
+main().catch((err) => {
+  // Non-fatal — don't block the build if DB is unreachable (e.g. CI)
+  console.warn(`[flush-sessions] Skipped: ${err.message}`);
+});

--- a/server/scripts/import-check.js
+++ b/server/scripts/import-check.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+/**
+ * Import Check Script
+ * Pre-flight check that all route modules can be imported without crashing
+ * Exits with non-zero code if any imports fail
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+// Routes to check (relative to server directory)
+const routesToCheck = [
+  // API routes (new structure)
+  'src/api/baptism.js',
+  'src/api/marriage.js',
+  'src/api/funeral.js',
+  
+  // Routes (current structure)
+  'src/routes/baptism.js',
+  'src/routes/marriage.js',
+  'src/routes/funeral.js',
+  'src/routes/logs.js',
+  'src/routes/library.js',
+  'src/routes/admin/churches.js',
+  'src/routes/admin/users.js',
+  
+  // Middleware
+  'src/middleware/logger.js',
+  'src/middleware/auth.js',
+  
+  // Main entry point (after build)
+  'dist/index.js'
+  // Note: src/index.ts is TypeScript - check dist/index.js after compilation
+];
+
+let hasErrors = false;
+const errors = [];
+
+console.log('🔍 Checking route module imports...\n');
+
+for (const routePath of routesToCheck) {
+  const fullPath = path.join(__dirname, '..', routePath);
+  
+  if (!fs.existsSync(fullPath)) {
+    console.log(`⚠️  SKIP: ${routePath} (file not found)`);
+    continue;
+  }
+  
+    try {
+      // Change to server directory for relative requires
+      const originalCwd = process.cwd();
+      process.chdir(path.join(__dirname, '..'));
+      
+      try {
+        require(fullPath);
+        console.log(`✅ PASS: ${routePath}`);
+      } catch (error) {
+        if (error.code === 'MODULE_NOT_FOUND') {
+          // Check if it's a missing dependency (not the file itself)
+          const errorMsg = error.message || String(error);
+          if (errorMsg.includes('Cannot find module') && !errorMsg.includes(routePath)) {
+            console.log(`❌ FAIL: ${routePath} - Missing module: ${error.message}`);
+            errors.push({ route: routePath, error: error.message });
+            hasErrors = true;
+          } else {
+            // File itself not found - skip (might be optional)
+            console.log(`⚠️  SKIP: ${routePath} - ${error.message}`);
+          }
+        } else if (error.message && error.message.includes('Unexpected token')) {
+          // TypeScript syntax error - skip TS files
+          console.log(`⚠️  SKIP: ${routePath} - TypeScript file (check after compilation)`);
+        } else {
+          // Other errors might be expected (e.g., missing env vars, database connections)
+          console.log(`⚠️  WARN: ${routePath} - ${error.message}`);
+        }
+      } finally {
+        process.chdir(originalCwd);
+      }
+    } catch (error) {
+      // Outer catch for file system errors
+      if (error.code === 'MODULE_NOT_FOUND' && error.message.includes(routePath)) {
+        console.log(`⚠️  SKIP: ${routePath} - File not found`);
+      } else {
+        console.log(`❌ FAIL: ${routePath} - ${error.message}`);
+        errors.push({ route: routePath, error: error.message });
+        hasErrors = true;
+      }
+    }
+}
+
+console.log('\n' + '='.repeat(60));
+
+if (hasErrors) {
+  console.log('❌ Import check FAILED');
+  console.log('\nErrors:');
+  errors.forEach(({ route, error }) => {
+    console.log(`  - ${route}: ${error}`);
+  });
+  process.exit(1);
+} else {
+  console.log('✅ All route imports successful');
+  process.exit(0);
+}

--- a/server/scripts/post-build-library.js
+++ b/server/scripts/post-build-library.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Post-build script to add library router to dist/index.js
+ * This runs automatically after the TypeScript compilation
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DIST_INDEX = path.join(__dirname, '../dist/index.js');
+
+console.log('\n📚 [post-build-library] Adding library router to dist/index.js...');
+
+try {
+  // Read the compiled index.js
+  let content = fs.readFileSync(DIST_INDEX, 'utf8');
+  
+  // Check if library router is already added (to avoid duplicates)
+  if (content.includes('const libraryRouter = require')) {
+    console.log('✅ [post-build-library] Library router already present in dist/index.js');
+    process.exit(0);
+  }
+  
+  // Add library router import after routerMenuRouter
+  const importPattern = /(const routerMenuRouter = require\('\.\/routes\/routerMenu'\);)/;
+  if (!importPattern.test(content)) {
+    console.error('❌ [post-build-library] Could not find routerMenuRouter import');
+    process.exit(1);
+  }
+  
+  content = content.replace(
+    importPattern,
+    "$1\nconst libraryRouter = require('./routes/library');"
+  );
+  
+  // Add library router mounting after omb router
+  const mountPattern = /(app\.use\('\/api\/omb', ombRouter\);)/;
+  if (!mountPattern.test(content)) {
+    console.error('❌ [post-build-library] Could not find omb router mounting');
+    process.exit(1);
+  }
+  
+  content = content.replace(
+    mountPattern,
+    "$1\n// Library routes for document library management\napp.use('/api/library', libraryRouter);\nconsole.log('✅ [Server] Mounted /api/library routes');"
+  );
+  
+  // Write back to file
+  fs.writeFileSync(DIST_INDEX, content, 'utf8');
+  
+  console.log('✅ [post-build-library] Library router successfully added to dist/index.js');
+  process.exit(0);
+  
+} catch (error) {
+  console.error('❌ [post-build-library] Error:', error.message);
+  process.exit(1);
+}

--- a/server/scripts/reset-password.js
+++ b/server/scripts/reset-password.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Reset a user's password by email address.
+ *
+ * Usage:
+ *   node server/scripts/reset-password.js <email> <new-password>
+ *
+ * Example:
+ *   node server/scripts/reset-password.js john@example.com NewPass123!
+ */
+
+const bcrypt = require('bcrypt');
+const mysql = require('mysql2/promise');
+
+const dbConfig = {
+  host: process.env.DB_HOST || 'localhost',
+  user: process.env.DB_USER || 'orthodoxapps',
+  password: process.env.DB_PASSWORD || 'Summerof1982@!',
+  database: 'orthodoxmetrics_db',
+  connectTimeout: 10000,
+};
+
+async function resetPassword(email, newPassword) {
+  if (!email || !newPassword) {
+    console.error('Usage: node reset-password.js <email> <new-password>');
+    process.exit(1);
+  }
+
+  if (newPassword.length < 8) {
+    console.error('Password must be at least 8 characters.');
+    process.exit(1);
+  }
+
+  let connection;
+  try {
+    connection = await mysql.createConnection(dbConfig);
+
+    // Look up user
+    const [users] = await connection.query(
+      'SELECT id, email, first_name, last_name, role, is_active FROM users WHERE email = ?',
+      [email]
+    );
+
+    if (users.length === 0) {
+      console.error(`No user found with email: ${email}`);
+      process.exit(1);
+    }
+
+    const user = users[0];
+    console.log(`Found user: ${user.first_name} ${user.last_name} (${user.email}) [${user.role}] active=${user.is_active}`);
+
+    // Hash new password
+    const passwordHash = await bcrypt.hash(newPassword, 10);
+
+    // Update
+    await connection.query(
+      'UPDATE users SET password_hash = ?, updated_at = NOW() WHERE id = ?',
+      [passwordHash, user.id]
+    );
+
+    console.log(`Password reset successfully for ${user.email} (id=${user.id}).`);
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  } finally {
+    if (connection) await connection.end();
+  }
+}
+
+const [,, email, newPassword] = process.argv;
+resetPassword(email, newPassword).then(() => process.exit(0));

--- a/server/scripts/test-omd-1302.sh
+++ b/server/scripts/test-omd-1302.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+#
+# test-omd-1302.sh — Verify the PR #826 / OMD-1302 test plan.
+#
+# Clones the repo into a scratch dir at a chosen ref, then runs the five
+# checks from the PR's test plan and stores results to disk.
+#
+# Usage:
+#   ./server/scripts/test-omd-1302.sh [-r <git-ref>] [-e <path-to-real-.env>] \
+#                                     [-o <output-dir>] [-u <repo-url>] [-s] [-h]
+#
+# Options:
+#   -r  Git ref to test (branch, tag, or SHA). Default: PR #826 branch.
+#   -e  Path to a real front-end/.env for var-name parity comparison.
+#       Default: /var/www/orthodoxmetrics/prod/front-end/.env
+#   -o  Output directory for results. Default: /tmp/omd-1302-test-<ts>
+#   -u  Repo URL to clone. Default: current repo's origin remote.
+#   -s  Skip the npm ci + npm run build steps (fast mode).
+#   -h  Print this help.
+#
+# Exit codes:
+#   0  All checks passed
+#   1  One or more checks failed
+#   2  Script-level error (bad args, tool missing, clone failed, etc.)
+
+set -u
+set -o pipefail
+
+# ------------------------------------------------------------------------
+# Defaults
+# ------------------------------------------------------------------------
+DEFAULT_REF="chore/1302-phase-4-un-ignore-server-scripts-commit-front-end"
+DEFAULT_ENV="/var/www/orthodoxmetrics/prod/front-end/.env"
+EXPECTED_SCRIPT_COUNT=16
+
+REF="$DEFAULT_REF"
+REAL_ENV="$DEFAULT_ENV"
+OUTPUT_DIR=""
+REPO_URL=""
+SKIP_BUILD=0
+
+# ------------------------------------------------------------------------
+# Arg parsing
+# ------------------------------------------------------------------------
+usage() {
+  sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+while getopts ":r:e:o:u:sh" opt; do
+  case "$opt" in
+    r) REF="$OPTARG" ;;
+    e) REAL_ENV="$OPTARG" ;;
+    o) OUTPUT_DIR="$OPTARG" ;;
+    u) REPO_URL="$OPTARG" ;;
+    s) SKIP_BUILD=1 ;;
+    h) usage ;;
+    \?) echo "Unknown option: -$OPTARG" >&2; exit 2 ;;
+    :)  echo "Option -$OPTARG requires an argument" >&2; exit 2 ;;
+  esac
+done
+
+# Resolve repo URL if not given — read from the CWD's origin remote.
+if [ -z "$REPO_URL" ]; then
+  REPO_URL="$(git -C "$(dirname "$0")/../.." remote get-url origin 2>/dev/null || true)"
+fi
+if [ -z "$REPO_URL" ]; then
+  echo "ERROR: could not determine repo URL. Pass -u <url>." >&2
+  exit 2
+fi
+
+# ------------------------------------------------------------------------
+# Output setup
+# ------------------------------------------------------------------------
+TS="$(date +%Y%m%d-%H%M%S)"
+if [ -z "$OUTPUT_DIR" ]; then
+  OUTPUT_DIR="/tmp/omd-1302-test-$TS"
+fi
+mkdir -p "$OUTPUT_DIR"
+
+LOG_FILE="$OUTPUT_DIR/results.log"
+JSON_FILE="$OUTPUT_DIR/results.json"
+SUMMARY_FILE="$OUTPUT_DIR/summary.txt"
+CLONE_DIR="$OUTPUT_DIR/clone"
+
+# Color helpers (TTY only)
+if [ -t 1 ]; then
+  C_RED=$'\033[31m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'
+  C_CYAN=$'\033[36m'; C_BOLD=$'\033[1m'; C_RESET=$'\033[0m'
+else
+  C_RED=""; C_GREEN=""; C_YELLOW=""; C_CYAN=""; C_BOLD=""; C_RESET=""
+fi
+
+log()  { printf '%s\n' "$*" | tee -a "$LOG_FILE"; }
+info() { printf '%s[INFO]%s  %s\n' "$C_CYAN" "$C_RESET" "$*" | tee -a "$LOG_FILE"; }
+pass() { printf '%s[PASS]%s  %s\n' "$C_GREEN" "$C_RESET" "$*" | tee -a "$LOG_FILE"; }
+fail() { printf '%s[FAIL]%s  %s\n' "$C_RED" "$C_RESET" "$*" | tee -a "$LOG_FILE"; }
+warn() { printf '%s[WARN]%s  %s\n' "$C_YELLOW" "$C_RESET" "$*" | tee -a "$LOG_FILE"; }
+
+# Result accumulator — one line per check, for the JSON summary.
+RESULTS_TMP="$OUTPUT_DIR/.results.tmp"
+: > "$RESULTS_TMP"
+
+record() {
+  # record <id> <name> <pass|fail|skip> <message>
+  local id="$1" name="$2" status="$3" msg="${4:-}"
+  printf '%s\t%s\t%s\t%s\n' "$id" "$name" "$status" "$msg" >> "$RESULTS_TMP"
+}
+
+# JSON-escape a string (handles quotes, backslashes, newlines).
+json_escape() {
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))'
+}
+
+# ------------------------------------------------------------------------
+# Preflight
+# ------------------------------------------------------------------------
+for tool in git python3 node npm; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: required tool '$tool' not on PATH" >&2
+    exit 2
+  fi
+done
+
+info "OMD-1302 test plan runner"
+info "ref:        $REF"
+info "repo:       $REPO_URL"
+info "real .env:  $REAL_ENV"
+info "output:     $OUTPUT_DIR"
+info "skip build: $SKIP_BUILD"
+log  ""
+
+# ------------------------------------------------------------------------
+# Clone
+# ------------------------------------------------------------------------
+info "Cloning $REPO_URL @ $REF into $CLONE_DIR"
+if ! git clone --quiet --branch "$REF" --single-branch --depth 50 \
+      "$REPO_URL" "$CLONE_DIR" >>"$LOG_FILE" 2>&1; then
+  fail "git clone failed — see $LOG_FILE"
+  record clone "fresh clone" fail "git clone failed"
+  exit 2
+fi
+pass "clone succeeded"
+CLONED_SHA="$(git -C "$CLONE_DIR" rev-parse HEAD)"
+info "HEAD: $CLONED_SHA"
+log ""
+
+# ------------------------------------------------------------------------
+# Check 1: server/scripts/ populated with expected count of files
+# ------------------------------------------------------------------------
+info "Check 1: server/scripts/ populated ($EXPECTED_SCRIPT_COUNT files expected)"
+if [ ! -d "$CLONE_DIR/server/scripts" ]; then
+  fail "server/scripts/ directory missing from clone"
+  record 1 "server/scripts populated" fail "directory missing"
+else
+  ACTUAL_COUNT="$(find "$CLONE_DIR/server/scripts" -maxdepth 1 -type f -name '*.js' | wc -l | tr -d ' ')"
+  find "$CLONE_DIR/server/scripts" -maxdepth 1 -type f -name '*.js' -printf '  %f\n' \
+    | sort >> "$LOG_FILE"
+  if [ "$ACTUAL_COUNT" = "$EXPECTED_SCRIPT_COUNT" ]; then
+    pass "server/scripts/ has $ACTUAL_COUNT .js files (expected $EXPECTED_SCRIPT_COUNT)"
+    record 1 "server/scripts populated" pass "$ACTUAL_COUNT files"
+  else
+    fail "server/scripts/ has $ACTUAL_COUNT .js files, expected $EXPECTED_SCRIPT_COUNT"
+    record 1 "server/scripts populated" fail "$ACTUAL_COUNT files (expected $EXPECTED_SCRIPT_COUNT)"
+  fi
+fi
+log ""
+
+# ------------------------------------------------------------------------
+# Check 2: front-end/.env.example exists and var names match real .env
+# ------------------------------------------------------------------------
+info "Check 2: front-end/.env.example exists and matches current .env var names"
+EXAMPLE_PATH="$CLONE_DIR/front-end/.env.example"
+if [ ! -f "$EXAMPLE_PATH" ]; then
+  fail "$EXAMPLE_PATH missing"
+  record 2 ".env.example var parity" fail "file missing"
+elif [ ! -f "$REAL_ENV" ]; then
+  warn "real .env not found at $REAL_ENV — existence-only check"
+  # Still ok for the plan's existence requirement.
+  pass ".env.example exists (parity skipped — no reference .env)"
+  record 2 ".env.example var parity" skip "example exists; no reference .env at $REAL_ENV"
+else
+  # Extract var names (strip inline comments, leading whitespace, 'export ').
+  extract_vars() {
+    grep -E '^[[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*=' "$1" \
+      | sed -E 's/^[[:space:]]*(export[[:space:]]+)?//' \
+      | cut -d= -f1 \
+      | sort -u
+  }
+  EXAMPLE_VARS="$OUTPUT_DIR/.vars-example.txt"
+  REAL_VARS="$OUTPUT_DIR/.vars-real.txt"
+  extract_vars "$EXAMPLE_PATH" > "$EXAMPLE_VARS"
+  extract_vars "$REAL_ENV"     > "$REAL_VARS"
+
+  MISSING_IN_EXAMPLE="$(comm -23 "$REAL_VARS" "$EXAMPLE_VARS" | tr '\n' ',' | sed 's/,$//')"
+  EXTRA_IN_EXAMPLE="$(comm -13 "$REAL_VARS" "$EXAMPLE_VARS" | tr '\n' ',' | sed 's/,$//')"
+
+  {
+    echo "  example vars ($(wc -l < "$EXAMPLE_VARS" | tr -d ' ')):"
+    sed 's/^/    /' "$EXAMPLE_VARS"
+    echo "  real vars ($(wc -l < "$REAL_VARS" | tr -d ' ')):"
+    sed 's/^/    /' "$REAL_VARS"
+  } >> "$LOG_FILE"
+
+  if [ -z "$MISSING_IN_EXAMPLE" ] && [ -z "$EXTRA_IN_EXAMPLE" ]; then
+    pass ".env.example var names match $REAL_ENV exactly"
+    record 2 ".env.example var parity" pass "exact match"
+  else
+    MSG=""
+    [ -n "$MISSING_IN_EXAMPLE" ] && MSG="missing in example: $MISSING_IN_EXAMPLE"
+    [ -n "$EXTRA_IN_EXAMPLE" ] && MSG="$MSG; extra in example: $EXTRA_IN_EXAMPLE"
+    fail ".env.example var names do not match: $MSG"
+    record 2 ".env.example var parity" fail "$MSG"
+  fi
+fi
+log ""
+
+# ------------------------------------------------------------------------
+# Check 3: git check-ignore server/scripts/build-copy.js returns empty
+# ------------------------------------------------------------------------
+info "Check 3: git check-ignore -v server/scripts/build-copy.js (should match nothing)"
+CI3_OUT="$(git -C "$CLONE_DIR" check-ignore -v server/scripts/build-copy.js 2>&1 || true)"
+# check-ignore exit codes: 0=ignored (match), 1=not ignored (no match).
+if [ -z "$CI3_OUT" ]; then
+  pass "server/scripts/build-copy.js is NOT ignored (no gitignore rule matches)"
+  record 3 "build-copy.js not ignored" pass "no match"
+else
+  fail "server/scripts/build-copy.js matched a gitignore rule: $CI3_OUT"
+  record 3 "build-copy.js not ignored" fail "$CI3_OUT"
+fi
+log ""
+
+# ------------------------------------------------------------------------
+# Check 4: git check-ignore server/scripts/backups/ returns a match
+# ------------------------------------------------------------------------
+info "Check 4: git check-ignore -v server/scripts/backups/ (should match)"
+# Trailing slash matters — 'backups/' is a directory-only rule, so without
+# the slash git won't match it when the dir doesn't exist on disk.
+CI4_OUT="$(git -C "$CLONE_DIR" check-ignore -v 'server/scripts/backups/' 2>&1 || true)"
+if [ -n "$CI4_OUT" ]; then
+  pass "server/scripts/backups/ IS ignored — $CI4_OUT"
+  record 4 "backups/ still ignored" pass "$CI4_OUT"
+else
+  fail "server/scripts/backups/ was NOT matched by any gitignore rule (expected to be ignored)"
+  record 4 "backups/ still ignored" fail "no match"
+fi
+log ""
+
+# ------------------------------------------------------------------------
+# Check 5 & 6: npm run build on server/ and front-end/
+# ------------------------------------------------------------------------
+if [ "$SKIP_BUILD" = "1" ]; then
+  warn "skipping npm build steps (-s given)"
+  record 5 "server build"    skip "skipped via -s"
+  record 6 "front-end build" skip "skipped via -s"
+else
+  # Front-end build needs a real .env (VITE_* vars are baked in). Copy one
+  # in from the reference if available, else fall back to .env.example.
+  if [ -f "$REAL_ENV" ]; then
+    cp "$REAL_ENV" "$CLONE_DIR/front-end/.env"
+    info "copied reference .env into front-end/ for build"
+  elif [ -f "$CLONE_DIR/front-end/.env.example" ]; then
+    cp "$CLONE_DIR/front-end/.env.example" "$CLONE_DIR/front-end/.env"
+    warn "no reference .env — using .env.example placeholders for build"
+  fi
+
+  run_build() {
+    # run_build <id> <label> <subdir>
+    local id="$1" label="$2" sub="$3"
+    info "Check $id: npm ci && npm run build in $sub/"
+    local build_log="$OUTPUT_DIR/build-$sub.log"
+    (
+      cd "$CLONE_DIR/$sub" \
+      && npm ci --no-audit --no-fund \
+      && npm run build
+    ) >"$build_log" 2>&1
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+      pass "$label build succeeded (log: $build_log)"
+      record "$id" "$label build" pass "rc=0"
+    else
+      fail "$label build FAILED (rc=$rc, log: $build_log)"
+      # Tail the last 20 lines into the main log for quick inspection.
+      {
+        echo "---- tail of $build_log ----"
+        tail -n 20 "$build_log"
+        echo "----"
+      } >> "$LOG_FILE"
+      record "$id" "$label build" fail "rc=$rc — see $build_log"
+    fi
+  }
+
+  run_build 5 "server"    server
+  run_build 6 "front-end" front-end
+fi
+log ""
+
+# ------------------------------------------------------------------------
+# Summary + JSON
+# ------------------------------------------------------------------------
+TOTAL=0; PASSED=0; FAILED=0; SKIPPED=0
+while IFS=$'\t' read -r id name status msg; do
+  TOTAL=$((TOTAL + 1))
+  case "$status" in
+    pass) PASSED=$((PASSED + 1)) ;;
+    fail) FAILED=$((FAILED + 1)) ;;
+    skip) SKIPPED=$((SKIPPED + 1)) ;;
+  esac
+done < "$RESULTS_TMP"
+
+{
+  echo "OMD-1302 test plan — summary"
+  echo "============================"
+  echo "Timestamp:  $TS"
+  echo "Ref:        $REF"
+  echo "SHA:        $CLONED_SHA"
+  echo "Total:      $TOTAL"
+  echo "Passed:     $PASSED"
+  echo "Failed:     $FAILED"
+  echo "Skipped:    $SKIPPED"
+  echo ""
+  echo "Per-check results:"
+  printf '  %-3s %-30s %-6s %s\n' "ID" "NAME" "STATUS" "MESSAGE"
+  while IFS=$'\t' read -r id name status msg; do
+    printf '  %-3s %-30s %-6s %s\n' "$id" "$name" "$status" "$msg"
+  done < "$RESULTS_TMP"
+} | tee "$SUMMARY_FILE" >> "$LOG_FILE"
+
+# Build JSON via python for robust escaping.
+python3 - "$RESULTS_TMP" "$TS" "$REF" "$CLONED_SHA" "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED" > "$JSON_FILE" <<'PY'
+import json, sys
+tmp, ts, ref, sha, total, passed, failed, skipped = sys.argv[1:9]
+checks = []
+with open(tmp) as f:
+    for line in f:
+        parts = line.rstrip('\n').split('\t')
+        if len(parts) < 4:
+            continue
+        cid, name, status, msg = parts[0], parts[1], parts[2], parts[3]
+        checks.append({"id": cid, "name": name, "status": status, "message": msg})
+out = {
+    "timestamp": ts,
+    "ref": ref,
+    "sha": sha,
+    "totals": {
+        "total": int(total),
+        "passed": int(passed),
+        "failed": int(failed),
+        "skipped": int(skipped),
+    },
+    "checks": checks,
+}
+json.dump(out, sys.stdout, indent=2)
+sys.stdout.write('\n')
+PY
+
+rm -f "$RESULTS_TMP"
+
+log ""
+info "Results:"
+info "  log:     $LOG_FILE"
+info "  summary: $SUMMARY_FILE"
+info "  json:    $JSON_FILE"
+
+if [ "$FAILED" -gt 0 ]; then
+  printf '%s%sOVERALL: FAIL%s  (%d/%d passed, %d skipped)\n' \
+    "$C_BOLD" "$C_RED" "$C_RESET" "$PASSED" "$TOTAL" "$SKIPPED"
+  exit 1
+fi
+
+printf '%s%sOVERALL: PASS%s  (%d/%d passed, %d skipped)\n' \
+  "$C_BOLD" "$C_GREEN" "$C_RESET" "$PASSED" "$TOTAL" "$SKIPPED"
+exit 0

--- a/server/scripts/verify-build.js
+++ b/server/scripts/verify-build.js
@@ -1,0 +1,217 @@
+/*
+  Post-build verification script
+  Verifies that the dist folder contains updated code by:
+  1. Checking that critical files exist
+  2. Comparing modification times of source vs dist files
+  3. Verifying recently modified files are in dist
+*/
+
+const path = require('path');
+const fs = require('fs');
+
+const ROOT = path.resolve(__dirname, '..');
+const DIST = path.join(ROOT, 'dist');
+
+// Files to verify (source -> dist mapping)
+// All source code lives under src/
+const CRITICAL_FILES = [
+  { src: 'src/routes/gallery.js', dist: 'routes/gallery.js', description: 'Gallery routes' },
+  { src: 'src/routes/docs.js', dist: 'routes/docs.js', description: 'Documentation routes' },
+  { src: 'src/config/db.js', dist: 'config/db.js', description: 'Database config' },
+  { src: 'src/config/session.js', dist: 'config/session.js', description: 'Session config' },
+];
+
+// Directories to verify exist
+const CRITICAL_DIRS = [
+  'routes',
+  'middleware',
+  'config',
+  'controllers',
+];
+
+function getFileStats(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    return fs.statSync(filePath);
+  } catch (error) {
+    return null;
+  }
+}
+
+function formatTime(ms) {
+  const date = new Date(ms);
+  return date.toISOString();
+}
+
+function verifyFile(srcPath, distPath, description) {
+  const fullSrcPath = path.join(ROOT, srcPath);
+  const fullDistPath = path.join(DIST, distPath);
+  
+  const srcStats = getFileStats(fullSrcPath);
+  const distStats = getFileStats(fullDistPath);
+  
+  if (!srcStats) {
+    console.warn(`⚠️  Source file not found: ${srcPath}`);
+    return { success: false, reason: 'source_not_found' };
+  }
+  
+  if (!distStats) {
+    console.error(`❌ Dist file missing: ${distPath} (${description})`);
+    return { success: false, reason: 'dist_missing', file: distPath };
+  }
+  
+  // Check if dist file is newer or same age as source (within 5 seconds tolerance for build time)
+  const timeDiff = distStats.mtime.getTime() - srcStats.mtime.getTime();
+  const tolerance = 5000; // 5 seconds
+  
+  if (timeDiff < -tolerance) {
+    console.error(`❌ Dist file is older than source: ${distPath} (${description})`);
+    console.error(`   Source: ${formatTime(srcStats.mtime.getTime())}`);
+    console.error(`   Dist:   ${formatTime(distStats.mtime.getTime())}`);
+    return { success: false, reason: 'dist_outdated', file: distPath };
+  }
+  
+  console.log(`✅ ${description}: ${distPath} (${(distStats.size / 1024).toFixed(2)} KB)`);
+  return { success: true, file: distPath };
+}
+
+function verifyDirectory(dirName) {
+  const distDir = path.join(DIST, dirName);
+  if (!fs.existsSync(distDir)) {
+    console.error(`❌ Dist directory missing: ${dirName}/`);
+    return false;
+  }
+  
+  const stats = fs.statSync(distDir);
+  if (!stats.isDirectory()) {
+    console.error(`❌ Dist path is not a directory: ${dirName}/`);
+    return false;
+  }
+  
+  console.log(`✅ Directory exists: ${dirName}/`);
+  return true;
+}
+
+function main() {
+  console.log('\n🔍 Verifying build output...\n');
+  console.log(`Source: ${ROOT}`);
+  console.log(`Dist:   ${DIST}\n`);
+  
+  if (!fs.existsSync(DIST)) {
+    console.error('❌ Dist directory does not exist!');
+    process.exit(1);
+  }
+  
+  let allPassed = true;
+  const results = {
+    files: [],
+    dirs: [],
+    errors: []
+  };
+  
+  // Verify critical directories
+  console.log('📁 Checking directories...');
+  for (const dir of CRITICAL_DIRS) {
+    const passed = verifyDirectory(dir);
+    results.dirs.push({ dir, passed });
+    if (!passed) allPassed = false;
+  }
+  
+  console.log('\n📄 Checking critical files...');
+  for (const { src, dist, description } of CRITICAL_FILES) {
+    const result = verifyFile(src, dist, description);
+    results.files.push({ src, dist, description, ...result });
+    if (!result.success) {
+      allPassed = false;
+      results.errors.push({ file: dist, reason: result.reason });
+    }
+  }
+  
+  // Check for recently modified files that might not be in dist
+  console.log('\n🔎 Checking for recently modified source files...');
+  const routesDir = path.join(ROOT, 'src', 'routes');
+  if (fs.existsSync(routesDir)) {
+    // Recursively find all .js files in routes directory
+    function findJsFiles(dir, baseDir = dir) {
+      const files = [];
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        const relPath = path.relative(baseDir, fullPath);
+        
+        if (entry.isDirectory()) {
+          files.push(...findJsFiles(fullPath, baseDir));
+        } else if (entry.isFile() && entry.name.endsWith('.js')) {
+          files.push({
+            name: relPath,
+            srcPath: fullPath,
+            distPath: path.join(DIST, 'routes', relPath)
+          });
+        }
+      }
+      return files;
+    }
+    
+    const routeFiles = findJsFiles(routesDir);
+    
+    let recentFilesFound = false;
+    let checkedCount = 0;
+    let upToDateCount = 0;
+    
+    for (const { name, srcPath, distPath } of routeFiles) {
+      checkedCount++;
+      const srcStats = getFileStats(srcPath);
+      const distStats = getFileStats(distPath);
+      
+      if (!srcStats) continue;
+      
+      if (!distStats) {
+        const age = Date.now() - srcStats.mtime.getTime();
+        if (age < 3600000) {
+          console.warn(`⚠️  Missing in dist: routes/${name} (modified ${Math.round(age / 60000)} min ago)`);
+          recentFilesFound = true;
+        }
+      } else if (distStats.mtime < srcStats.mtime) {
+        const age = Date.now() - srcStats.mtime.getTime();
+        const timeDiff = srcStats.mtime.getTime() - distStats.mtime.getTime();
+        // Only warn about files modified in the last hour
+        if (age < 3600000) {
+          console.warn(`⚠️  Outdated in dist: routes/${name} (source is ${Math.round(timeDiff / 1000)}s newer)`);
+          recentFilesFound = true;
+        }
+      } else {
+        upToDateCount++;
+      }
+    }
+    
+    if (!recentFilesFound) {
+      console.log(`✅ No recently modified files found that are missing from dist`);
+      console.log(`   Checked ${checkedCount} route files, ${upToDateCount} are up-to-date in dist`);
+    } else {
+      console.log(`   Checked ${checkedCount} route files, ${upToDateCount} are up-to-date`);
+    }
+  }
+  
+  // Summary
+  console.log('\n' + '='.repeat(60));
+  if (allPassed) {
+    console.log('✅ Build verification PASSED');
+    console.log(`   Verified ${results.files.length} files and ${results.dirs.length} directories`);
+  } else {
+    console.log('❌ Build verification FAILED');
+    console.log(`   ${results.errors.length} error(s) found:`);
+    results.errors.forEach(err => {
+      console.log(`   - ${err.file}: ${err.reason}`);
+    });
+    console.log('\n💡 Tip: Run "npm run build" again to update dist folder');
+  }
+  console.log('='.repeat(60) + '\n');
+  
+  process.exit(allPassed ? 0 : 1);
+}
+
+main();
+

--- a/server/scripts/verify-database-imports.js
+++ b/server/scripts/verify-database-imports.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Verification script to ensure all routes use correct database imports
+ * Checks that no routes import '../database' (which doesn't exist in dist)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DIST_DIR = path.join(__dirname, '..', 'dist');
+const ROUTES_DIR = path.join(DIST_DIR, 'routes');
+
+let errors = [];
+let warnings = [];
+
+function checkFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const relativePath = path.relative(DIST_DIR, filePath);
+  
+  // Check for problematic imports
+  if (content.includes("require('../database')") || 
+      content.includes('require("../database")') ||
+      content.includes("require('../../database')") ||
+      content.includes('require("../../database")')) {
+    errors.push(`❌ ${relativePath}: Contains require('../database') which doesn't exist in dist`);
+  }
+  
+  // Check for DatabaseManager.getPool() usage (should use getAppPool instead)
+  if (content.includes('DatabaseManager.getPool()')) {
+    errors.push(`❌ ${relativePath}: Uses DatabaseManager.getPool() - should use getAppPool()`);
+  }
+  
+  // Warn if using '../config/db' instead of '../../config/db-compat' (works but inconsistent)
+  if (content.includes("require('../config/db')") && !content.includes('interactiveReports')) {
+    warnings.push(`⚠️  ${relativePath}: Uses '../config/db' - consider '../../config/db-compat' for consistency`);
+  }
+}
+
+function checkDirectory(dir) {
+  if (!fs.existsSync(dir)) {
+    console.error(`❌ Directory does not exist: ${dir}`);
+    process.exit(1);
+  }
+  
+  const files = fs.readdirSync(dir, { withFileTypes: true });
+  
+  for (const file of files) {
+    const fullPath = path.join(dir, file.name);
+    
+    if (file.isDirectory()) {
+      checkDirectory(fullPath);
+    } else if (file.name.endsWith('.js') && !file.name.endsWith('.backup') && !file.name.endsWith('.back')) {
+      checkFile(fullPath);
+    }
+  }
+}
+
+// Verify required config files exist
+function verifyConfigFiles() {
+  const requiredFiles = [
+    'dist/config/db.js',
+    'dist/config/db-compat.js'
+  ];
+  
+  for (const file of requiredFiles) {
+    const fullPath = path.join(__dirname, '..', file);
+    if (!fs.existsSync(fullPath)) {
+      errors.push(`❌ Missing required file: ${file}`);
+    } else {
+      console.log(`✅ Found: ${file}`);
+    }
+  }
+}
+
+console.log('🔍 Verifying database imports in dist/routes...\n');
+
+// Check config files first
+verifyConfigFiles();
+console.log('');
+
+// Check all route files
+if (fs.existsSync(ROUTES_DIR)) {
+  checkDirectory(ROUTES_DIR);
+} else {
+  errors.push(`❌ Routes directory does not exist: ${ROUTES_DIR}`);
+}
+
+// Report results
+console.log('\n📊 Results:\n');
+
+if (warnings.length > 0) {
+  console.log('⚠️  Warnings:');
+  warnings.forEach(w => console.log(`   ${w}`));
+  console.log('');
+}
+
+if (errors.length > 0) {
+  console.log('❌ Errors found:');
+  errors.forEach(e => console.log(`   ${e}`));
+  console.log('\n❌ Verification FAILED');
+  process.exit(1);
+} else {
+  console.log('✅ All database imports are correct!');
+  console.log('✅ No require("../database") found');
+  console.log('✅ No DatabaseManager.getPool() usage found');
+  process.exit(0);
+}

--- a/server/scripts/verify-interactive-reports-build.js
+++ b/server/scripts/verify-interactive-reports-build.js
@@ -1,0 +1,46 @@
+/**
+ * Verification script for interactive reports build
+ * Checks that all required files exist in dist/ after build
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DIST = path.join(__dirname, '..', 'dist');
+
+const requiredFiles = [
+  'routes/interactiveReports.js',
+  'utils/tokenUtils.js',
+  'utils/emailService.js',
+  'middleware/rateLimiter.js',
+  'config/db.js',
+  'middleware/auth.js',
+];
+
+console.log('🔍 Verifying interactive reports build...\n');
+
+let allFound = true;
+
+for (const file of requiredFiles) {
+  const fullPath = path.join(DIST, file);
+  const exists = fs.existsSync(fullPath);
+  
+  if (exists) {
+    console.log(`✅ ${file}`);
+  } else {
+    console.log(`❌ ${file} - MISSING`);
+    allFound = false;
+  }
+}
+
+console.log('');
+
+if (allFound) {
+  console.log('✅ All required files found in dist/');
+  console.log('✅ Build verification passed');
+  process.exit(0);
+} else {
+  console.log('❌ Some required files are missing');
+  console.log('❌ Run: npm run build');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Adds `server/scripts/test-omd-1302.sh`, a self-contained runner for the **PR #826 (OMD-1302)** test plan. Clones the repo into a scratch dir at a chosen ref, runs each check, and writes results to disk. Exits 0 on all-pass, 1 on any-fail, 2 on script-level error.

**This PR is stacked on #826** — it lives at `server/scripts/` because root-level `/scripts/` stays ignored in #826. Please merge #826 first, then this retargets to `main`.

## What the script checks

| # | Check | Expected |
|---|-------|----------|
| 1 | `server/scripts/*.js` in the fresh clone | 16 files |
| 2 | `front-end/.env.example` exists + var names match a reference `.env` | exact match |
| 3 | `git check-ignore -v server/scripts/build-copy.js` | no match |
| 4 | `git check-ignore -v server/scripts/backups/` | matched by a rule |
| 5 | `npm ci && npm run build` in `server/` | exit 0 |
| 6 | `npm ci && npm run build` in `front-end/` | exit 0 |

## Output files (default output dir `/tmp/omd-1302-test-<ts>/`)

- `results.log` — full verbose log (every step, stderr from clone/build)
- `summary.txt` — human-readable table
- `results.json` — machine-readable summary (timestamp, ref, sha, per-check status)
- `build-server.log`, `build-front-end.log` — raw npm output
- `clone/` — the scratch clone

## Usage

```bash
# Default — verifies PR #826's branch on current repo's origin remote
./server/scripts/test-omd-1302.sh

# Quick mode (skips npm builds)
./server/scripts/test-omd-1302.sh -s

# Test any ref
./server/scripts/test-omd-1302.sh -r main

# Custom output dir, custom reference .env for var parity
./server/scripts/test-omd-1302.sh -o /tmp/my-run -e /path/to/real/.env

# Local path as repo URL (avoids hitting GitHub)
./server/scripts/test-omd-1302.sh -u /var/www/orthodoxmetrics/prod
```

## Verification during development

- Positive run (PR #826 branch, `-s` fast mode): **4/4 checks PASS**.
- Negative run (against `main` before PR #826 merges): checks 1, 2, 3 FAIL with descriptive messages; check 4 PASS (unrelated gitignore rule still matches); exit code 1.
- **Full run with builds against PR #826 branch: 6/6 checks PASS** (server build rc=0, front-end `✓ built in 1m 15s`).

## Test plan

- [x] `./server/scripts/test-omd-1302.sh -s -r chore/1302-phase-4-un-ignore-server-scripts-commit-front-end` → overall PASS, 4/6 PASS + 2 SKIP
- [x] `./server/scripts/test-omd-1302.sh -s -r main` → overall FAIL, checks 1/2/3 fail as expected
- [x] `./server/scripts/test-omd-1302.sh -r chore/1302-phase-4-un-ignore-server-scripts-commit-front-end` → overall PASS, 6/6 PASS (full build)
- [x] `cat /tmp/omd-1302-test-*/results.json` → valid JSON with totals + checks array

Relates to OMD-1302 (#826).

🤖 Generated with [Claude Code](https://claude.com/claude-code)