### PR TITLE
OMD-1308: remove Horizontal layout option from Customizer

### DIFF
--- a/front-end/src/context/CustomizerContext.tsx
+++ b/front-end/src/context/CustomizerContext.tsx
@@ -94,9 +94,11 @@ export const CustomizerContextProvider: React.FC<CustomizerContextProps> = ({ ch
     const [activeTheme, setActiveThemeState] = useState<string>(() =>
         getStoredValue('activeTheme', config.activeTheme)
     );
-    const [activeLayout, setActiveLayoutState] = useState<string>(() => 
-        getStoredValue('activeLayout', config.activeLayout)
-    );
+    const [activeLayout, setActiveLayoutState] = useState<string>(() => {
+        // Horizontal layout was removed — coerce any stale localStorage value to vertical.
+        const stored = getStoredValue('activeLayout', config.activeLayout);
+        return stored === 'horizontal' ? 'vertical' : stored;
+    });
     const [isCardShadow, setIsCardShadowState] = useState<boolean>(() => 
         getStoredValue('isCardShadow', config.isCardShadow)
     );

--- a/front-end/src/layouts/full/FullLayout.tsx
+++ b/front-end/src/layouts/full/FullLayout.tsx
@@ -4,8 +4,6 @@ import { Outlet, useLocation } from 'react-router-dom';
 import Header from './vertical/header/Header';
 import Sidebar from './vertical/sidebar/Sidebar';
 import Customizer from './shared/customizer/Customizer';
-import Navigation from '../full/horizontal/navbar/Navigation';
-import HorizontalHeader from '../full/horizontal/header/Header';
 import ScrollToTop from '@/shared/ui/ScrollToTop';
 import { CustomizerContext } from '@/context/CustomizerContext';
 import config from '@/context/config';
@@ -43,7 +41,7 @@ const PageWrapper = styled('div')(({ theme }) => ({
 }));
 
 const FullLayout: FC = () => {
-  const { activeLayout, isLayout, activeMode, isCollapse } = useContext(CustomizerContext);
+  const { isLayout, activeMode, isCollapse } = useContext(CustomizerContext);
   const theme = useTheme();
   const { isSuperAdmin } = useAuth();
   const churchCtx = useContext(ChurchContext);
@@ -64,7 +62,7 @@ const FullLayout: FC = () => {
         {/* ------------------------------------------- */}
         {/* Sidebar */}
         {/* ------------------------------------------- */}
-        {activeLayout === 'horizontal' ? '' : <Sidebar />}
+        <Sidebar />
         {/* ------------------------------------------- */}
         {/* Main Wrapper */}
         {/* ------------------------------------------- */}
@@ -83,11 +81,9 @@ const FullLayout: FC = () => {
           {/* ------------------------------------------- */}
           {/* Header */}
           {/* ------------------------------------------- */}
-          {activeLayout === 'horizontal' ? <HorizontalHeader /> : <Header />}
+          <Header />
           {/* Work Session Start Prompt (shows once after login if no active session) */}
           <WorkSessionPrompt />
-          {/* PageContent */}
-          {activeLayout === 'horizontal' ? <Navigation /> : ''}
           <Container
             sx={{
               pt: '30px',

--- a/front-end/src/layouts/full/shared/customizer/Customizer.tsx
+++ b/front-end/src/layouts/full/shared/customizer/Customizer.tsx
@@ -18,7 +18,7 @@ import { useDraggableFab } from '@/hooks/useDraggableFab';
 // @ts-ignore
 import Scrollbar from '@/components/custom-scroll/Scrollbar';
 import { CustomizerContext } from '@/context/CustomizerContext';
-import { BorderOuter, PaddingTwoTone, ViewComfyTwoTone } from '@mui/icons-material';
+import { BorderOuter } from '@mui/icons-material';
 import AspectRatioTwoToneIcon from '@mui/icons-material/AspectRatioTwoTone';
 import CallToActionTwoToneIcon from '@mui/icons-material/CallToActionTwoTone';
 import DarkModeTwoToneIcon from '@mui/icons-material/DarkModeTwoTone';
@@ -60,8 +60,6 @@ const Customizer: FC = () => {
     isCollapse,
     setIsCollapse,
     activeTheme,
-    activeLayout,
-    setActiveLayout,
     isLayout,
     isCardShadow,
     setIsCardShadow,
@@ -291,39 +289,6 @@ const Customizer: FC = () => {
             </Grid2>
             <Box pt={4} />
             {/* ------------------------------------------- */}
-            {/* ------------ Layout Horizontal / Vertical ------------- */}
-            {/* ------------------------------------------- */}
-            <Typography variant="h6" gutterBottom>
-              Layout Type
-            </Typography>
-            <Stack direction={"row"} gap={2} my={2}>
-              <StyledBox
-                onClick={() => setActiveLayout("vertical")}
-                display="flex"
-                gap={1}
-              >
-                <ViewComfyTwoTone
-                  color={
-                    activeLayout === 'vertical' ? "primary" : "inherit"
-                  }
-                />
-                Vertical
-              </StyledBox>
-              <StyledBox
-                onClick={() => setActiveLayout("horizontal")}
-                display="flex"
-                gap={1}
-              >
-                <PaddingTwoTone
-                  color={
-                    activeLayout === 'horizontal' ? "primary" : "inherit"
-                  }
-                />
-                Horizontal
-              </StyledBox>
-            </Stack>
-            <Box pt={4} />
-            {/* ------------------------------------------- */}
             {/* ------------ Layout Boxed / Full ------------- */}
             {/* ------------------------------------------- */}
             <Typography variant="h6" gutterBottom>
@@ -359,41 +324,35 @@ const Customizer: FC = () => {
             {/* ------------------------------------------- */}
 
             {/* ------------------------------------------- */}
-            {/* ------------ Theme Color setting ------------- */}
+            {/* ------------ Sidebar Type ------------- */}
             {/* ------------------------------------------- */}
-            {activeLayout === "horizontal" ? (
-              ""
-            ) : (
-              <>
-                <Typography variant="h6" gutterBottom>
-                  Sidebar Type
-                </Typography>
-                <Stack direction={"row"} gap={2} my={2}>
-                  <StyledBox
-                    onClick={() => {
-                      setIsCollapse('full-sidebar')
-                    }}
-                    display="flex"
-                    gap={1}
-                  >
-                    <WebAssetTwoToneIcon
-                      color={isCollapse === "full-sidebar" ? "primary" : "inherit"}
-                    />
-                    Full
-                  </StyledBox>
-                  <StyledBox
-                    onClick={() => setIsCollapse("mini-sidebar")}
-                    display="flex"
-                    gap={1}
-                  >
-                    <ViewSidebarTwoToneIcon
-                      color={isCollapse === "mini-sidebar" ? "primary" : "inherit"}
-                    />
-                    mini
-                  </StyledBox>
-                </Stack>
-              </>
-            )}
+            <Typography variant="h6" gutterBottom>
+              Sidebar Type
+            </Typography>
+            <Stack direction={"row"} gap={2} my={2}>
+              <StyledBox
+                onClick={() => {
+                  setIsCollapse('full-sidebar')
+                }}
+                display="flex"
+                gap={1}
+              >
+                <WebAssetTwoToneIcon
+                  color={isCollapse === "full-sidebar" ? "primary" : "inherit"}
+                />
+                Full
+              </StyledBox>
+              <StyledBox
+                onClick={() => setIsCollapse("mini-sidebar")}
+                display="flex"
+                gap={1}
+              >
+                <ViewSidebarTwoToneIcon
+                  color={isCollapse === "mini-sidebar" ? "primary" : "inherit"}
+                />
+                mini
+              </StyledBox>
+            </Stack>
             <Box pt={4} />
             <Typography variant="h6" gutterBottom>
               Card With


### PR DESCRIPTION
## Summary

- Removes the Horizontal button from the Customizer's **Layout Type** section (and removes the now-single-option heading entirely, since only Vertical remains).
- Drops the `activeLayout === 'horizontal'` branches in `FullLayout.tsx` and the dead `Navigation` / `HorizontalHeader` imports — the layout is now unconditionally vertical (Sidebar + Header).
- Coerces any stale `localStorage['orthodoxmetrics-activeLayout'] === 'horizontal'` to `'vertical'` on load so users who had horizontal selected don't get stranded.

The horizontal layout components (`layouts/full/horizontal/**`) are left in place for now — this PR removes the entry points, not the whole feature directory.

## Test plan

- [x] Open the Customizer drawer — **Layout Type** section is gone
- [x] Sidebar + vertical header render as before on all pages
- [x] With `localStorage.setItem('orthodoxmetrics-activeLayout', '"horizontal"')` pre-seeded, reload → value is coerced to `vertical` and the sidebar renders (no blank/nav-less page)
- [x] No console errors about missing `activeLayout` / `setActiveLayout` context values
- [x] `tsc --noEmit` clean on the three touched files

Closes OMD-1308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)