### PR TITLE
OMD-1355: reconcile public Pricing CTAs and FAQ with current capabilities

### DIFF
--- a/server/src/routes/i18n.js
+++ b/server/src/routes/i18n.js
@@ -375,7 +375,7 @@ const ENGLISH_DEFAULTS = {
   'pricing.badge_popular': 'Most Popular',
   'pricing.btn_get_started': 'Get Started',
   'pricing.btn_contact_sales': 'Contact Sales',
-  'pricing.btn_start_trial': 'Start Free Trial',
+  'pricing.btn_start_trial': 'Talk to Us',
   // Small Parish features
   'pricing.plan_small_feat1': 'Up to 2,000 records',
   'pricing.plan_small_feat2': '2 user accounts',
@@ -434,18 +434,18 @@ const ENGLISH_DEFAULTS = {
   // FAQ
   'pricing.faq_title': 'Frequently Asked Questions',
   'pricing.faq1_q': 'Can I switch plans later?',
-  'pricing.faq1_a': 'Yes, you can upgrade or downgrade your plan at any time. Changes take effect at the start of your next billing cycle.',
+  'pricing.faq1_a': 'Yes. During the assisted-onboarding phase, your account manager handles plan changes — just let us know what you need.',
   'pricing.faq2_q': 'What happens if I exceed my record limit?',
-  'pricing.faq2_a': 'We\'ll notify you when you\'re approaching your limit. You can either upgrade your plan or archive older records.',
+  'pricing.faq2_a': 'We\'ll notify you when you\'re approaching your limit. You can either move to a larger plan or archive older records.',
   'pricing.faq3_q': 'Is there a setup fee?',
-  'pricing.faq3_a': 'No setup fees. We also offer free onboarding assistance to help you get started with digitizing your records.',
-  'pricing.faq4_q': 'Do you offer discounts for annual billing?',
-  'pricing.faq4_a': 'Yes! Save 15–20% by paying annually instead of monthly.',
+  'pricing.faq3_a': 'No setup fees. We include free onboarding assistance to help you get started with digitizing your records.',
+  'pricing.faq4_q': 'Do you offer annual billing?',
+  'pricing.faq4_a': 'Yes — annual billing options are available. We\'ll discuss the right cadence for your parish during onboarding.',
   'pricing.faq5_q': 'What payment methods do you accept?',
-  'pricing.faq5_a': 'We accept all major credit cards, ACH transfers, and can invoice for annual plans.',
+  'pricing.faq5_a': 'We arrange billing with you during onboarding — credit card, ACH, or invoice for annual plans.',
   // CTA
   'pricing.cta_title': 'Ready to Get Started?',
-  'pricing.cta_subtitle': 'Start your free trial today. No credit card required.',
+  'pricing.cta_subtitle': 'Schedule a 30-minute demo. We\'ll help you set up your parish.',
 
   // ─── samples.* ──────────────────────────────────────────────────────
   // Hero


### PR DESCRIPTION
## Summary

Public-site flow audit (Recommendation 3): the Pricing page promises a self-serve trial, plan-switching, 15–20% annual discounts, and credit-card/ACH/invoicing — but Stripe is explicitly removed (`server/src/api/billing.js:9`) and there is no public checkout. This PR reconciles the copy with reality.

- `pricing.btn_start_trial`: **"Start Free Trial" → "Talk to Us"** (button still routes to `/contact`, only the label changes)
- `pricing.cta_subtitle`: drop "free trial today, no credit card" claim → "Schedule a 30-minute demo. We'll help you set up your parish."
- `pricing.faq1_a`: plan-switching via account manager (not self-serve billing cycle)
- `pricing.faq2_a`: minor copy tightening
- `pricing.faq3_a`: minor copy tightening
- `pricing.faq4_q/_a`: drop specific 15–20% discount claim; offer annual billing with cadence discussed during onboarding
- `pricing.faq5_a`: clarify payment methods are arranged during onboarding

No `Pricing.tsx` changes — the CTAs already route to `/contact`. Only the labels misled visitors.

## Scope

This is the first of five small PRs from `_report/public-site-flow-audit.md` (Recommendations 1–5). Other four (Fix 2 register relabel, Fix 4 header CTA, Fix 5 legal pages, Fix 1 root gate) follow as separate items.

## Test plan

- [x] `/api/i18n/translations?lang=en` returns the new strings (no JS errors when the i18n route reloads)
- [x] `/frontend-pages/pricing` renders without console errors after deploy
- [x] Bottom CTA shows "Talk to Us" instead of "Start Free Trial"
- [x] FAQ entries 1, 4, 5 read correctly
- [x] CTA section subtitle no longer says "free trial today / no credit card"
- [x] Other locales (el/ru/ro/ka) fall back gracefully (translations table may not have these keys yet — English defaults serve as fallback)