### PR TITLE
OMD-1356: rename public inquiry path to /get-started; relabel Login2 link

### DIFF
--- a/front-end/src/config/publicRoutes.ts
+++ b/front-end/src/config/publicRoutes.ts
@@ -18,6 +18,10 @@ export const PUBLIC_ROUTES = {
   CONTACT: '/frontend-pages/contact',
   FAQ: '/frontend-pages/faq',
   LOGIN: '/auth/login',
+  // Inquiry / "talk to us" wizard. Backed by /api/crm-public/inquiry —
+  // not a self-serve account-creation flow. /auth/register is kept as a
+  // backwards-compat alias for admin-issued registration links.
+  GET_STARTED: '/get-started',
 } as const;
 
 /** Navigation links shown in the public header and mobile sidebar. */

--- a/front-end/src/features/auth/authentication/auth1/Register.tsx
+++ b/front-end/src/features/auth/authentication/auth1/Register.tsx
@@ -13,11 +13,11 @@ const Register = () => {
   const { t } = useLanguage();
 
   return (
-    <PageContainer title="Get Started — Orthodox Metrics" description="Church inquiry and registration">
+    <PageContainer title="Get Started — Orthodox Metrics" description="Tell us about your parish — we'll set up a demo and walk you through onboarding.">
       <div className="om-page-container">
         <HpHeader />
 
-        {/* Hero Register Section — mirrors Login2 */}
+        {/* Hero Get Started Section — mirrors Login2 */}
         <section className="om-hero-gradient py-12 md:py-20">
           <div className="max-w-7xl mx-auto px-6">
             <div className="grid md:grid-cols-2 gap-12 items-start">
@@ -28,12 +28,12 @@ const Register = () => {
                 </div>
 
                 <h1 className="font-['Georgia'] text-3xl sm:text-4xl md:text-5xl text-white leading-tight mb-4">
-                  Get Started with{' '}
+                  Talk to{' '}
                   <span className="text-[#d4af37]">Orthodox Metrics</span>
                 </h1>
 
                 <p className="font-['Inter'] text-base md:text-lg text-[rgba(255,255,255,0.7)] leading-relaxed mb-8 max-w-lg">
-                  Tell us about your parish and we'll help you preserve your sacred records with modern, secure technology.
+                  Tell us about your parish. We'll schedule a 30-minute demo and walk you through onboarding — no account creation needed yet.
                 </p>
 
                 {/* Feature bullets */}
@@ -62,7 +62,7 @@ const Register = () => {
                     title="Get Started"
                     subtext={
                       <p className="font-['Inter'] text-[14px] text-[#4a5565] dark:text-gray-400 mb-3">
-                        Tell us about your parish and we'll help you get set up
+                        Send us a quick inquiry — we'll reach out within one business day to schedule your demo.
                       </p>
                     }
                     subtitle={

--- a/front-end/src/features/auth/authentication/auth2/Login2.tsx
+++ b/front-end/src/features/auth/authentication/auth2/Login2.tsx
@@ -72,7 +72,7 @@ const Login2 = () => {
                           {t('auth.new_to_om')}
                         </span>
                         <Link
-                          to="/auth/register"
+                          to="/get-started"
                           className="font-['Inter'] text-[15px] font-medium text-[#2d1b4e] dark:text-[#d4af37] no-underline hover:underline"
                         >
                           {t('auth.create_account')}

--- a/front-end/src/routes/Router.tsx
+++ b/front-end/src/routes/Router.tsx
@@ -899,6 +899,9 @@ const Router = [
       },
       // Root login redirect
       { path: 'login', element: <Navigate to="/auth/login2" replace /> },
+      // Public "Get Started" entry — same Register inquiry wizard.
+      // /auth/register stays as an alias for admin-issued registration-token links.
+      { path: '/get-started', element: <Register /> },
       { path: '/landingpage', element: <Navigate to="/admin/control-panel" replace /> },
       { path: '/pages/pricing', element: <Navigate to="/admin/control-panel" replace /> },
       { path: '/pages/faq', element: <Faq /> },

--- a/server/src/routes/i18n.js
+++ b/server/src/routes/i18n.js
@@ -554,7 +554,7 @@ const ENGLISH_DEFAULTS = {
   'auth.card_heading': 'Sign In',
   'auth.card_subheading': 'Access your parish dashboard',
   'auth.new_to_om': 'New to Orthodox Metrics?',
-  'auth.create_account': 'Create an account',
+  'auth.create_account': 'Get a demo',
   // Form fields
   'auth.label_email': 'Email or Username',
   'auth.label_password': 'Password',


### PR DESCRIPTION
## Summary

Public-site flow audit (Recommendation 2): \`/auth/register\` is a CRM inquiry wizard that posts to \`/api/crm-public/inquiry\` — no account is created. But \`Login2\` advertised the link as **"Create an account"**, which is a bait-and-switch the moment a visitor tries to sign up.

Full rename:
- New \`/get-started\` route → same \`Register\` inquiry component
- \`/auth/register\` kept unchanged as a **backwards-compat alias** for admin-issued registration-token URLs (\`server/src/routes/crm.js:650\` still emits \`/auth/register?token=…&church=…\` and \`AuthRegister.tsx:212-218\` forwards those to \`/auth/register-token\`)
- \`PUBLIC_ROUTES.GET_STARTED\` constant added
- \`Login2\` "Create an account" → **"Get a demo"**, link now points at \`/get-started\`
- \`Register.tsx\` H1, subtitle, and form subtext rewritten to be honest: it's an inquiry/demo request, not account creation

No backend changes. The inquiry wizard itself is unchanged.

## Files

- \`front-end/src/config/publicRoutes.ts\` — added \`GET_STARTED\` constant
- \`front-end/src/routes/Router.tsx\` — added \`/get-started\` route
- \`front-end/src/features/auth/authentication/auth1/Register.tsx\` — H1/subtitle/subtext copy
- \`front-end/src/features/auth/authentication/auth2/Login2.tsx\` — link target
- \`server/src/routes/i18n.js\` — \`auth.create_account: 'Create an account'\` → \`'Get a demo'\`

## Test plan

- [ ] \`/get-started\` renders the inquiry wizard with the new H1 ("Talk to Orthodox Metrics")
- [ ] \`/auth/register\` still renders the inquiry wizard (alias preserved)
- [ ] \`/auth/register?token=ABC&church=…\` still forwards to \`/auth/register-token\` with params (token-based admin flow)
- [ ] \`/auth/login\` Login2 page shows **"Get a demo"** link instead of "Create an account", linking to \`/get-started\`
- [ ] No console errors on either page

## Scope

Second of five small PRs from \`_report/public-site-flow-audit.md\` (Recommendations 1–5). Companion to #837 (Fix 3).