### PR TITLE
OMD-1357: add primary Get Started CTA to public header and mobile sidebar

### DIFF
--- a/front-end/src/components/frontend-pages/shared/header/HpHeader.tsx
+++ b/front-end/src/components/frontend-pages/shared/header/HpHeader.tsx
@@ -159,12 +159,20 @@ const HpHeader = () => {
               authenticated ? (
                 <Profile />
               ) : (
-                <a
-                  href="/auth/login"
-                  className="px-6 py-2.5 bg-[#2d1b4e] dark:bg-[#d4af37] text-white dark:text-[#2d1b4e] rounded-lg font-['Inter'] text-[15px] font-medium hover:bg-[#1f1236] dark:hover:bg-[#c29d2f] transition-colors no-underline"
-                >
-                  {t('common.sign_in')}
-                </a>
+                <>
+                  <a
+                    href="/auth/login"
+                    className="font-['Inter'] text-[15px] text-[#2d1b4e] dark:text-white hover:text-[#1f1236] dark:hover:text-[#d4af37] transition-colors no-underline"
+                  >
+                    {t('common.sign_in')}
+                  </a>
+                  <a
+                    href="/auth/register"
+                    className="px-5 py-2.5 bg-[#d4af37] text-[#2d1b4e] rounded-lg font-['Inter'] text-[15px] font-medium hover:bg-[#c29d2f] transition-colors no-underline"
+                  >
+                    {t('common.get_started')}
+                  </a>
+                </>
               )
             )}
           </div>

--- a/front-end/src/components/frontend-pages/shared/header/MobileSidebar.tsx
+++ b/front-end/src/components/frontend-pages/shared/header/MobileSidebar.tsx
@@ -85,7 +85,18 @@ const MobileSidebar = ({ isPortal = false }: MobileSidebarProps) => {
                   {t(navlink.tKey)}
                 </Button>
               ))}
-              <Button color="primary" variant="contained" href="/auth/login">
+              <Button
+                variant="contained"
+                href="/auth/register"
+                sx={{
+                  backgroundColor: '#d4af37',
+                  color: '#2d1b4e',
+                  '&:hover': { backgroundColor: '#c29d2f' },
+                }}
+              >
+                {t('common.get_started')}
+              </Button>
+              <Button color="primary" variant="outlined" href="/auth/login">
                 {t('common.church_login')}
               </Button>
             </>

--- a/server/src/routes/i18n.js
+++ b/server/src/routes/i18n.js
@@ -31,6 +31,7 @@ const ENGLISH_DEFAULTS = {
   'common.sign_in': 'Sign In',
   'common.sign_out': 'Sign Out',
   'common.church_login': 'Church Login',
+  'common.get_started': 'Get Started',
   'common.dark_mode': 'Dark Mode',
   'common.light_mode': 'Light Mode',
   'common.language': 'Language',


### PR DESCRIPTION
## Summary

Public-site flow audit (Recommendation 4): the public header had only a Sign In button — visitors who do not scroll to the page-level CTA section never saw a conversion path.

- **HpHeader.tsx**: Sign In demoted to a text-link; new **gold primary "Get Started"** button to its right. Both shown only when not authenticated and not in portal-nav mode (church staff already see PortalNavigations).
- **MobileSidebar.tsx**: new gold "Get Started" button above the existing "Church Login" (now outlined to preserve visual hierarchy).
- **i18n.js**: new \`common.get_started\` key.

Both CTAs link to \`/auth/register\` (the inquiry-wizard route; also reachable via \`/get-started\` alias from OMD-1356 / #838).

## Files

- \`front-end/src/components/frontend-pages/shared/header/HpHeader.tsx\`
- \`front-end/src/components/frontend-pages/shared/header/MobileSidebar.tsx\`
- \`server/src/routes/i18n.js\`

## Test plan

- [ ] Public header on every \`/frontend-pages/*\` route shows two buttons on the right when logged out: text-link "Sign In" + gold "Get Started"
- [ ] Get Started button routes to \`/auth/register\` (inquiry wizard)
- [ ] Header CTA hidden when authenticated (Profile menu shows instead)
- [ ] Mobile sidebar shows gold Get Started + outlined Church Login (in that order) when logged out
- [ ] Tablet width (md breakpoint) doesn't break the layout
- [ ] No console errors

## Scope

Third of five small PRs from \`_report/public-site-flow-audit.md\` (Recommendations 1–5). Companions: #837 (Fix 3), #838 (Fix 2).