### PR TITLE
OMD-1358: add Privacy/Terms/Security placeholder pages and Legal footer column

### DIFF
--- a/front-end/src/components/frontend-pages/shared/footer/SiteFooter.tsx
+++ b/front-end/src/components/frontend-pages/shared/footer/SiteFooter.tsx
@@ -9,7 +9,7 @@ const SiteFooter = () => {
   return (
     <footer className="bg-[#2d1b4e] dark:bg-gray-950 text-white">
       <div className="max-w-7xl mx-auto px-6 py-16">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-12">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-12">
           {/* Brand */}
           <div className="col-span-1">
             <div className="flex items-center gap-2 mb-4">
@@ -51,6 +51,23 @@ const SiteFooter = () => {
             <h3 className="font-['Inter'] font-medium text-[16px] mb-4">{t('footer.heading_company')}</h3>
             <ul className="space-y-3 list-none p-0 m-0">
               {FOOTER_LINKS.company.map((link) => (
+                <li key={link.to}>
+                  <Link
+                    to={link.to}
+                    className="font-['Inter'] text-[14px] text-[rgba(255,255,255,0.7)] hover:text-white transition-colors no-underline"
+                  >
+                    {t(link.tKey)}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Legal */}
+          <div>
+            <h3 className="font-['Inter'] font-medium text-[16px] mb-4">{t('footer.heading_legal')}</h3>
+            <ul className="space-y-3 list-none p-0 m-0">
+              {FOOTER_LINKS.legal.map((link) => (
                 <li key={link.to}>
                   <Link
                     to={link.to}

--- a/front-end/src/config/publicRoutes.ts
+++ b/front-end/src/config/publicRoutes.ts
@@ -18,6 +18,9 @@ export const PUBLIC_ROUTES = {
   CONTACT: '/frontend-pages/contact',
   FAQ: '/frontend-pages/faq',
   LOGIN: '/auth/login',
+  PRIVACY: '/privacy',
+  TERMS: '/terms',
+  SECURITY: '/security',
 } as const;
 
 /** Navigation links shown in the public header and mobile sidebar. */
@@ -42,5 +45,10 @@ export const FOOTER_LINKS = {
     { tKey: 'footer.about_us', to: PUBLIC_ROUTES.ABOUT },
     { tKey: 'footer.blog', to: PUBLIC_ROUTES.BLOG },
     { tKey: 'footer.contact', to: PUBLIC_ROUTES.CONTACT },
+  ],
+  legal: [
+    { tKey: 'footer.privacy', to: PUBLIC_ROUTES.PRIVACY },
+    { tKey: 'footer.terms', to: PUBLIC_ROUTES.TERMS },
+    { tKey: 'footer.security', to: PUBLIC_ROUTES.SECURITY },
   ],
 } as const;

--- a/front-end/src/features/pages/frontend-pages/Privacy.tsx
+++ b/front-end/src/features/pages/frontend-pages/Privacy.tsx
@@ -1,0 +1,46 @@
+import { HeroSection } from '@/components/frontend-pages/shared/sections';
+import EditableText from '@/components/frontend-pages/shared/EditableText';
+import PageContainer from '@/shared/ui/PageContainer';
+import { useLanguage } from '@/context/LanguageContext';
+
+const Privacy = () => {
+  const { t } = useLanguage();
+
+  return (
+    <PageContainer title="Privacy Policy" description="Orthodox Metrics privacy policy">
+      <HeroSection
+        badge={t('privacy.hero_badge')}
+        title={t('privacy.hero_title')}
+        subtitle={t('privacy.hero_subtitle')}
+        editKeyPrefix="privacy.hero"
+      />
+
+      <section className="py-20 om-section-base">
+        <div className="max-w-3xl mx-auto px-6">
+          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-6 mb-8">
+            <EditableText contentKey="privacy.draft_notice" as="p" className="font-['Inter'] text-[15px] text-amber-900 dark:text-amber-200 leading-relaxed" multiline>
+              {t('privacy.draft_notice')}
+            </EditableText>
+          </div>
+
+          <EditableText contentKey="privacy.body_p1" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
+            {t('privacy.body_p1')}
+          </EditableText>
+          <EditableText contentKey="privacy.body_p2" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
+            {t('privacy.body_p2')}
+          </EditableText>
+
+          <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mt-8">
+            {t('privacy.contact_prefix')}{' '}
+            <a href="mailto:legal@orthodoxmetrics.com" className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline">
+              legal@orthodoxmetrics.com
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+    </PageContainer>
+  );
+};
+
+export default Privacy;

--- a/front-end/src/features/pages/frontend-pages/Security.tsx
+++ b/front-end/src/features/pages/frontend-pages/Security.tsx
@@ -1,0 +1,46 @@
+import { HeroSection } from '@/components/frontend-pages/shared/sections';
+import EditableText from '@/components/frontend-pages/shared/EditableText';
+import PageContainer from '@/shared/ui/PageContainer';
+import { useLanguage } from '@/context/LanguageContext';
+
+const Security = () => {
+  const { t } = useLanguage();
+
+  return (
+    <PageContainer title="Security" description="Orthodox Metrics security and trust">
+      <HeroSection
+        badge={t('security.hero_badge')}
+        title={t('security.hero_title')}
+        subtitle={t('security.hero_subtitle')}
+        editKeyPrefix="security.hero"
+      />
+
+      <section className="py-20 om-section-base">
+        <div className="max-w-3xl mx-auto px-6">
+          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-6 mb-8">
+            <EditableText contentKey="security.draft_notice" as="p" className="font-['Inter'] text-[15px] text-amber-900 dark:text-amber-200 leading-relaxed" multiline>
+              {t('security.draft_notice')}
+            </EditableText>
+          </div>
+
+          <EditableText contentKey="security.body_p1" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
+            {t('security.body_p1')}
+          </EditableText>
+          <EditableText contentKey="security.body_p2" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
+            {t('security.body_p2')}
+          </EditableText>
+
+          <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mt-8">
+            {t('security.contact_prefix')}{' '}
+            <a href="mailto:security@orthodoxmetrics.com" className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline">
+              security@orthodoxmetrics.com
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+    </PageContainer>
+  );
+};
+
+export default Security;

--- a/front-end/src/features/pages/frontend-pages/Terms.tsx
+++ b/front-end/src/features/pages/frontend-pages/Terms.tsx
@@ -1,0 +1,46 @@
+import { HeroSection } from '@/components/frontend-pages/shared/sections';
+import EditableText from '@/components/frontend-pages/shared/EditableText';
+import PageContainer from '@/shared/ui/PageContainer';
+import { useLanguage } from '@/context/LanguageContext';
+
+const Terms = () => {
+  const { t } = useLanguage();
+
+  return (
+    <PageContainer title="Terms of Service" description="Orthodox Metrics terms of service">
+      <HeroSection
+        badge={t('terms.hero_badge')}
+        title={t('terms.hero_title')}
+        subtitle={t('terms.hero_subtitle')}
+        editKeyPrefix="terms.hero"
+      />
+
+      <section className="py-20 om-section-base">
+        <div className="max-w-3xl mx-auto px-6">
+          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-6 mb-8">
+            <EditableText contentKey="terms.draft_notice" as="p" className="font-['Inter'] text-[15px] text-amber-900 dark:text-amber-200 leading-relaxed" multiline>
+              {t('terms.draft_notice')}
+            </EditableText>
+          </div>
+
+          <EditableText contentKey="terms.body_p1" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
+            {t('terms.body_p1')}
+          </EditableText>
+          <EditableText contentKey="terms.body_p2" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
+            {t('terms.body_p2')}
+          </EditableText>
+
+          <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mt-8">
+            {t('terms.contact_prefix')}{' '}
+            <a href="mailto:legal@orthodoxmetrics.com" className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline">
+              legal@orthodoxmetrics.com
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+    </PageContainer>
+  );
+};
+
+export default Terms;

--- a/front-end/src/routes/Router.tsx
+++ b/front-end/src/routes/Router.tsx
@@ -190,6 +190,9 @@ const WelcomeMessage = Loadable(lazy(() => import('../features/pages/frontend-pa
 const Tour = Loadable(lazy(() => import('../features/pages/frontend-pages/Tour')));
 const Faq = Loadable(lazy(() => import('../features/pages/frontend-pages/Faq')));
 const SacramentalRestrictionsPublicPage = Loadable(lazy(() => import('../features/pages/frontend-pages/SacramentalRestrictionsPublicPage')));
+const Privacy = Loadable(lazy(() => import('../features/pages/frontend-pages/Privacy')));
+const Terms = Loadable(lazy(() => import('../features/pages/frontend-pages/Terms')));
+const Security = Loadable(lazy(() => import('../features/pages/frontend-pages/Security')));
 
 const CertificateGeneratorPage = Loadable(lazy(() => import('../features/certificates/CertificateGeneratorPage')));
 
@@ -924,6 +927,9 @@ const Router = [
           { path: '/frontend-pages/samples', element: <Samples /> },
           { path: '/samples/explorer', element: <SampleRecordsExplorer /> },
           { path: '/tour', element: <Tour /> },
+          { path: '/privacy', element: <Privacy /> },
+          { path: '/terms', element: <Terms /> },
+          { path: '/security', element: <Security /> },
         ],
       },
       { path: '/greek_baptism_table_demo.html', element: <GreekRecordsViewer /> },

--- a/server/src/routes/i18n.js
+++ b/server/src/routes/i18n.js
@@ -56,6 +56,7 @@ const ENGLISH_DEFAULTS = {
   'footer.tagline': 'Preserving sacred records for Orthodox Christian parishes.',
   'footer.heading_product': 'Product',
   'footer.heading_company': 'Company',
+  'footer.heading_legal': 'Legal',
   'footer.heading_support': 'Support',
   'footer.platform_tour': 'Platform Tour',
   'footer.sample_records': 'Sample Records',
@@ -63,8 +64,38 @@ const ENGLISH_DEFAULTS = {
   'footer.about_us': 'About Us',
   'footer.blog': 'Blog',
   'footer.contact': 'Contact',
+  'footer.privacy': 'Privacy Policy',
+  'footer.terms': 'Terms of Service',
+  'footer.security': 'Security',
   'footer.hours': 'Monday – Friday, 9am – 5pm EST',
   'footer.copyright': '© {year} Orthodox Metrics. All rights reserved.',
+
+  // ─── privacy.* ──────────────────────────────────────────────────────
+  'privacy.hero_badge': 'Legal',
+  'privacy.hero_title': 'Privacy Policy',
+  'privacy.hero_subtitle': 'How Orthodox Metrics collects, stores, and protects parish data.',
+  'privacy.draft_notice': 'This page is being finalized. The full Privacy Policy is under legal review and will be published here. For questions about how we handle your parish\'s data today, please email us using the address below.',
+  'privacy.body_p1': 'Orthodox Metrics processes sacramental records and parish administrative data on behalf of subscribed parishes. Each parish remains the data controller for its records; Orthodox Metrics acts as a data processor under your direction.',
+  'privacy.body_p2': 'When the full policy is published it will cover what we collect, how we store and secure it, how long we retain it, your rights, who we share it with (if anyone), our subprocessors, breach notification, and how we handle requests for access, correction, and deletion.',
+  'privacy.contact_prefix': 'For privacy questions or data requests, contact',
+
+  // ─── terms.* ────────────────────────────────────────────────────────
+  'terms.hero_badge': 'Legal',
+  'terms.hero_title': 'Terms of Service',
+  'terms.hero_subtitle': 'The agreement between Orthodox Metrics and your parish.',
+  'terms.draft_notice': 'This page is being finalized. The full Terms of Service are under legal review and will be published here. For questions about subscription terms, acceptable use, or contractual matters today, please email us using the address below.',
+  'terms.body_p1': 'These Terms will govern your parish\'s use of Orthodox Metrics, including subscription, payment, acceptable use, intellectual property, warranty, liability, and termination.',
+  'terms.body_p2': 'Until the full Terms are published, the working agreement is the onboarding letter or service order signed with your parish during setup. If you have not received one, please reach out to us.',
+  'terms.contact_prefix': 'For contract or licensing questions, contact',
+
+  // ─── security.* ─────────────────────────────────────────────────────
+  'security.hero_badge': 'Trust',
+  'security.hero_title': 'Security',
+  'security.hero_subtitle': 'How we protect your parish\'s sacramental records.',
+  'security.draft_notice': 'This page is being finalized. A full security overview — covering hosting, encryption, backup posture, role separation, audit logging, and our compliance roadmap — is being prepared. For specific security questions today, please email us using the address below.',
+  'security.body_p1': 'Orthodox Metrics is built around the principle that sacramental records are irreplaceable. Each parish gets an isolated tenant database. Access is gated by role-based permissions and audit-logged. Records are backed up regularly and stored in a hardened hosting environment.',
+  'security.body_p2': 'When the full security page is published it will cover hosting and data residency, encryption at rest and in transit, backup retention and recovery objectives, tenant isolation, role-based access control, audit logging, vendor management, our compliance posture (GDPR/CCPA), and breach disclosure commitments.',
+  'security.contact_prefix': 'For security questions, vulnerability reports, or compliance inquiries, contact',
 
   // ─── home.* ─────────────────────────────────────────────────────
   // Hero


### PR DESCRIPTION
## Summary

Public-site flow audit (Recommendation 5): the footer had **no Privacy / Terms / Security links** — a hard blocker for any future paid self-serve flow. This PR adds three honest placeholder pages, wires them into a new Legal footer column, and routes them through \`PublicLayout\`.

## What's added

**Three new placeholder pages** under \`front-end/src/features/pages/frontend-pages/\`:
- \`Privacy.tsx\` → \`/privacy\` — privacy policy placeholder
- \`Terms.tsx\` → \`/terms\` — terms of service placeholder
- \`Security.tsx\` → \`/security\` — security/trust placeholder

Each page:
- Reuses shared \`HeroSection\` for visual consistency with About/Pricing/etc.
- Carries a prominent **amber draft-notice banner** explicitly stating the page is being finalized and pointing to the right inbox
- Two paragraphs of body text describing what the final page will cover (data handling commitments, contract scope, security posture)
- \`EditableText\` keys throughout, so super_admin inline-edit mode works
- Contact mailto: \`legal@orthodoxmetrics.com\` for Privacy/Terms; \`security@orthodoxmetrics.com\` for Security

**Routing & footer wiring**:
- \`front-end/src/routes/Router.tsx\`: lazy imports + three new routes under \`PublicLayout\` (so they get HpHeader + SiteFooter automatically)
- \`front-end/src/config/publicRoutes.ts\`: added \`PRIVACY\`, \`TERMS\`, \`SECURITY\` constants and \`FOOTER_LINKS.legal\` group
- \`front-end/src/components/frontend-pages/shared/footer/SiteFooter.tsx\`: expanded grid from \`md:grid-cols-4\` → \`md:grid-cols-2 lg:grid-cols-5\` (responsive to tablet) and rendered the new Legal column between Company and Support
- \`server/src/routes/i18n.js\`: 17 new keys (footer.heading_legal, footer.privacy, footer.terms, footer.security, plus the page-level keys)

## Out of scope

Real legal copy still needs counsel — flagged in audit. The placeholders are honest about being drafts and route inquiries to legal@/security@ inboxes. Counsel-reviewed text can swap in later via either inline-edit mode or by replacing the i18n defaults.

## Test plan

- [x] \`/privacy\`, \`/terms\`, \`/security\` each render with HpHeader + SiteFooter
- [x] Each page shows the amber draft-notice banner
- [x] Footer (on every public page) shows a new "Legal" column with three links between Company and Support
- [x] Footer responsive: 1-col mobile → 2-col md → 5-col lg, no overflow
- [x] Mailto links open mail client
- [x] No console errors
- [x] super_admin inline-edit mode works for the new pages (EditableText hooks)

## Scope

Fourth of five small PRs from \`_report/public-site-flow-audit.md\` (Recommendations 1–5). Companions: #837 (Fix 3), #838 (Fix 2), #839 (Fix 4).