### PR TITLE
OMD-1359: apex / serves marketing Homepage for unauthenticated visitors

### DIFF
--- a/front-end/src/components/routing/RootGate.tsx
+++ b/front-end/src/components/routing/RootGate.tsx
@@ -1,0 +1,55 @@
+import { lazy, Suspense, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
+import HpHeader from '@/components/frontend-pages/shared/header/HpHeader';
+import SiteFooter from '@/components/frontend-pages/shared/footer/SiteFooter';
+
+const Homepage = lazy(() => import('@/features/pages/frontend-pages/Homepage'));
+
+/**
+ * RootGate — what `/` does for unauthenticated visitors.
+ *
+ * Unauthenticated users see the marketing Homepage immediately (wrapped in
+ * the public HpHeader + SiteFooter), with no auth-check spinner. A first-time
+ * visitor typing the apex URL lands on marketing copy, not the login screen.
+ *
+ * Authenticated users get role-based redirected to their dashboard via
+ * useEffect (super_admin / admin → /admin/control-panel, everyone else → /portal).
+ * They may briefly see the Homepage before the redirect fires; this matches
+ * the standard SaaS pattern.
+ *
+ * Replaces SmartRedirect at `/`. SmartRedirect is still importable for any
+ * other call site that needs the spinner-then-decide behavior.
+ */
+const RootGate = () => {
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const authenticated = auth?.authenticated ?? false;
+  const user = auth?.user;
+
+  useEffect(() => {
+    if (!authenticated || !user) return;
+
+    if (user.email === 'frjames@ssppoc.org') {
+      navigate('/portal', { replace: true });
+      return;
+    }
+    if (user.role === 'super_admin' || user.role === 'admin') {
+      navigate('/admin/control-panel', { replace: true });
+      return;
+    }
+    navigate('/portal', { replace: true });
+  }, [authenticated, user, navigate]);
+
+  return (
+    <div className="om-page-container">
+      <HpHeader />
+      <Suspense fallback={null}>
+        <Homepage />
+      </Suspense>
+      <SiteFooter />
+    </div>
+  );
+};
+
+export default RootGate;

--- a/front-end/src/routes/Router.tsx
+++ b/front-end/src/routes/Router.tsx
@@ -8,6 +8,7 @@ import { createBrowserRouter, Navigate } from 'react-router-dom';
 import ProtectedRoute from '../components/auth/ProtectedRoute';
 import AdminErrorBoundary from '../components/ErrorBoundary/AdminErrorBoundary';
 import SmartRedirect from '../components/routing/SmartRedirect';
+import RootGate from '../components/routing/RootGate';
 import Loadable from '../layouts/full/shared/loadable/Loadable';
 
 // Route sub-modules
@@ -204,11 +205,17 @@ function AccountLayoutSwitcher() {
 }
 
 const Router = [
+  // Root: unauthenticated visitors see the marketing Homepage; authenticated
+  // users are redirected to their role-appropriate dashboard. Renders its own
+  // HpHeader + SiteFooter so it does not need FullLayout (which gates on auth).
+  {
+    path: '/',
+    element: <RootGate />,
+  },
   {
     path: '/',
     element: <FullLayout />,
     children: [
-      { path: '/', element: <SmartRedirect /> },
       {
         path: '/dashboards/modern',
         exact: true,


### PR DESCRIPTION
## Summary

**Highest-priority fix** from \`_report/public-site-flow-audit.md\` (Recommendation 1). Previously \`GET /\` dropped unauthenticated visitors on \`/auth/login\` via \`SmartRedirect\` — a first-time visitor typing \`orthodoxmetrics.com\` saw a login screen instead of the marketing site. The marketing Homepage was reachable only at \`/frontend-pages/homepage\`, which no inbound link points to.

## What's added

**\`front-end/src/components/routing/RootGate.tsx\`** — new top-level gate for \`/\`:

- **Unauthenticated users** see \`<Homepage />\` immediately, wrapped in \`HpHeader\` + \`SiteFooter\` (visually identical to \`/frontend-pages/homepage\`). **No auth-check spinner**, no flash of a login screen.
- **Authenticated users** get role-redirected via \`useEffect\` reading from \`AuthContext\`:
  - super_admin / admin → \`/admin/control-panel\`
  - \`frjames@ssppoc.org\` (legacy special-case kept for parity with SmartRedirect) → \`/portal\`
  - everyone else → \`/portal\`
- \`AuthContext\` hydrates synchronously from localStorage, so an already-logged-in user gets redirected on the first render with at most a brief flash of Homepage. This matches the standard SaaS pattern.

## What changes in Router.tsx

- Top-level \`/\` route now points at \`<RootGate />\` as a sibling to the \`FullLayout\` group (which keeps its nested authenticated routes like \`/dashboards/modern\`).
- Removed the FullLayout-nested \`{ path: '/', element: <SmartRedirect /> }\` since RootGate replaces that responsibility.
- \`SmartRedirect.tsx\` is **left in place** — still imported by \`AuthLogin\` and any other call site that wants the spinner-then-decide flow. Only \`/\` no longer uses it.

## Risks & test plan

- [x] Unauthenticated cold visit to \`/\` → renders Homepage with header/footer; no flash of login or spinner
- [x] Authenticated super_admin visit to \`/\` → redirects to \`/admin/control-panel\` (may briefly see Homepage)
- [x] Authenticated priest/church_admin visit to \`/\` → redirects to \`/portal\`
- [x] Authenticated user with stale localStorage but invalid server session → still redirects (then ProtectedRoute on the destination bounces to login — same behavior as before)
- [x] Direct visit to \`/frontend-pages/homepage\` still works
- [x] Direct visit to \`/auth/login\` still works (Sign In button in header still routes there)
- [x] All other top-level routes (\`/portal\`, \`/admin/...\`, \`/apps/...\`, \`/account/...\`, \`/auth/...\`) still resolve correctly under FullLayout / their existing layouts
- [x] No regressions in router console output

## Scope

Last of five small PRs from \`_report/public-site-flow-audit.md\` (Recommendations 1–5). Companions: #837, #838, #839 (merged), #840 (open).

After this lands, the visitor → marketing → conversion path is:
\`orthodoxmetrics.com\` → Homepage (RootGate) → "Get Started" header CTA (#839) → \`/auth/register\` honest inquiry wizard (#838) → CRM lead → assisted onboarding. Pricing copy now matches reality (#837); footer carries Privacy/Terms/Security (#840).