### PR TITLE
fix(certificates): route record queries to church-scoped DB

### DIFF
--- a/server/src/api/baptismCertificates.js
+++ b/server/src/api/baptismCertificates.js
@@ -1,10 +1,23 @@
 const { getAppPool } = require('../config/db-compat');
+const { getChurchPool } = require('../db/pool');
 const express = require('express');
 const router = express.Router();
 const fs = require('fs');
 const path = require('path');
 const { createCanvas, loadImage } = require('canvas');
 const { promisePool } = require('../config/db-compat'); // Use promisePool instead of db
+
+// Records live in the church-scoped DB (om_church_<id>), not the platform DB.
+// Resolve the right pool from the authenticated user's church_id.
+function getRecordsPoolForRequest(req) {
+  const churchId = req.user && (req.user.church_id || req.user.churchId);
+  if (!churchId) {
+    const err = new Error('No church context on request');
+    err.code = 'NO_CHURCH_CONTEXT';
+    throw err;
+  }
+  return getChurchPool(churchId);
+}
 
 // Certificate output path
 const OUTPUT_DIR = path.join(__dirname, '../certificates');
@@ -100,7 +113,7 @@ router.get('/:id', async (req, res) => {
 
   try {
     // Query the baptism record
-    const [rows] = await getAppPool().query('SELECT * FROM baptism_records WHERE id = ?', [id]);
+    const [rows] = await getRecordsPoolForRequest(req).query('SELECT * FROM baptism_records WHERE id = ?', [id]);
     if (rows.length === 0) return res.status(404).send('Record not found');
 
     const record = rows[0];
@@ -140,7 +153,7 @@ router.post('/:id/preview', async (req, res) => {
 
   try {
     // Query the baptism record
-    const [rows] = await getAppPool().query('SELECT * FROM baptism_records WHERE id = ?', [id]);
+    const [rows] = await getRecordsPoolForRequest(req).query('SELECT * FROM baptism_records WHERE id = ?', [id]);
     if (rows.length === 0) return res.status(404).send('Record not found');
 
     const record = rows[0];
@@ -178,7 +191,7 @@ router.get('/:id/download', async (req, res) => {
 
   try {
     // Query the baptism record
-    const [rows] = await getAppPool().query('SELECT * FROM baptism_records WHERE id = ?', [id]);
+    const [rows] = await getRecordsPoolForRequest(req).query('SELECT * FROM baptism_records WHERE id = ?', [id]);
     if (rows.length === 0) return res.status(404).send('Record not found');
 
     const record = rows[0];

--- a/server/src/api/funeralCertificates.js
+++ b/server/src/api/funeralCertificates.js
@@ -1,10 +1,23 @@
 const { getAppPool } = require('../config/db-compat');
+const { getChurchPool } = require('../db/pool');
 const express = require('express');
 const router = express.Router();
 const fs = require('fs');
 const path = require('path');
 const { createCanvas, loadImage } = require('canvas');
 const { promisePool } = require('../config/db-compat'); // Use promisePool instead of db
+
+// Records live in the church-scoped DB (om_church_<id>), not the platform DB.
+// Resolve the right pool from the authenticated user's church_id.
+function getRecordsPoolForRequest(req) {
+  const churchId = req.user && (req.user.church_id || req.user.churchId);
+  if (!churchId) {
+    const err = new Error('No church context on request');
+    err.code = 'NO_CHURCH_CONTEXT';
+    throw err;
+  }
+  return getChurchPool(churchId);
+}
 
 // Certificate output path
 const OUTPUT_DIR = path.join(__dirname, '../certificates');
@@ -103,7 +116,7 @@ router.post('/:id/preview', async (req, res) => {
 
   try {
     // Query the funeral record
-    const [rows] = await getAppPool().query('SELECT * FROM funeral_records WHERE id = ?', [id]);
+    const [rows] = await getRecordsPoolForRequest(req).query('SELECT * FROM funeral_records WHERE id = ?', [id]);
     if (rows.length === 0) return res.status(404).json({ success: false, error: 'Record not found' });
 
     const record = rows[0];
@@ -143,7 +156,7 @@ router.get('/:id/download', async (req, res) => {
 
   try {
     // Query the funeral record
-    const [rows] = await getAppPool().query('SELECT * FROM funeral_records WHERE id = ?', [id]);
+    const [rows] = await getRecordsPoolForRequest(req).query('SELECT * FROM funeral_records WHERE id = ?', [id]);
     if (rows.length === 0) return res.status(404).send('Record not found');
 
     const record = rows[0];

--- a/server/src/api/marriageCertificates.js
+++ b/server/src/api/marriageCertificates.js
@@ -1,10 +1,23 @@
 const { getAppPool } = require('../config/db-compat');
+const { getChurchPool } = require('../db/pool');
 const express = require('express');
 const router = express.Router();
 const fs = require('fs');
 const path = require('path');
 const { createCanvas, loadImage } = require('canvas');
 const { promisePool } = require('../config/db-compat'); // Use promisePool instead of db
+
+// Records live in the church-scoped DB (om_church_<id>), not the platform DB.
+// Resolve the right pool from the authenticated user's church_id.
+function getRecordsPoolForRequest(req) {
+  const churchId = req.user && (req.user.church_id || req.user.churchId);
+  if (!churchId) {
+    const err = new Error('No church context on request');
+    err.code = 'NO_CHURCH_CONTEXT';
+    throw err;
+  }
+  return getChurchPool(churchId);
+}
 
 // Certificate output path
 const OUTPUT_DIR = path.join(__dirname, '../certificates');
@@ -143,7 +156,7 @@ router.get('/:id', async (req, res) => {
 
   try {
     // Query the marriage record
-    const [rows] = await getAppPool().query('SELECT * FROM marriage_records WHERE id = ?', [id]);
+    const [rows] = await getRecordsPoolForRequest(req).query('SELECT * FROM marriage_records WHERE id = ?', [id]);
     if (rows.length === 0) return res.status(404).send('Record not found');
 
     const record = rows[0];
@@ -183,7 +196,7 @@ router.post('/:id/preview', async (req, res) => {
 
   try {
     // Query the marriage record
-    const [rows] = await getAppPool().query('SELECT * FROM marriage_records WHERE id = ?', [id]);
+    const [rows] = await getRecordsPoolForRequest(req).query('SELECT * FROM marriage_records WHERE id = ?', [id]);
     if (rows.length === 0) return res.status(404).send('Record not found');
 
     const record = rows[0];
@@ -220,7 +233,7 @@ router.get('/:id/download', async (req, res) => {
 
   try {
     // Query the marriage record
-    const [rows] = await getAppPool().query('SELECT * FROM marriage_records WHERE id = ?', [id]);
+    const [rows] = await getRecordsPoolForRequest(req).query('SELECT * FROM marriage_records WHERE id = ?', [id]);
     if (rows.length === 0) return res.status(404).send('Record not found');
 
     const record = rows[0];


### PR DESCRIPTION
## Summary
Fixes HTTP 500 on `/api/baptismCertificates/:id`, `/api/marriageCertificates/:id`, `/api/funeralCertificates/:id`. The handlers were querying `baptism_records` / `marriage_records` / `funeral_records` from the central `orthodoxmetrics_db` (where those tables don't exist) instead of from the church-scoped `om_church_<id>` database (where the records actually live).

## Reproduction (before this PR)
```
$ curl … /api/baptismCertificates/200
HTTP 500  type text/html  body: "Error generating certificate"

[server log]
Error: Table 'orthodoxmetrics_db.baptism_records' doesn't exist
  at /var/www/.../dist/api/baptismCertificates.js:103
  code: 'ER_NO_SUCH_TABLE'
```
Same failure on `/api/marriageCertificates/266`. Funeral cert route was 404 in probing (likely router not mounted; tracked as a separate concern, see "Out of scope" below).

## Why
The records are tenant-scoped: `om_church_46` (Saints Peter & Paul) holds 621 baptism + 223 marriage + 447 funeral records. None of those tables exist in `orthodoxmetrics_db`. The cert handlers were the wrong-pool callers; `churchCertificates.js` already does this correctly via `getChurchPool(churchId)` and that's the pattern this PR copies.

## Fix
Single helper at the top of each of the 3 files:
```js
const { getChurchPool } = require('../db/pool');

function getRecordsPoolForRequest(req) {
  const churchId = req.user && (req.user.church_id || req.user.churchId);
  if (!churchId) {
    const err = new Error('No church context on request');
    err.code = 'NO_CHURCH_CONTEXT';
    throw err;
  }
  return getChurchPool(churchId);
}
```
Then each `getAppPool().query('SELECT * FROM <records> WHERE id = ?', [id])` becomes `getRecordsPoolForRequest(req).query(...)`. **8 callsites total** (3 baptism + 3 marriage + 2 funeral).

`req.user.church_id` is populated upstream by both auth paths (JWT in `middleware/auth.js:101`, session in `middleware/auth.js:68`), so this works for either auth method.

## Risk
- **Low.** Localized 1-line change at each callsite. Same pool-resolution pattern already in production for the `/api/church/:churchId/certificate/*` routes via `churchCertificates.js`.
- The catch block already handles thrown errors; the `NO_CHURCH_CONTEXT` error falls into the existing 500 path. We could shape this into a 401 in a follow-up, but the current handler's catch returns 500 with `"Error generating certificate"` either way — no behavior regression vs. today.

## Test plan
- [x] `node --check` on all three files
- [x] Logic verified against the same pattern in `churchCertificates.js`
- [x] frjames's JWT carries `churchId=46`, `om_church_46` has the records (verified via DB inspection: 621 baptism, 223 marriage, 447 funeral)
- [ ] After deploy: re-run the curl reproduction (full command in commit message). Expect HTTP 200 + image/png body.
- [ ] Click into a record from the UI and confirm the cert preview/download buttons return PNG instead of an error.

## Out of scope
- **getChurchPool creates a new pool on every request.** The helper in `db/pool.ts:40` lacks the per-database caching that `databaseService.js:90` has. Latent connection-leak under load. Same as existing `churchCertificates.js` callsites; deserves a focused PR.
- **Disk leak:** every cert generation writes a PNG to `server/src/certificates/` and never cleans up. Pre-existing.
- **Funeral cert route mounting:** `/api/funeralCertificates/:id` returned 404 in pre-fix probing, suggesting it's not registered in `index.ts`. With this PR the *handler* works correctly; the route may still need to be mounted. Worth a check during your post-deploy verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)