### PR TITLE
feat(platform): read-only provider feeds for OMStudio

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -884,6 +884,13 @@ app.use('/api/user/sessions', userSessionsRouter);
 const workSessionsRouter = require('./routes/work-sessions');
 app.use('/api/work-sessions', workSessionsRouter);
 
+// CS-OMSTUDIO-PLATFORM-PROVIDERS-V1 — read-only platform-provider
+// feeds for OMStudio (church-summary, resource-usage). Authenticates
+// via X-Service-Token. Mounts BEFORE the session-cookie auth so its
+// middleware runs first.
+const platformProviderRouter = require('./routes/platform');
+app.use('/api/platform', platformProviderRouter);
+
 // Profile image upload routes (avatar + banner)
 const profileUploadRouter = require('./routes/upload');
 app.use('/api/upload', profileUploadRouter);

--- a/server/src/middleware/serviceTokenAuth.js
+++ b/server/src/middleware/serviceTokenAuth.js
@@ -1,0 +1,51 @@
+// server/src/middleware/serviceTokenAuth.js
+// Service-token authentication for the OM platform-provider
+// surface (CS-OMSTUDIO-PLATFORM-PROVIDERS-V1).
+//
+// OMStudio sends X-Service-Token + (optionally) X-On-Behalf-Of-
+// Email + X-Source-System on every cross-host call. This
+// middleware validates the token and surfaces caller info on
+// req.serviceCaller for downstream auditing.
+//
+// 503 service_token_not_configured  — env not set
+// 401 missing_service_token         — header absent
+// 401 invalid_service_token         — token mismatch (constant-time compare)
+
+const crypto = require('crypto');
+
+function constantTimeEquals(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
+function requireServiceToken(req, res, next) {
+  const expected = process.env.OMSTUDIO_SERVICE_TOKEN || '';
+  if (!expected) {
+    return res.status(503).json({ error: 'service_token_not_configured' });
+  }
+  const provided = req.headers['x-service-token'];
+  if (!provided || typeof provided !== 'string') {
+    return res.status(401).json({ error: 'missing_service_token' });
+  }
+  if (!constantTimeEquals(provided, expected)) {
+    return res.status(401).json({ error: 'invalid_service_token' });
+  }
+  // Capture for audit / downstream filtering. Never trust these
+  // for authorization — they're informational only.
+  req.serviceCaller = {
+    email: typeof req.headers['x-on-behalf-of-email'] === 'string'
+      ? req.headers['x-on-behalf-of-email']
+      : null,
+    sourceSystem: typeof req.headers['x-source-system'] === 'string'
+      ? req.headers['x-source-system']
+      : 'unknown',
+  };
+  next();
+}
+
+module.exports = { requireServiceToken };

--- a/server/src/routes/platform.js
+++ b/server/src/routes/platform.js
@@ -1,0 +1,314 @@
+// server/src/routes/platform.js
+// Read-only platform-provider feeds for OMStudio
+// (CS-OMSTUDIO-PLATFORM-PROVIDERS-V1).
+//
+// Mounted at /api/platform. Authenticates via X-Service-Token
+// (see middleware/serviceTokenAuth.js); never reads a session
+// cookie. All endpoints are READ-ONLY and never mutate church
+// records. OMStudio is the consumer; OM is the source of
+// church + records data.
+//
+// Endpoints:
+//   GET /api/platform/church-summary
+//   GET /api/platform/resource-usage/certificates
+//
+// Both endpoints support ?limit= (capped server-side).
+
+'use strict';
+
+const express = require('express');
+const { requireServiceToken } = require('../middleware/serviceTokenAuth');
+const {
+  queryPlatform,
+  getChurchRecordConnection,
+} = require('../services/databaseService');
+
+const router = express.Router();
+
+router.use(requireServiceToken);
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 500;
+
+function parseLimit(rawLimit, defaultValue = DEFAULT_LIMIT, maxValue = MAX_LIMIT) {
+  const n = Number.parseInt(rawLimit, 10);
+  if (!Number.isFinite(n) || n <= 0) return defaultValue;
+  return Math.min(n, maxValue);
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+// Extract a best-effort jurisdiction string from the church
+// settings JSON. Most rows have no jurisdiction field; surface
+// null instead of inventing one.
+function extractJurisdiction(settingsJson) {
+  if (!settingsJson) return null;
+  let s = settingsJson;
+  if (typeof s === 'string') {
+    try { s = JSON.parse(s); } catch { return null; }
+  }
+  if (!s || typeof s !== 'object') return null;
+  if (typeof s.jurisdiction === 'string') return s.jurisdiction;
+  if (typeof s.diocese === 'string') return s.diocese;
+  if (s.organization && typeof s.organization.jurisdiction === 'string') {
+    return s.organization.jurisdiction;
+  }
+  return null;
+}
+
+function shapeChurchSummary(row) {
+  return {
+    churchId: String(row.id),
+    churchName: row.name || null,
+    jurisdiction: extractJurisdiction(row.settings),
+    schema: row.database_name || null,
+    status: row.is_active ? 'active' : 'inactive',
+    city: row.city || null,
+    state: row.state_province || null,
+    country: row.country || null,
+    lastActivityAt: row.updated_at ? new Date(row.updated_at).toISOString() : null,
+    metadata: {
+      setupComplete: !!row.setup_complete,
+      createdAt: row.created_at ? new Date(row.created_at).toISOString() : null,
+    },
+  };
+}
+
+// ── /church-summary ─────────────────────────────────────────────
+//
+// Lightweight roll-up of the platform `churches` table. Filters
+// to active churches by default; pass ?include_inactive=1 to
+// include the rest.
+router.get('/church-summary', async (req, res) => {
+  try {
+    const limit = parseLimit(req.query.limit);
+    const includeInactive = req.query.include_inactive === '1' || req.query.include_inactive === 'true';
+
+    const where = includeInactive ? '' : 'WHERE is_active = 1';
+    const sql = `
+      SELECT id, name, city, state_province, country, settings, is_active,
+             database_name, setup_complete, created_at, updated_at
+        FROM churches
+        ${where}
+        ORDER BY name ASC
+        LIMIT ?
+    `;
+    const [rows] = await queryPlatform(sql, [limit]);
+
+    res.json({
+      ok: true,
+      sourceSystem: 'om',
+      generatedAt: new Date().toISOString(),
+      churches: (rows || []).map(shapeChurchSummary),
+    });
+  } catch (err) {
+    res.status(500).json({
+      ok: false,
+      error: 'church_summary_failed',
+      detail: err && err.message ? err.message : String(err),
+    });
+  }
+});
+
+// ── /resource-usage/certificates ────────────────────────────────
+//
+// Two-stage discovery:
+//   1. Enumerate active churches in orthodoxmetrics_db.
+//   2. Per-church, count records in the canonical sacrament tables
+//      (baptism_records, marriage_records, funeral_records, plus
+//      optional chrismation_records). information_schema is queried
+//      first so missing tables don't throw.
+//
+// Settle-per-church via Promise.allSettled — one broken church DB
+// does NOT fail the response. discoveryState reflects whether all
+// queries succeeded (`live`), some failed (`partial`), or
+// everything failed (`unavailable`).
+
+const SACRAMENT_TABLES = [
+  // type, table, optional, dateColumn, certificateLabel
+  { type: 'baptism',     table: 'baptism_records',     optional: false, dateCol: 'reception_date',   certLabel: 'Baptism' },
+  { type: 'marriage',    table: 'marriage_records',    optional: false, dateCol: 'mdate',            certLabel: 'Marriage' },
+  { type: 'funeral',     table: 'funeral_records',     optional: false, dateCol: 'funeral_date',     certLabel: 'Funeral' },
+  { type: 'chrismation', table: 'chrismation_records', optional: true,  dateCol: 'chrismation_date', certLabel: 'Chrismation' },
+];
+
+async function listExistingTables(conn, schemaName) {
+  const [rows] = await conn.query(
+    `SELECT table_name AS t
+       FROM information_schema.tables
+       WHERE table_schema = ?
+         AND table_name IN (?)`,
+    [schemaName, SACRAMENT_TABLES.map((s) => s.table)],
+  );
+  const set = new Set();
+  for (const r of (rows || [])) {
+    // Some MariaDB returns lower-case keys.
+    const tn = (r.t || r.TABLE_NAME || r.table_name || '').toString();
+    if (tn) set.add(tn);
+  }
+  return set;
+}
+
+async function discoverChurchUsage(church) {
+  const churchId = church.id;
+  const out = {
+    churchId: String(churchId),
+    churchName: church.name || null,
+    jurisdiction: extractJurisdiction(church.settings),
+    schema: church.database_name || null,
+    certificatesDiscovered: 0,
+    certificateTypes: [],
+    lastCertificateDate: null,
+    recordsSource: church.database_name
+      ? `${church.database_name}.{baptism|marriage|funeral|chrismation}_records`
+      : 'unavailable',
+    status: church.is_active ? 'active' : 'inactive',
+    metadata: {},
+  };
+
+  if (!church.database_name) {
+    out.status = 'unavailable';
+    out.metadata.reason = 'no_database_name';
+    return out;
+  }
+
+  let conn;
+  try {
+    conn = await getChurchRecordConnection(churchId);
+  } catch (err) {
+    out.status = 'unavailable';
+    out.metadata.reason = 'connection_failed';
+    out.metadata.error = err && err.message ? err.message : String(err);
+    return out;
+  }
+
+  let existingTables;
+  try {
+    existingTables = await listExistingTables(conn, church.database_name);
+  } catch (err) {
+    out.status = 'unavailable';
+    out.metadata.reason = 'information_schema_failed';
+    out.metadata.error = err && err.message ? err.message : String(err);
+    return out;
+  }
+
+  let total = 0;
+  let latestEpoch = null;
+  const types = [];
+
+  for (const sacrament of SACRAMENT_TABLES) {
+    if (!existingTables.has(sacrament.table)) continue;
+    try {
+      const [rows] = await conn.query(
+        `SELECT COUNT(*) AS c, MAX(\`${sacrament.dateCol}\`) AS latest FROM \`${sacrament.table}\``,
+      );
+      const r = rows && rows[0] ? rows[0] : {};
+      const count = Number(r.c || 0);
+      if (count > 0) {
+        types.push(sacrament.certLabel);
+        total += count;
+        const latest = r.latest ? new Date(r.latest) : null;
+        if (latest && !Number.isNaN(latest.getTime())) {
+          const epoch = latest.getTime();
+          if (latestEpoch === null || epoch > latestEpoch) latestEpoch = epoch;
+        }
+      }
+    } catch (err) {
+      // Non-fatal — note partial in metadata.
+      out.metadata[`${sacrament.table}_error`] = err && err.message ? err.message : String(err);
+    }
+  }
+
+  out.certificatesDiscovered = total;
+  out.certificateTypes = types;
+  out.lastCertificateDate = latestEpoch
+    ? new Date(latestEpoch).toISOString().slice(0, 10)
+    : null;
+  return out;
+}
+
+router.get('/resource-usage/certificates', async (req, res) => {
+  try {
+    const limit = parseLimit(req.query.limit);
+
+    const [churches] = await queryPlatform(
+      `SELECT id, name, city, state_province, country, settings, is_active, database_name
+         FROM churches
+        WHERE is_active = 1
+        ORDER BY name ASC
+        LIMIT ?`,
+      [limit],
+    );
+
+    const settled = await Promise.allSettled((churches || []).map(discoverChurchUsage));
+
+    const usage = [];
+    let succeeded = 0;
+    let failed = 0;
+    settled.forEach((s, i) => {
+      if (s.status === 'fulfilled') {
+        usage.push(s.value);
+        if (s.value.status !== 'unavailable') succeeded += 1;
+        else failed += 1;
+      } else {
+        failed += 1;
+        const c = churches[i] || {};
+        usage.push({
+          churchId: String(c.id || ''),
+          churchName: c.name || null,
+          jurisdiction: extractJurisdiction(c.settings),
+          schema: c.database_name || null,
+          certificatesDiscovered: 0,
+          certificateTypes: [],
+          lastCertificateDate: null,
+          recordsSource: 'unavailable',
+          status: 'unavailable',
+          metadata: { reason: 'discovery_threw', error: s.reason && s.reason.message ? s.reason.message : String(s.reason) },
+        });
+      }
+    });
+
+    let discoveryState = 'live';
+    if (succeeded === 0 && failed > 0) discoveryState = 'unavailable';
+    else if (failed > 0) discoveryState = 'partial';
+
+    res.json({
+      ok: true,
+      sourceSystem: 'om',
+      generatedAt: new Date().toISOString(),
+      discoveryState,
+      queryDescription:
+        'Two-stage: enumerate active churches in orthodoxmetrics_db; ' +
+        'per-church, count records in baptism_records / marriage_records / ' +
+        'funeral_records (and chrismation_records when present via ' +
+        'information_schema check). Settle-per-church via ' +
+        'Promise.allSettled so one broken church DB does not fail the ' +
+        'response.',
+      usage,
+      query: {
+        kind: 'existing',
+        sqlOrDescription: [
+          "-- Stage 1 (orthodoxmetrics_db):",
+          "SELECT id, name, settings, is_active, database_name FROM churches WHERE is_active = 1;",
+          "",
+          "-- Stage 2 (per om_church_<id>):",
+          "SELECT COUNT(*), MAX(<date_col>) FROM <baptism|marriage|funeral|chrismation>_records;",
+        ].join('\n'),
+        limitations: [
+          'Funeral counts roll up into the per-church total but are sacramental records, not certificate templates.',
+          'Reception and Recognition certificates have no dedicated record table; they are not surfaced here.',
+          'lastCertificateDate is the MAX across the four sacrament tables, not the global latest by certificate type.',
+          'Per-church information_schema query runs on every request — consider caching once snapshot persistence lands.',
+        ],
+      },
+    });
+  } catch (err) {
+    res.status(500).json({
+      ok: false,
+      error: 'resource_usage_failed',
+      detail: err && err.message ? err.message : String(err),
+    });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
First OM-side endpoints in the OMStudio platform-provider contract (CS-OMSTUDIO-PLATFORM-PROVIDERS-V1). OMStudio reads church and certificate-usage data through these read-only feeds via X-Service-Token; OM remains the sole owner of church + records data.

## Endpoints (`/api/platform/*`)

### `GET /api/platform/church-summary`
Lightweight roll-up of `orthodoxmetrics_db.churches`.

- `?limit` (default 200, max 500)
- `?include_inactive=1` includes inactive parishes
- Returns `{ ok, sourceSystem, generatedAt, churches[] }` — each church carries `churchId`, `churchName`, `jurisdiction` (extracted from `settings` JSON), `schema` (database_name), `status`, `city`, `state`, `country`, `lastActivityAt`, `metadata`.

### `GET /api/platform/resource-usage/certificates`
Two-stage discovery:

1. Enumerate active churches in `orthodoxmetrics_db.churches`.
2. Per-church, count records in `baptism_records` / `marriage_records` / `funeral_records` (always present), plus `chrismation_records` when the optional table exists — checked via `information_schema.tables` **before** counting so missing tables never throw.

Settle-per-church via `Promise.allSettled` — a single broken church DB does NOT fail the response. Top-level `discoveryState` is `'live'` when every church succeeded, `'partial'` when some failed, `'unavailable'` when everything failed. Returns the actual SQL used + a `limitations` array so the OMStudio UI can be honest about what's covered.

## Auth
`middleware/serviceTokenAuth.js` — validates `X-Service-Token` against `process.env.OMSTUDIO_SERVICE_TOKEN` with constant-time compare. Captures `X-On-Behalf-Of-Email` + `X-Source-System` on `req.serviceCaller` for downstream auditing. Returns:

- `503 service_token_not_configured` — env unset
- `401 missing_service_token` — header absent
- `401 invalid_service_token` — token mismatch

## Read-only guarantees
- No INSERT / UPDATE / DELETE on church records
- No certificate issuance / filling / generation
- No new mutation routes
- Router mounted next to `/api/work-sessions` in `index.ts` so existing request-logging + error-handling middleware apply

## Verification
- `npx tsc --noEmit -p server/tsconfig.json` — clean
- `node --check` on platform.js + serviceTokenAuth.js — OK
- Endpoints are pure SELECT queries; SACRAMENT_TABLES list is whitelisted, no string interpolation from request data into SQL identifiers (table/column names live in code-side constants only)

## Deployment notes
- Requires `OMSTUDIO_SERVICE_TOKEN` env on the OM host (.239). Same token value as OMStudio's `OMSTUDIO_SERVICE_TOKEN` / `PLATFORM_CONNECTOR_SERVICE_TOKEN`.
- After merge, restart the OM backend: `sudo systemctl restart orthodox-backend` (the ecosystem runs on systemd; pm2 is not installed). The `/api/platform/*` namespace will then be reachable from OMStudio's connector layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
