### PR TITLE
LEGACY-CERT-AUDIT: write generated_certificates rows from baptism/marriage/funeral PNG endpoints

### DIFF
--- a/server/src/api/baptismCertificates.js
+++ b/server/src/api/baptismCertificates.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const { createCanvas, loadImage } = require('canvas');
 const { promisePool } = require('../config/db-compat'); // Use promisePool instead of db
+const { recordCertificateGeneration, churchIdFromReq, userIdFromReq } = require('../certificates/audit');
 
 // Records live in the church-scoped DB (om_church_<id>), not the platform DB.
 // Resolve the right pool from the authenticated user's church_id.
@@ -134,10 +135,24 @@ router.get('/:id', async (req, res) => {
     const outputFile = path.join(OUTPUT_DIR, `baptism_${id}.png`);
     const outStream = fs.createWriteStream(outputFile);
     const stream = canvas.createPNGStream();
-    
+
     stream.pipe(outStream);
     outStream.on('finish', () => {
-      res.sendFile(outputFile);
+      res.sendFile(outputFile, (sendErr) => {
+        if (sendErr) return;
+        let fileSize = null;
+        try { fileSize = fs.statSync(outputFile).size; } catch {}
+        recordCertificateGeneration({
+          churchId: churchIdFromReq(req),
+          recordType: 'baptism',
+          recordId: id,
+          status: 'generated',
+          filePath: outputFile,
+          fileSize,
+          userId: userIdFromReq(req),
+          metadata: { source: 'legacy_png_endpoint', route: 'GET /api/baptismCertificates/:id' },
+        });
+      });
     });
 
   } catch (err) {
@@ -222,10 +237,25 @@ router.get('/:id/download', async (req, res) => {
     const filename = `baptism_certificate_${record.first_name}_${record.last_name}_${id}.png`;
     res.setHeader('Content-Type', 'image/png');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-    
+
     // Send the image buffer
     const buffer = canvas.toBuffer('image/png');
     res.send(buffer);
+    recordCertificateGeneration({
+      churchId: churchIdFromReq(req),
+      recordType: 'baptism',
+      recordId: id,
+      status: 'downloaded',
+      filePath: null,
+      fileSize: buffer.length,
+      userId: userIdFromReq(req),
+      metadata: {
+        source: 'legacy_png_endpoint',
+        route: 'GET /api/baptismCertificates/:id/download',
+        filename,
+        hiddenFields: hiddenFields.length ? hiddenFields : undefined,
+      },
+    });
 
   } catch (err) {
     console.error(err);

--- a/server/src/api/funeralCertificates.js
+++ b/server/src/api/funeralCertificates.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const { createCanvas, loadImage } = require('canvas');
 const { promisePool } = require('../config/db-compat'); // Use promisePool instead of db
+const { recordCertificateGeneration, churchIdFromReq, userIdFromReq } = require('../certificates/audit');
 
 // Records live in the church-scoped DB (om_church_<id>), not the platform DB.
 // Resolve the right pool from the authenticated user's church_id.
@@ -187,10 +188,25 @@ router.get('/:id/download', async (req, res) => {
     const filename = `funeral_certificate_${record.first_name}_${record.last_name}_${id}.png`;
     res.setHeader('Content-Type', 'image/png');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-    
+
     // Send the image buffer
     const buffer = canvas.toBuffer('image/png');
     res.send(buffer);
+    recordCertificateGeneration({
+      churchId: churchIdFromReq(req),
+      recordType: 'funeral',
+      recordId: id,
+      status: 'downloaded',
+      filePath: null,
+      fileSize: buffer.length,
+      userId: userIdFromReq(req),
+      metadata: {
+        source: 'legacy_png_endpoint',
+        route: 'GET /api/funeralCertificates/:id/download',
+        filename,
+        hiddenFields: hiddenFields.length ? hiddenFields : undefined,
+      },
+    });
 
   } catch (err) {
     console.error(err);

--- a/server/src/api/marriageCertificates.js
+++ b/server/src/api/marriageCertificates.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const { createCanvas, loadImage } = require('canvas');
 const { promisePool } = require('../config/db-compat'); // Use promisePool instead of db
+const { recordCertificateGeneration, churchIdFromReq, userIdFromReq } = require('../certificates/audit');
 
 // Records live in the church-scoped DB (om_church_<id>), not the platform DB.
 // Resolve the right pool from the authenticated user's church_id.
@@ -177,10 +178,24 @@ router.get('/:id', async (req, res) => {
     const outputFile = path.join(OUTPUT_DIR, `marriage_${id}.png`);
     const outStream = fs.createWriteStream(outputFile);
     const stream = canvas.createPNGStream();
-    
+
     stream.pipe(outStream);
     outStream.on('finish', () => {
-      res.sendFile(outputFile);
+      res.sendFile(outputFile, (sendErr) => {
+        if (sendErr) return;
+        let fileSize = null;
+        try { fileSize = fs.statSync(outputFile).size; } catch {}
+        recordCertificateGeneration({
+          churchId: churchIdFromReq(req),
+          recordType: 'marriage',
+          recordId: id,
+          status: 'generated',
+          filePath: outputFile,
+          fileSize,
+          userId: userIdFromReq(req),
+          metadata: { source: 'legacy_png_endpoint', route: 'GET /api/marriageCertificates/:id' },
+        });
+      });
     });
 
   } catch (err) {
@@ -255,10 +270,24 @@ router.get('/:id/download', async (req, res) => {
     const filename = `marriage_certificate_${record.fname_groom}_${record.lname_groom}_${record.fname_bride}_${record.lname_bride}_${id}.png`;
     res.setHeader('Content-Type', 'image/png');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-    
+
     // Send the image buffer
     const buffer = canvas.toBuffer('image/png');
     res.send(buffer);
+    recordCertificateGeneration({
+      churchId: churchIdFromReq(req),
+      recordType: 'marriage',
+      recordId: id,
+      status: 'downloaded',
+      filePath: null,
+      fileSize: buffer.length,
+      userId: userIdFromReq(req),
+      metadata: {
+        source: 'legacy_png_endpoint',
+        route: 'GET /api/marriageCertificates/:id/download',
+        filename,
+      },
+    });
 
   } catch (err) {
     console.error(err);

--- a/server/src/certificates/audit.js
+++ b/server/src/certificates/audit.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// Audit writer for the legacy PNG certificate endpoints.
+//
+// The new template-driven path (POST /api/certificate-templates/generate)
+// already inserts into orthodoxmetrics_db.generated_certificates. The
+// older per-sacrament endpoints (baptismCertificates.js, marriageCertificates.js,
+// funeralCertificates.js) used to deliver a PNG without leaving any
+// audit trail — so /api/platform/resource-usage/certificates couldn't
+// see them. This helper closes that gap.
+//
+// Failure mode: an audit insert MUST NOT break the user-facing response.
+// If the INSERT throws (DB hiccup, FK violation, anything), we log and
+// move on. The user still gets their certificate.
+
+const { getAppPool } = require('../config/db-compat');
+
+const VALID_RECORD_TYPES = new Set(['baptism', 'marriage', 'funeral', 'reception']);
+const VALID_STATUSES = new Set(['generated', 'downloaded', 'voided']);
+
+async function recordCertificateGeneration({
+  churchId,
+  recordType,
+  recordId,
+  status = 'generated',
+  filePath = null,
+  fileSize = null,
+  userId = null,
+  metadata = null,
+} = {}) {
+  try {
+    const cid = Number(churchId);
+    const rid = Number(recordId);
+    if (!Number.isFinite(cid) || cid <= 0) return;
+    if (!Number.isFinite(rid) || rid <= 0) return;
+    if (!VALID_RECORD_TYPES.has(recordType)) return;
+    const safeStatus = VALID_STATUSES.has(status) ? status : 'generated';
+    const uid = Number.isFinite(Number(userId)) && Number(userId) > 0 ? Number(userId) : null;
+    const metadataJson = metadata == null ? null : JSON.stringify(metadata);
+
+    await getAppPool().query(
+      `INSERT INTO generated_certificates
+         (church_id, record_type, record_id, template_id, file_path, file_size, generated_by, status, metadata_json)
+       VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?)`,
+      [cid, recordType, rid, filePath, fileSize, uid, safeStatus, metadataJson],
+    );
+  } catch (err) {
+    // Audit failure must never break the certificate download.
+    console.error('[cert-audit] failed to write generated_certificates row:', err && err.message ? err.message : err);
+  }
+}
+
+function churchIdFromReq(req) {
+  if (!req || !req.user) return null;
+  return req.user.church_id || req.user.churchId || null;
+}
+
+function userIdFromReq(req) {
+  if (!req || !req.user) return null;
+  return req.user.id || req.user.user_id || req.user.userId || null;
+}
+
+module.exports = {
+  recordCertificateGeneration,
+  churchIdFromReq,
+  userIdFromReq,
+};


### PR DESCRIPTION
## Summary
The legacy per-sacrament PNG endpoints (`baptismCertificates.js`, `marriageCertificates.js`, `funeralCertificates.js`) deliver a rendered PNG without leaving any audit trail. As a result, the new `/api/platform/resource-usage/certificates` feed (PR #848) sees only certificates produced by the template-driven path (`POST /api/certificate-templates/generate`) — the legacy path is invisible to OMStudio's `actual_certificate_usage` view.

This PR closes the gap with a single audit helper, wired into the success paths of the three legacy routers. Failure-isolated: a bad audit insert can never break the user's PNG download.

## What changes

**New module:** `server/src/certificates/audit.js`
```js
recordCertificateGeneration({
  churchId, recordType, recordId,
  status,        // 'generated' | 'downloaded' | 'voided'
  filePath, fileSize, userId, metadata
})
```
- Inserts into `orthodoxmetrics_db.generated_certificates`.
- Wraps the INSERT in try/catch + `console.error`. An audit failure (FK violation, DB hiccup, malformed input) is logged and swallowed.
- Validates `record_type` / `status` against allowlists; rejects non-positive `churchId` / `recordId`.

**Wired into:**

| Route | Audited as |
|------|------------|
| `GET /api/baptismCertificates/:id` (sendFile) | `status='generated'` |
| `GET /api/baptismCertificates/:id/download` (attachment) | `status='downloaded'` |
| `GET /api/marriageCertificates/:id` | `status='generated'` |
| `GET /api/marriageCertificates/:id/download` | `status='downloaded'` |
| `GET /api/funeralCertificates/:id/download` | `status='downloaded'` |

`POST /:id/preview` is intentionally **not** audited — preview is a UI rendering, not an issuance. Funeral has no `GET /:id` base route, only `/:id/download`.

Each row carries `metadata_json` with `source='legacy_png_endpoint'` + the route, so eligibility queries can distinguish legacy rows from template-driven rows when needed.

## Schema notes
- `generated_certificates.template_id` is nullable in production (`DEFAULT NULL`), even though the original migration declared it `NOT NULL`. Production matches the FK's `ON DELETE SET NULL` semantics. Legacy rows insert with `template_id=NULL` since the PNG flows use hardcoded templates not registered in `certificate_templates`. **No schema migration required.**
- `record_type` enum already covers `baptism / marriage / funeral / reception`.

## Failure containment
The audit helper has one job: never let an audit failure escape into the user response. Verified live by attempting an insert with `church_id=999999`:
```
[cert-audit] failed to write generated_certificates row: Cannot add or update a child row: a foreign key constraint fails (...)
returned without throwing (good)
```

## Verification
- `node --check` clean on all four files.
- `npm run build` (full server pipeline) — passes; "All route imports successful".
- Live insert against prod DB: row lands correctly with `template_id=NULL`, `metadata_json.source='legacy_png_endpoint'`. Synthetic test row cleaned up; existing real row from PR #848 untouched.
- Live failure path: FK violation on bogus `church_id` → logged + swallowed.

## Read-only-of-records guarantee
- No mutations on `*_records` tables.
- No certificate generation logic added — only audit writes alongside existing generation.
- No new routes; no schema changes.

## After deploy
`/api/platform/resource-usage/certificates` will include legacy PNG downloads in `actual_certificate_usage` counts — not just the template-driven path. PR #848 is a prerequisite for that feed to exist.

## Deployment
After merge: `sudo systemctl restart orthodox-backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
