### PR TITLE
OM-PLATFORM-WORK-SESSIONS-ACTIVE: service-token endpoint for OMStudio's active-session badge

### DIFF
--- a/server/src/routes/platform.js
+++ b/server/src/routes/platform.js
@@ -543,4 +543,125 @@ router.get('/resource-usage/certificates', async (req, res) => {
   }
 });
 
+// ── /work-sessions/active ───────────────────────────────────────
+//
+// Service-to-service lookup for OMStudio's "do I have an active OM
+// work session right now?" badge. OMStudio MUST NOT forward its
+// user JWT to OM — JWT secrets and claim shapes differ. This
+// endpoint takes the user's email via X-On-Behalf-Of-Email,
+// resolves it against orthodoxmetrics_db.users, and returns the
+// active session for that user (or active:false).
+//
+// Read-only — never mutates work_sessions or any other table.
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+router.get('/work-sessions/active', async (req, res) => {
+  try {
+    const rawEmail = req.serviceCaller && typeof req.serviceCaller.email === 'string'
+      ? req.serviceCaller.email.trim()
+      : '';
+    if (!rawEmail) {
+      return res.status(400).json({
+        ok: false,
+        error: 'missing_on_behalf_of_email',
+        message: 'X-On-Behalf-Of-Email header is required for this endpoint.',
+      });
+    }
+    if (!EMAIL_RE.test(rawEmail)) {
+      return res.status(400).json({
+        ok: false,
+        error: 'invalid_email',
+        message: 'X-On-Behalf-Of-Email is not a valid email format.',
+      });
+    }
+    const email = rawEmail.toLowerCase();
+
+    // Resolve user. Email column is UNIQUE, so LIMIT 1 is belt-and-suspenders.
+    const [userRows] = await queryPlatform(
+      `SELECT id FROM users WHERE email = ? LIMIT 1`,
+      [email],
+    );
+    if (!userRows || userRows.length === 0) {
+      return res.json({
+        ok: true,
+        sourceSystem: 'om',
+        email,
+        active: false,
+        reason: 'user_not_found',
+      });
+    }
+    const userId = userRows[0].id;
+
+    const [rows] = await queryPlatform(
+      `SELECT id, user_id, source_system, started_at, status, start_context
+         FROM work_sessions
+        WHERE user_id = ? AND status = 'active'
+        ORDER BY started_at DESC
+        LIMIT 1`,
+      [userId],
+    );
+    if (!rows || rows.length === 0) {
+      return res.json({
+        ok: true,
+        sourceSystem: 'om',
+        email,
+        active: false,
+      });
+    }
+
+    const session = rows[0];
+    let startContext = {};
+    if (session.start_context) {
+      try {
+        const parsed = typeof session.start_context === 'string'
+          ? JSON.parse(session.start_context)
+          : session.start_context;
+        if (parsed && typeof parsed === 'object') startContext = parsed;
+      } catch {
+        startContext = {};
+      }
+    }
+
+    // Use DB NOW() for elapsed so app-server clock drift can't lie.
+    let elapsedSeconds = null;
+    try {
+      const [nowRows] = await queryPlatform('SELECT NOW() AS db_now');
+      const dbNow = nowRows && nowRows[0] && nowRows[0].db_now
+        ? new Date(nowRows[0].db_now)
+        : new Date();
+      const startedAt = new Date(session.started_at);
+      elapsedSeconds = Math.max(0, Math.floor((dbNow.getTime() - startedAt.getTime()) / 1000));
+    } catch {
+      // Non-fatal — still return the session, just without elapsed.
+    }
+
+    return res.json({
+      ok: true,
+      sourceSystem: 'om',
+      email,
+      active: true,
+      session: {
+        id: String(session.id),
+        userId: String(session.user_id),
+        sourceSystem: session.source_system,
+        status: session.status,
+        startedAt: session.started_at ? new Date(session.started_at).toISOString() : null,
+        elapsedSeconds,
+        // summary_note and end_context are intentionally excluded — they can
+        // contain free-form user notes. start_context is exposed in metadata
+        // because it's structured app context (page path, source_system).
+        metadata: { startContext },
+      },
+    });
+  } catch (err) {
+    // Log server-side; don't leak DB error text to the caller.
+    console.error('[platform] work-sessions/active failed:', err && err.message ? err.message : err);
+    return res.status(500).json({
+      ok: false,
+      error: 'work_sessions_active_failed',
+    });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
Adds `GET /api/platform/work-sessions/active` to the OM platform-provider surface so OMStudio can ask "does this user have an active work session in OM right now?" without forwarding its user JWT to OM.

## Why
OMStudio's `/resources/usage` page was hitting its own `/api/work-sessions/active`, which delegated to OM's normal user route while passing the OMStudio user JWT in the Authorization header. That fails two ways:
1. OM and OMStudio don't share `JWT_ACCESS_SECRET` — OM's `jwt.verify` rejects → 401 `NO_SESSION`.
2. OM's auth middleware reads `decoded.userId`; OMStudio's token uses `sub`. The claim shapes never align.

OMStudio then mapped the upstream 401 into a generic 404 `{"error":"Not found"}`, masking the real fault.

The correct contract is the existing platform-provider pattern (PR #847's `church-summary` / `resource-usage/certificates`): service-token auth + `X-On-Behalf-Of-Email` for the user pivot. This PR adds the OM provider endpoint to support that.

## Endpoint

`GET /api/platform/work-sessions/active`

| Header | Purpose |
|---|---|
| `X-Service-Token` | Validates against `OMSTUDIO_SERVICE_TOKEN` (constant-time compare; existing `requireServiceToken` middleware) |
| `X-On-Behalf-Of-Email` | The OMStudio-authenticated user's email; resolved to an OM user by `orthodoxmetrics_db.users.email` (UNIQUE) |

### Response cases

| Case | Status | Body |
|---|---|---|
| Env unset | 503 | `{"error":"service_token_not_configured"}` |
| No token | 401 | `{"error":"missing_service_token"}` |
| Bad token | 401 | `{"error":"invalid_service_token"}` |
| No email | 400 | `{"ok":false,"error":"missing_on_behalf_of_email","message":"..."}` |
| Bad email format | 400 | `{"ok":false,"error":"invalid_email","message":"..."}` |
| Unknown email | 200 | `{"ok":true,"sourceSystem":"om","email":"...","active":false,"reason":"user_not_found"}` |
| Known email, no active session | 200 | `{"ok":true,"sourceSystem":"om","email":"...","active":false}` |
| Known email + active session | 200 | `{"ok":true,"sourceSystem":"om","email":"...","active":true,"session":{...}}` |

### Active-session shape
```json
{
  "id": "<numeric>",
  "userId": "<numeric>",
  "sourceSystem": "orthodoxmetrics | omai",
  "status": "active",
  "startedAt": "ISO timestamp",
  "elapsedSeconds": 1234,
  "metadata": { "startContext": { ... } }
}
```

`elapsedSeconds` uses `SELECT NOW()` against the DB so app-server clock drift can't lie.

## Read-only guarantees
- Pure SELECT against `users` + `work_sessions`; no mutations.
- `summary_note` and `end_context` deliberately excluded — they can contain free-form user notes. `start_context` is exposed in `metadata` because it's structured app context (page path, source_system).
- Existing `/api/work-sessions/active` is **untouched** — `server/src/routes/work-sessions.ts` is not modified.
- Raw DB error messages are not surfaced to the caller; logged server-side only.

## Verification (live, prod DB 192.168.1.241)
```
[no-token]          401 {"error":"missing_service_token"}
[bad-token]         401 {"error":"invalid_service_token"}
[no-email]          400 {"ok":false,"error":"missing_on_behalf_of_email",...}
[bad-email-format]  400 {"ok":false,"error":"invalid_email",...}
[unknown-email]     200 {"ok":true,"active":false,"reason":"user_not_found",...}
[known-email]       200 {"ok":true,"active":false,...}   # no active session
```
- `npm run build` (full server pipeline) — passes; "All route imports successful".
- `node --check server/src/routes/platform.js` — clean.

## OMStudio-side change (separate repo)
The OMStudio fix lives on a different repo and host — branch `feature/platform-work-sessions-connector-fix`. The connector should:
1. Read the OMStudio user's email from its own session/JWT.
2. Call `${OM_API_BASE_URL}/api/platform/work-sessions/active` with `X-Service-Token` + `X-On-Behalf-Of-Email`.
3. Surface upstream 401/403 as `provider_auth_failed` (not 404).
4. Return clean configured/auth-context errors: `provider_not_configured`, `missing_user_email`, `provider_unreachable`, `upstream_error`.

A spec for that change is included in the PR thread / change-set notes.

## Deployment
After merge: `sudo systemctl restart orthodox-backend`. Confirms `OMSTUDIO_SERVICE_TOKEN` is set in OM's env (already in place from PR #847).

## Recommended next work item
Implement the OMStudio connector update on .242 (`feature/platform-work-sessions-connector-fix`) so the browser actually starts hitting the new endpoint. Until that lands, OMStudio's `/api/work-sessions/active` will continue returning 404 — but for a different (legitimate) reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
