### PR TITLE
OCA-CERT-FIELDS-FIX: split parents + dates on baptism_child certificate

### DIFF
--- a/server/database/migrations/20260503_oca_baptism_child_split_fields.sql
+++ b/server/database/migrations/20260503_oca_baptism_child_split_fields.sql
@@ -1,0 +1,91 @@
+-- OCA baptism_child certificate template — replace single-field date and
+-- combined parent_line with split fields that match the actual artwork:
+--
+--   "CHILD OF ___ AND ___"          → father_name + mother_name (separate spots)
+--   "ON _________________, 20___"   → birth_date_md + birth_date_yy
+--   "ON _________________, 20___"   → baptism_date_md + baptism_date_yy
+--
+-- Coordinates derived from the actual baptism-child.pdf bbox extraction:
+-- pdftotext -layout -bbox storage/certificates/templates/OCA/baptism-child.pdf
+-- pdf-lib uses bottom-left origin, so y = (792 - top_down_yMax_of_underline).
+--
+-- Idempotent: deletes the obsolete fields and INSERT IGNOREs on the unique
+-- (template_id, field_key) constraint.
+
+-- Resolve the baptism_child template id once. Stored in a session var to
+-- keep the migration readable and DRY.
+SET @oca_child_tpl := (
+  SELECT t.id
+    FROM certificate_template_groups g
+    JOIN certificate_templates t ON t.template_group_id = g.id
+   WHERE g.jurisdiction_code = 'OCA' AND g.template_type = 'baptism_child'
+   ORDER BY t.id
+   LIMIT 1
+);
+
+-- ─── 1. Reset the field set for this template ──────────────────────
+-- Wipe ALL existing fields for the template so updated coordinates take
+-- effect on every field — INSERT IGNORE on uq_template_field would skip
+-- coordinate updates on existing rows. Migration is idempotent: re-running
+-- produces the exact same final state.
+DELETE FROM certificate_template_fields WHERE template_id = @oca_child_tpl;
+
+-- ─── 2. Insert the full field set ───────────────────────────────────
+-- All sort_order values renumbered so the final field set reads top-down.
+INSERT INTO certificate_template_fields
+  (template_id, field_key, label, source_type, source_path,
+   x, y, width, height, font_family, font_size, font_weight, text_align,
+   color, text_transform, is_required, is_multiline, sort_order)
+VALUES
+  -- Child name (centered on the long underline) — keep existing if present;
+  -- this row is here so re-running the migration on a fresh DB still seeds it.
+  (@oca_child_tpl, 'child_full_name', 'Child Name',         'computed', 'first_name+last_name',
+   304, 346, 305, NULL, 'TimesRoman', 18.0, 'normal', 'center', '#000000', 'none', 1, 0, 10),
+
+  -- CHILD OF ___ AND ___
+  (@oca_child_tpl, 'father_name',     'Father Name',         'computed', 'parents|first',
+   250, 324, 135, NULL, 'TimesRoman', 13.0, 'normal', 'center', '#000000', 'none', 0, 0, 20),
+  (@oca_child_tpl, 'mother_name',     'Mother Name',         'computed', 'parents|second',
+   422, 324, 135, NULL, 'TimesRoman', 13.0, 'normal', 'center', '#000000', 'none', 0, 0, 21),
+
+  -- WHO WAS BORN IN ___
+  (@oca_child_tpl, 'birthplace',      'Birthplace',          'record',   'birthplace',
+   368, 302, 226, NULL, 'TimesRoman', 13.0, 'normal', 'center', '#000000', 'none', 0, 0, 30),
+
+  -- ON _________________, 20___
+  (@oca_child_tpl, 'birth_date_md',   'Birth Date (Month/Day)', 'computed', 'birth_date|md',
+   291, 280, 194, NULL, 'TimesRoman', 13.0, 'normal', 'center', '#000000', 'none', 0, 0, 40),
+  (@oca_child_tpl, 'birth_date_yy',   'Birth Date (YY)',     'computed', 'birth_date|yy',
+   425, 280,  26, NULL, 'TimesRoman', 13.0, 'normal', 'center', '#000000', 'none', 0, 0, 41),
+
+  -- BY ___
+  (@oca_child_tpl, 'clergy_name',     'Officiating Clergy',  'record',   'clergy',
+   316, 212, 282, NULL, 'TimesRoman', 13.0, 'normal', 'center', '#000000', 'none', 0, 0, 50),
+
+  -- AT THE CHURCH OF ___
+  (@oca_child_tpl, 'church_name',     'Church Name',         'church',   'name',
+   372, 190, 226, NULL, 'TimesRoman', 13.0, 'normal', 'center', '#000000', 'none', 0, 0, 60),
+
+  -- ON _________________, 20___
+  (@oca_child_tpl, 'baptism_date_md', 'Baptism Date (Month/Day)', 'computed', 'reception_date|md',
+   291, 168, 194, NULL, 'TimesRoman', 13.0, 'normal', 'center', '#000000', 'none', 0, 0, 70),
+  (@oca_child_tpl, 'baptism_date_yy', 'Baptism Date (YY)',   'computed', 'reception_date|yy',
+   425, 168,  26, NULL, 'TimesRoman', 13.0, 'normal', 'center', '#000000', 'none', 0, 0, 71),
+
+  -- SPONSORS ___
+  (@oca_child_tpl, 'sponsors',        'Sponsors',            'record',   'sponsors',
+   338, 146, 281, NULL, 'TimesRoman', 12.0, 'normal', 'center', '#000000', 'none', 0, 0, 80),
+
+  -- THIS IS A TRUE EXTRACT ... CHURCH OF ___ (small repeat near footer)
+  (@oca_child_tpl, 'church_name_short','Church Name (footer)', 'church',  'name',
+   400, 114, 149, NULL, 'TimesRoman', 11.0, 'normal', 'center', '#000000', 'none', 0, 0, 90),
+
+  -- Rector signature line (lower-left)
+  (@oca_child_tpl, 'rector_name',     'Rector',              'church',   'rector_name',
+   202, 101, 130, NULL, 'TimesRoman', 11.0, 'normal', 'center', '#000000', 'none', 0, 0, 100);
+
+-- ─── 3. Verification ────────────────────────────────────────────────
+SELECT field_key, source_type, source_path, x, y, font_size, sort_order
+  FROM certificate_template_fields
+ WHERE template_id = @oca_child_tpl
+ ORDER BY sort_order;

--- a/server/src/certificates/field-mapper.js
+++ b/server/src/certificates/field-mapper.js
@@ -49,8 +49,11 @@ function mapFieldValues(fields, record, church = {}) {
         break;
     }
 
-    // Format dates
-    if (value && isDateField(field.field_key, field.source_path)) {
+    // Format dates — only for raw record-typed date columns. Computed
+    // values use their own format directives (e.g. birth_date|md), so
+    // applying formatDate here would mangle "12/3" back into a long
+    // "Month Day, Year" string.
+    if (value && field.source_type === 'record' && isDateField(field.field_key, field.source_path)) {
       value = formatDate(value);
     }
 
@@ -97,15 +100,36 @@ function resolveChurchValue(sourcePath, church) {
 }
 
 /**
- * Resolve computed values — typically combining multiple record fields.
+ * Resolve computed values — typically combining or formatting record fields.
  *
  * source_path conventions:
- *   'first_name+last_name' — joins with space
+ *   'first_name+last_name'  — joins with space
  *   'fname_groom+lname_groom' — joins with space
- *   'parents' — returns parents field directly (used for child baptism "child of" line)
+ *   'parents'               — returns parents field directly (used for child baptism "child of" line)
+ *
+ *   Format directives — `path|format`. The directive is applied AFTER the
+ *   field is resolved. Used by the OCA template fields where the artwork
+ *   has separate placeholder spots (e.g. "ON ____, 20___" with the year
+ *   pre-printed as "20"):
+ *
+ *     'birth_date|md'      — "12/3"   (month/day, no zero-pad)
+ *     'birth_date|yy'      — "25"     (last 2 digits of year)
+ *     'birth_date|yyyy'    — "2025"   (4-digit year)
+ *     'reception_date|md'  — same shape as |md above
+ *     'parents|first'      — "Nicholas Torrisi"  (first half of "A & B" / "A, B")
+ *     'parents|second'     — "Samantha Dominy"   (second half)
+ *     'witness|first'      — same split for marriage witnesses
+ *     'witness|second'     — ditto
  */
 function resolveComputedValue(sourcePath, record, church) {
   if (!sourcePath) return '';
+
+  // Format directive: path|format
+  if (sourcePath.includes('|')) {
+    const [rawPath, format] = sourcePath.split('|', 2).map(s => s.trim());
+    const raw = record[rawPath] != null ? record[rawPath] : (church[rawPath] != null ? church[rawPath] : '');
+    return applyComputedFormat(raw, format);
+  }
 
   // Concatenation pattern: field1+field2
   if (sourcePath.includes('+')) {
@@ -122,6 +146,74 @@ function resolveComputedValue(sourcePath, record, church) {
   if (church[sourcePath] != null) return String(church[sourcePath]);
 
   return '';
+}
+
+// Apply a |format directive to a resolved raw value. Used for OCA's
+// split-field placeholders. Returns '' on any parse failure rather than
+// surfacing the raw value, since "wrong format" on a certificate is
+// worse than "blank".
+function applyComputedFormat(raw, format) {
+  if (raw == null || raw === '') return '';
+
+  switch (format) {
+    case 'md': {
+      const d = parseDate(raw);
+      if (!d) return '';
+      return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+    }
+    case 'yy': {
+      const d = parseDate(raw);
+      if (!d) return '';
+      return String(d.getUTCFullYear()).slice(-2);
+    }
+    case 'yyyy': {
+      const d = parseDate(raw);
+      if (!d) return '';
+      return String(d.getUTCFullYear());
+    }
+    case 'first':
+    case 'second': {
+      const [a, b] = splitTwoParty(String(raw));
+      return format === 'first' ? a : b;
+    }
+    default:
+      // Unknown directive — return raw to avoid silently dropping.
+      return String(raw);
+  }
+}
+
+// Robust date parse — accepts Date objects, ISO strings, YYYY-MM-DD, or
+// MySQL TIMESTAMP strings. Returns a Date in UTC (so getUTCMonth/Date
+// match the date the DB stored, regardless of server timezone).
+function parseDate(raw) {
+  if (raw instanceof Date) {
+    return Number.isNaN(raw.getTime()) ? null : raw;
+  }
+  if (typeof raw === 'string') {
+    // YYYY-MM-DD — interpret as UTC midnight (no timezone shift).
+    const ymd = /^(\d{4})-(\d{2})-(\d{2})/.exec(raw);
+    if (ymd) {
+      return new Date(Date.UTC(Number(ymd[1]), Number(ymd[2]) - 1, Number(ymd[3])));
+    }
+    const d = new Date(raw);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+// Split a combined "A & B" / "A, B" / "A; B" string into [A, B].
+// Mirrors the front-end splitTwoParty helper to keep round-trip stable.
+function splitTwoParty(combined) {
+  if (!combined) return ['', ''];
+  const trimmed = String(combined).trim();
+  if (!trimmed) return ['', ''];
+  for (const sep of [' & ', '&', ';', ',']) {
+    if (trimmed.includes(sep)) {
+      const parts = trimmed.split(sep).map(s => s.trim()).filter(Boolean);
+      return [parts[0] || '', parts[1] || ''];
+    }
+  }
+  return [trimmed, ''];
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes the baptism_child OCA certificate to match the actual artwork layout:
- **CHILD OF \_\_\_ AND \_\_\_** — was showing nothing; now fills two separate spots with father / mother.
- **ON \_\_\_, 20\_\_** (birth date) — was trying to fit the full date in the first slot; now fills `M/D` in the long blank and `YY` over the underscores after the pre-printed `20`.
- Same shape for the baptism date row.

User-facing semantics (real values for Edmund Torrisi, `id=740`, `parents='Nicholas Torrisi & Samantha Dominy'`, `birth_date='2025-12-03'`, `reception_date='2026-02-21'`):

| Spot | Renders |
|---|---|
| `father_name` | `Nicholas Torrisi` |
| `mother_name` | `Samantha Dominy` |
| `birth_date_md` | `12/3` |
| `birth_date_yy` | `25` |
| `baptism_date_md` | `2/21` |
| `baptism_date_yy` | `26` |

## Two changes

### 1. `field-mapper.js` — `path|format` directives

The `computed` source type now accepts `path|format` syntax so one record column can drive multiple template spots:

```
birth_date|md       → "12/3"
birth_date|yy       → "25"
birth_date|yyyy     → "2025"
reception_date|md   → "2/21"
reception_date|yy   → "26"
parents|first       → first half of "A & B" / "A, B" / "A; B"
parents|second      → second half (mirrors the front-end splitTwoParty helper)
witness|first       → same split for marriage witnesses
witness|second      → ditto
```

Date parsing uses UTC (`getUTCMonth/Date/FullYear`) so the rendered values match the date the DB stored regardless of server timezone.

Also fixed an interaction bug: `mapFieldValues` used to run `formatDate` on any field whose key/path contained "date" — that would mangle computed `"12/3"` / `"25"` outputs back into `"Month Day, Year"`. `formatDate` now only fires for `source_type='record'`; computed values pass through verbatim.

### 2. Migration — `20260503_oca_baptism_child_split_fields.sql`

Resets the OCA `baptism_child` template's field set to the 13 fields the artwork has — including the new split fields and a `church_name_short` for the small repeat near the footer. Coordinates derived from the actual PDF bbox extraction (`pdftotext -layout -bbox`, then pdf-lib y = `792 - top_down_yMax_of_underline`).

Migration uses `DELETE + INSERT` rather than `INSERT IGNORE` so re-running picks up coordinate updates on existing `field_keys`. Idempotent.

## Verification
Live generation against Edmund Torrisi's actual record:
```
record: Edmund Torrisi | birth_date: 2025-12-03T05:00:00.000Z | reception_date: 2026-02-21T05:00:00.000Z | parents: Nicholas Torrisi & Samantha Dominy
templateType: baptism_child
template: 2 | fields: 13

  child_full_name        = "Edmund Torrisi"
  father_name            = "Nicholas Torrisi"
  mother_name            = "Samantha Dominy"
  birthplace             = "Mount Laurel, NJ"
  birth_date_md          = "12/3"
  birth_date_yy          = "25"
  clergy_name            = "Rev. James Parsells"
  church_name            = "Saints Peter & Paul Orthodox Church"
  baptism_date_md        = "2/21"
  baptism_date_yy        = "26"
  sponsors               = "Zachary Sokol & Polina Dineva"
  church_name_short      = "Saints Peter & Paul Orthodox Church"
  rector_name            = ""
```

Server build clean, migration applied to live DB, backend restarted. The user can refresh `/portal/certificates`, regenerate Edmund's certificate, and see the correct values.

## Limitations / follow-ups
- `baptism_adult` still uses the old single-field date format. The adult artwork has a 4-digit year slot (`ON ____, ______`), not `20__`, so it doesn't need the YY split — but it could benefit from the M/D split for consistency. Out of scope here since the user only reported the child cert.
- `rector_name` for SSPPOC is `NULL` in `churches` — populating it via the church admin page will fill the rector signature line.
- Coordinates are best-guess from the PDF underline positions. Visual inspection may surface a few point-level nudges, which can be applied via `PUT /api/certificate-templates/:id/fields/:fieldId` without redeploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
