### PR TITLE
CERT-TEMPLATE-PREVIEW-UPLOAD: per-type preview + custom upload on /portal/certificates

### DIFF
--- a/front-end/src/features/portal/PortalCertificatesPage.tsx
+++ b/front-end/src/features/portal/PortalCertificatesPage.tsx
@@ -45,6 +45,8 @@ import {
   Favorite as MarriageIcon,
   Church as ReceptionIcon,
   History as HistoryIcon,
+  CloudUpload as UploadIcon,
+  Visibility as PreviewIcon,
 } from '@mui/icons-material';
 import Breadcrumb from '@/layouts/full/shared/breadcrumb/Breadcrumb';
 import PageContainer from '@/shared/ui/PageContainer';
@@ -81,6 +83,19 @@ interface GeneratedCert {
   version_label: string;
   template_name: string;
   jurisdiction_code: string;
+}
+
+interface TemplateInfo {
+  templateId: number;
+  templateType: string;
+  groupName: string | null;
+  jurisdictionCode: string | null;
+  versionLabel: string | null;
+  resolution: string;
+  isChurchOverride: boolean;
+  fieldCount: number;
+  previewUrl: string;
+  cacheBust: number;
 }
 
 // ─── Constants ───────────────────────────────────────────────
@@ -145,6 +160,15 @@ const PortalCertificatesPage: React.FC = () => {
   const [historyLoading, setHistoryLoading] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
 
+  // Per-type template (shown above the record list)
+  const [templateInfo, setTemplateInfo] = useState<TemplateInfo | null>(null);
+  const [templateLoading, setTemplateLoading] = useState(false);
+  const [templateError, setTemplateError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadSuccess, setUploadSuccess] = useState<string | null>(null);
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+
   // ─── Load records ──────────────────────────────────────────
 
   const loadRecords = useCallback(async (type: string) => {
@@ -178,6 +202,75 @@ const PortalCertificatesPage: React.FC = () => {
     }
   }, []);
 
+  const loadTemplateInfo = useCallback(async (type: string) => {
+    setTemplateLoading(true);
+    setTemplateError(null);
+    setTemplateInfo(null);
+    try {
+      const res = await apiClient.get(`/certificate-templates/by-type/${encodeURIComponent(type)}`);
+      if (res?.success && res.template) {
+        setTemplateInfo({
+          templateId: res.template.id,
+          templateType: res.template.templateType,
+          groupName: res.template.groupName,
+          jurisdictionCode: res.template.jurisdictionCode,
+          versionLabel: res.template.versionLabel,
+          resolution: res.resolution || 'system_default',
+          isChurchOverride: !!res.template.churchId,
+          fieldCount: res.fieldCount || 0,
+          previewUrl: res.previewUrl,
+          cacheBust: Date.now(),
+        });
+      } else {
+        setTemplateError(res?.error || 'No template registered for this type');
+      }
+    } catch (err: any) {
+      setTemplateError(err?.response?.data?.error || err?.message || 'Failed to load template');
+    } finally {
+      setTemplateLoading(false);
+    }
+  }, []);
+
+  const handleUploadChoose = () => {
+    setUploadError(null);
+    setUploadSuccess(null);
+    fileInputRef.current?.click();
+  };
+
+  const handleUploadFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !selectedType) return;
+    if (file.type && file.type !== 'application/pdf' && !file.name.toLowerCase().endsWith('.pdf')) {
+      setUploadError('Please choose a PDF file.');
+      e.target.value = '';
+      return;
+    }
+    setUploading(true);
+    setUploadError(null);
+    setUploadSuccess(null);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const res = await apiClient.post(
+        `/certificate-templates/by-type/${encodeURIComponent(selectedType)}/upload`,
+        fd,
+        { headers: { 'Content-Type': 'multipart/form-data' } },
+      );
+      if (res?.success) {
+        setUploadSuccess(res.action === 'created' ? 'Custom template uploaded' : 'Custom template replaced');
+        // Reload template info so the preview swaps to the new file.
+        await loadTemplateInfo(selectedType);
+      } else {
+        setUploadError(res?.error || 'Upload failed');
+      }
+    } catch (err: any) {
+      setUploadError(err?.response?.data?.error || err?.message || 'Upload failed');
+    } finally {
+      setUploading(false);
+      e.target.value = '';
+    }
+  };
+
   // ─── Select type ───────────────────────────────────────────
 
   const handleSelectType = (type: string) => {
@@ -185,8 +278,11 @@ const PortalCertificatesPage: React.FC = () => {
     setSelectedRecord(null);
     setGenResult(null);
     setGenError(null);
+    setUploadError(null);
+    setUploadSuccess(null);
     setStep('record');
     loadRecords(type);
+    loadTemplateInfo(type);
   };
 
   const handleSelectRecord = (record: RecordRow) => {
@@ -256,6 +352,121 @@ const PortalCertificatesPage: React.FC = () => {
 
   // ─── Render: Record Selection ──────────────────────────────
 
+  const renderTemplateSection = () => {
+    const typeLabel = RECORD_TYPES.find(rt => rt.key === selectedType)?.label || selectedType || '';
+    return (
+      <Card variant="outlined" sx={{ mb: 3, borderColor: alpha(theme.palette.primary.main, 0.25) }}>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="stretch">
+            {/* Left: metadata + actions */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                <PreviewIcon fontSize="small" color="primary" />
+                <Typography variant="subtitle1" fontWeight={600}>
+                  Current {typeLabel} Certificate Template
+                </Typography>
+              </Stack>
+
+              {templateLoading ? (
+                <Box sx={{ py: 3, textAlign: 'center' }}><CircularProgress size={24} /></Box>
+              ) : templateError ? (
+                <Alert severity="warning" sx={{ mb: 1 }}>{templateError}</Alert>
+              ) : templateInfo ? (
+                <>
+                  <Stack spacing={0.5} sx={{ mb: 2 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      <strong>Template:</strong> {templateInfo.groupName || '—'}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      <strong>Jurisdiction:</strong> {templateInfo.jurisdictionCode || '—'}
+                      {templateInfo.versionLabel ? ` · v${templateInfo.versionLabel}` : ''}
+                    </Typography>
+                    <Stack direction="row" spacing={1} sx={{ mt: 0.5 }}>
+                      <Chip
+                        size="small"
+                        label={templateInfo.isChurchOverride ? 'Custom (this parish)' : 'System default'}
+                        color={templateInfo.isChurchOverride ? 'primary' : 'default'}
+                      />
+                      <Chip size="small" label={`${templateInfo.fieldCount} fields`} variant="outlined" />
+                    </Stack>
+                  </Stack>
+                </>
+              ) : null}
+
+              {uploadError && <Alert severity="error" sx={{ mb: 1 }}>{uploadError}</Alert>}
+              {uploadSuccess && <Alert severity="success" sx={{ mb: 1 }}>{uploadSuccess}</Alert>}
+
+              <Stack direction="row" spacing={1}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={uploading ? <CircularProgress size={16} color="inherit" /> : <UploadIcon />}
+                  onClick={handleUploadChoose}
+                  disabled={uploading || !selectedType}
+                >
+                  {uploading ? 'Uploading…' : (templateInfo?.isChurchOverride ? 'Replace Custom Template' : 'Upload Custom Template')}
+                </Button>
+                {templateInfo && (
+                  <Button
+                    variant="text"
+                    size="small"
+                    startIcon={<DownloadIcon />}
+                    href={templateInfo.previewUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open in new tab
+                  </Button>
+                )}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="application/pdf,.pdf"
+                  hidden
+                  onChange={handleUploadFile}
+                />
+              </Stack>
+            </Box>
+
+            {/* Right: PDF preview */}
+            <Box sx={{ flex: 1, minWidth: 0, minHeight: 320 }}>
+              {templateInfo ? (
+                <Box
+                  component="iframe"
+                  // cacheBust forces re-fetch after upload
+                  src={`${templateInfo.previewUrl}?v=${templateInfo.cacheBust}`}
+                  title={`${typeLabel} certificate template preview`}
+                  sx={{
+                    width: '100%',
+                    height: 360,
+                    border: `1px solid ${alpha(theme.palette.divider, 0.6)}`,
+                    borderRadius: 1,
+                    backgroundColor: theme.palette.background.default,
+                  }}
+                />
+              ) : (
+                <Box
+                  sx={{
+                    width: '100%',
+                    height: 360,
+                    border: `1px dashed ${alpha(theme.palette.divider, 0.8)}`,
+                    borderRadius: 1,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: 'text.secondary',
+                  }}
+                >
+                  {templateLoading ? <CircularProgress size={20} /> : 'No preview available'}
+                </Box>
+              )}
+            </Box>
+          </Stack>
+        </CardContent>
+      </Card>
+    );
+  };
+
   const renderRecordSelection = () => (
     <Box>
       <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 2 }}>
@@ -265,6 +476,8 @@ const PortalCertificatesPage: React.FC = () => {
         </Typography>
         <Chip label={t('portal.certs_records_count').replace('{count}', String(records.length))} size="small" />
       </Stack>
+
+      {renderTemplateSection()}
 
       {recordsLoading ? (
         <Box sx={{ py: 6, textAlign: 'center' }}><CircularProgress /></Box>

--- a/server/src/routes/certificate-templates.js
+++ b/server/src/routes/certificate-templates.js
@@ -7,13 +7,28 @@ const express = require('express');
 const router = express.Router();
 const path = require('path');
 const fs = require('fs');
+const multer = require('multer');
 const { getAppPool } = require('../config/db');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireRole } = require('../middleware/auth');
 const { resolveTemplate, determineBaptismVariant } = require('../certificates/template-resolver');
 const { mapFieldValues } = require('../certificates/field-mapper');
 
 const ADMIN_ROLES = ['super_admin', 'admin'];
 const TEMPLATE_MGMT_ROLES = ['super_admin'];
+const TEMPLATE_UPLOAD_ROLES = ['super_admin', 'admin', 'church_admin', 'priest'];
+
+// Frontend uses simplified card labels; backend stores adult/child variants.
+// "baptism" without a suffix maps to baptism_child as the canonical variant
+// (the more common case in real parish data).
+const TEMPLATE_TYPE_ALIAS = {
+  baptism: 'baptism_child',
+};
+function normalizeTemplateType(t) {
+  return TEMPLATE_TYPE_ALIAS[t] || t;
+}
+const VALID_TEMPLATE_TYPES = new Set([
+  'baptism_adult', 'baptism_child', 'marriage', 'reception', 'funeral', 'chrismation', 'recognition',
+]);
 
 /* ══════════════════════════════════════════════════════════
    Template Groups — List / Get
@@ -359,5 +374,288 @@ router.get('/jurisdictions/summary', requireAuth, async (req, res) => {
     res.status(500).json({ error: 'Failed to list jurisdictions' });
   }
 });
+
+/* ══════════════════════════════════════════════════════════
+   Per-Type Preview + Upload — used by /portal/certificates UI
+   ══════════════════════════════════════════════════════════ */
+
+// Multer config for template PDF uploads. PDFs only, max 10 MB. Files are
+// staged in a per-church folder under storage so the deploy-tree treats
+// them like any other artifact.
+const TEMPLATE_UPLOAD_MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+function templateUploadDir(churchId) {
+  const dir = path.resolve(__dirname, '../../storage/certificates/templates/church-' + Number(churchId));
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+const templateUpload = multer({
+  storage: multer.diskStorage({
+    destination: (req, _file, cb) => {
+      const cid = Number(req.user && req.user.church_id);
+      if (!Number.isFinite(cid) || cid <= 0) {
+        return cb(new Error('No church context on request'));
+      }
+      cb(null, templateUploadDir(cid));
+    },
+    filename: (req, file, cb) => {
+      const t = normalizeTemplateType(req.params.templateType || 'unknown').replace(/[^a-z0-9_]/gi, '');
+      const ext = path.extname(file.originalname).toLowerCase() === '.pdf' ? '.pdf' : '.pdf';
+      cb(null, `${t}-${Date.now()}${ext}`);
+    },
+  }),
+  limits: { fileSize: TEMPLATE_UPLOAD_MAX_SIZE },
+  fileFilter: (_req, file, cb) => {
+    // Trust nothing — we re-validate the magic bytes after upload below.
+    if (file.mimetype === 'application/pdf' || file.originalname.toLowerCase().endsWith('.pdf')) {
+      return cb(null, true);
+    }
+    cb(new Error('Only PDF files are allowed'));
+  },
+}).single('file');
+
+// Wraps multer to surface friendly JSON errors instead of HTML 500s.
+function handleTemplateUpload(req, res, next) {
+  templateUpload(req, res, (err) => {
+    if (err) {
+      const status = err.code === 'LIMIT_FILE_SIZE' ? 413 : 400;
+      return res.status(status).json({ success: false, error: err.message || 'Upload failed' });
+    }
+    next();
+  });
+}
+
+// Verify a freshly uploaded file is actually a PDF (magic bytes %PDF-).
+function isLikelyPdf(filePath) {
+  try {
+    const fd = fs.openSync(filePath, 'r');
+    const buf = Buffer.alloc(5);
+    fs.readSync(fd, buf, 0, 5, 0);
+    fs.closeSync(fd);
+    return buf.toString('latin1').startsWith('%PDF-');
+  } catch {
+    return false;
+  }
+}
+
+// GET /api/certificate-templates/by-type/:templateType
+// Returns the canonical template the user's church will use for this type.
+// Combines church-specific override (if any) with the system default.
+router.get('/by-type/:templateType', requireAuth, async (req, res) => {
+  try {
+    const churchId = Number(req.user && req.user.church_id);
+    if (!Number.isFinite(churchId) || churchId <= 0) {
+      return res.status(400).json({ success: false, error: 'No church context on request' });
+    }
+    const templateType = normalizeTemplateType(req.params.templateType);
+    if (!VALID_TEMPLATE_TYPES.has(templateType)) {
+      return res.status(400).json({ success: false, error: `Unknown template type: ${req.params.templateType}` });
+    }
+
+    const resolved = await resolveTemplate({ churchId, templateType });
+    if (!resolved) {
+      return res.status(404).json({ success: false, error: `No template registered for ${templateType}` });
+    }
+
+    const tpl = resolved.template;
+    res.json({
+      success: true,
+      requestedType: req.params.templateType,
+      resolvedType: templateType,
+      resolution: resolved.resolution || (tpl.church_id ? 'church_specific' : 'system_default'),
+      template: {
+        id: tpl.id,
+        templateType: tpl.template_type || templateType,
+        groupName: tpl.group_name || null,
+        jurisdictionCode: tpl.jurisdiction_code || null,
+        versionLabel: tpl.version_label || null,
+        churchId: tpl.church_id || null,
+        backgroundAssetPath: tpl.background_asset_path || null,
+        pageWidth: Number(tpl.page_width) || 612,
+        pageHeight: Number(tpl.page_height) || 792,
+        renderMode: tpl.render_mode || 'pdf_overlay',
+        isActive: !!tpl.is_active,
+        updatedAt: tpl.updated_at || null,
+      },
+      fieldCount: Array.isArray(resolved.fields) ? resolved.fields.length : 0,
+      previewUrl: `/api/certificate-templates/${tpl.id}/background.pdf`,
+    });
+  } catch (err) {
+    console.error('[certificate-templates] GET /by-type error:', err.message);
+    res.status(500).json({ success: false, error: 'Failed to resolve template' });
+  }
+});
+
+// GET /api/certificate-templates/:id/background.pdf
+// Streams the template's background PDF for inline preview. Read-only.
+// No church scoping — anyone authenticated can preview any registered
+// template (templates aren't sensitive; per-record certs are).
+router.get('/:id/background.pdf', requireAuth, async (req, res) => {
+  try {
+    const id = Number(req.params.id);
+    if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid template id' });
+
+    const [rows] = await getAppPool().query(
+      'SELECT id, background_asset_path FROM certificate_templates WHERE id = ?',
+      [id],
+    );
+    if (!rows.length) return res.status(404).json({ error: 'Template not found' });
+    const tpl = rows[0];
+    if (!tpl.background_asset_path) {
+      return res.status(404).json({ error: 'Template has no background asset' });
+    }
+
+    const fullPath = path.isAbsolute(tpl.background_asset_path)
+      ? tpl.background_asset_path
+      : path.resolve(__dirname, '../../storage', tpl.background_asset_path);
+
+    // Confine reads to the storage tree — defence against any future
+    // background_asset_path that contains '..' or absolute paths outside
+    // the allowed root.
+    const storageRoot = path.resolve(__dirname, '../../storage');
+    if (!fullPath.startsWith(storageRoot + path.sep) && fullPath !== storageRoot) {
+      return res.status(403).json({ error: 'Template asset path is outside the storage root' });
+    }
+    if (!fs.existsSync(fullPath)) {
+      return res.status(404).json({ error: 'Template asset missing on disk' });
+    }
+
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `inline; filename="template-${id}.pdf"`);
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+    fs.createReadStream(fullPath).pipe(res);
+  } catch (err) {
+    console.error('[certificate-templates] GET /:id/background.pdf error:', err.message);
+    res.status(500).json({ error: 'Failed to read template background' });
+  }
+});
+
+// POST /api/certificate-templates/by-type/:templateType/upload
+// Multipart file upload (field: "file"). Creates a church-specific
+// override row if one doesn't already exist for this church + group;
+// otherwise updates the existing override's background_asset_path.
+//
+// Field positions are NOT migrated automatically — when an override is
+// first created the church inherits the system default's field shape via
+// resolveTemplate's fall-through. If the operator wants to fine-tune
+// positions for the new artwork they can do so via the existing
+// PUT /:id/fields/:fieldId endpoint.
+router.post(
+  '/by-type/:templateType/upload',
+  requireAuth,
+  requireRole(TEMPLATE_UPLOAD_ROLES),
+  handleTemplateUpload,
+  async (req, res) => {
+    let uploadedAbsPath = null;
+    try {
+      const churchId = Number(req.user && req.user.church_id);
+      if (!Number.isFinite(churchId) || churchId <= 0) {
+        return res.status(400).json({ success: false, error: 'No church context on request' });
+      }
+      const templateType = normalizeTemplateType(req.params.templateType);
+      if (!VALID_TEMPLATE_TYPES.has(templateType)) {
+        return res.status(400).json({ success: false, error: `Unknown template type: ${req.params.templateType}` });
+      }
+      if (!req.file) {
+        return res.status(400).json({ success: false, error: 'No file uploaded (expected multipart field "file")' });
+      }
+      uploadedAbsPath = req.file.path;
+
+      // Hard-validate the magic bytes — fileFilter only checked MIME/ext.
+      if (!isLikelyPdf(uploadedAbsPath)) {
+        try { fs.unlinkSync(uploadedAbsPath); } catch {}
+        return res.status(400).json({ success: false, error: 'Uploaded file is not a valid PDF' });
+      }
+
+      const pool = getAppPool();
+
+      // Find the system / jurisdiction template_group for this type.
+      // We assume the OCA group is the active one for this type — pick
+      // the most recently-created active group as a fallback.
+      const [groupRows] = await pool.query(
+        `SELECT id FROM certificate_template_groups
+          WHERE template_type = ? AND is_active = TRUE
+          ORDER BY (jurisdiction_code = 'OCA') DESC, id DESC
+          LIMIT 1`,
+        [templateType],
+      );
+      if (!groupRows.length) {
+        try { fs.unlinkSync(uploadedAbsPath); } catch {}
+        return res.status(404).json({ success: false, error: `No template group registered for ${templateType}` });
+      }
+      const groupId = groupRows[0].id;
+
+      // Path stored in DB is RELATIVE to server/storage so dist + restore
+      // round-trip cleanly. The disk path multer wrote is absolute.
+      const storageRoot = path.resolve(__dirname, '../../storage');
+      const relativePath = path.relative(storageRoot, uploadedAbsPath).split(path.sep).join('/');
+
+      // Upsert the church override. UNIQUE constraint on
+      // (template_group_id, church_id) isn't declared in the schema, so
+      // we look up + UPDATE or INSERT manually.
+      const [existing] = await pool.query(
+        `SELECT id, background_asset_path FROM certificate_templates
+          WHERE template_group_id = ? AND church_id = ?
+          ORDER BY id DESC LIMIT 1`,
+        [groupId, churchId],
+      );
+
+      let templateId;
+      let action;
+      let prevAssetAbs = null;
+      if (existing.length) {
+        templateId = existing[0].id;
+        action = 'updated';
+        if (existing[0].background_asset_path) {
+          prevAssetAbs = path.resolve(storageRoot, existing[0].background_asset_path);
+        }
+        await pool.query(
+          `UPDATE certificate_templates
+              SET background_asset_path = ?, is_active = TRUE, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?`,
+          [relativePath, templateId],
+        );
+      } else {
+        action = 'created';
+        const [insertResult] = await pool.query(
+          `INSERT INTO certificate_templates
+             (template_group_id, church_id, version_label, background_asset_path,
+              page_width, page_height, render_mode, is_active, created_by)
+           VALUES (?, ?, ?, ?, 612, 792, 'pdf_overlay', TRUE, ?)`,
+          [groupId, churchId, '1.0-custom', relativePath, req.user.id || null],
+        );
+        templateId = insertResult.insertId;
+      }
+
+      // Best-effort: remove the previous custom asset if we just replaced
+      // it with a different filename. Never delete a system default
+      // asset (those are shared across churches).
+      if (action === 'updated' && prevAssetAbs && prevAssetAbs !== uploadedAbsPath) {
+        const churchScopedRoot = path.resolve(storageRoot, 'certificates/templates/church-' + churchId);
+        if (prevAssetAbs.startsWith(churchScopedRoot + path.sep)) {
+          try { fs.unlinkSync(prevAssetAbs); } catch {}
+        }
+      }
+
+      res.json({
+        success: true,
+        action,
+        templateId,
+        templateType,
+        churchId,
+        backgroundAssetPath: relativePath,
+        fileSize: req.file.size || null,
+        previewUrl: `/api/certificate-templates/${templateId}/background.pdf`,
+      });
+    } catch (err) {
+      // If anything blew up after a successful disk write, clean up the
+      // orphan file so storage doesn't accumulate dead PDFs.
+      if (uploadedAbsPath) {
+        try { fs.unlinkSync(uploadedAbsPath); } catch {}
+      }
+      console.error('[certificate-templates] POST /by-type/:templateType/upload error:', err.message);
+      res.status(500).json({ success: false, error: 'Failed to save template upload' });
+    }
+  },
+);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
On `/portal/certificates`, after the user picks Baptism / Marriage / Reception, the page now shows the **current certificate template** for that type and lets them **upload a custom one** for their parish. New custom templates are church-scoped — they don't affect other parishes.

## Backend — three new endpoints under `/api/certificate-templates`

| Endpoint | Purpose |
|---|---|
| `GET  /by-type/:templateType` | Resolves the canonical template the caller's church will use for this type (church override if any, else system default). Returns metadata + `previewUrl`. |
| `GET  /:id/background.pdf` | Streams the background PDF inline for `<iframe>` preview. `Cache-Control: no-cache` so a freshly-uploaded file shows up after refetch. |
| `POST /by-type/:templateType/upload` | Multipart `file` upload. Upsert behaviour — if the church already has a custom row for this template group, **UPDATE** it; otherwise **INSERT** a new church-scoped row. |

Frontend `"baptism"` resolves to `baptism_child` (the canonical variant for the dominant case). Marriage and reception map directly.

### Storage and DB shape

- New custom files land at `server/storage/certificates/templates/church-<id>/<type>-<timestamp>.pdf`.
- `certificate_templates` gets an INSERT (or UPDATE) with `church_id` set to the caller's church and `version_label = '1.0-custom'`.
- Field positions are inherited from the system default automatically — `resolveTemplate` already falls through to the default's fields when the church-specific row has none of its own.
- When a custom template is replaced, the prior file is deleted **only** if it lives under that church's own subdir. System default assets are never touched.

### Auth + safety

- All three endpoints require auth.
- Upload requires role in `[super_admin, admin, church_admin, priest]`.
- 10 MB upload cap.
- File validated by **magic bytes** (`%PDF-`), not just MIME / extension.
- Path traversal blocked: `background_asset_path` is confined to the storage tree (rejects absolute paths or `..` escapes).
- On any mid-flight error the freshly-uploaded file is removed so storage doesn't accumulate orphans.

## Frontend (`PortalCertificatesPage.tsx`)

After type selection, a **Current Template** card sits above the record list:

- Left panel: group name · jurisdiction · version · "Custom (this parish)" or "System default" chip · field count · **Upload Custom Template** / **Replace Custom Template** button (label flips based on whether the church already has an override) · "Open in new tab".
- Right panel: 360px PDF preview iframe pointing at `previewUrl?v=<cacheBust>`.

A hidden `<input type="file" accept=".pdf">` handles the upload. On success the page re-fetches `by-type` so the preview swaps to the new file.

## Verified end-to-end (prod DB, in-process tests)

**Reads** (fake req.user as `priest @ ssppoc`, `church_id=46`):

```
GET /by-type/baptism      200  baptism_child id=2 (system default), 13 fields
GET /by-type/marriage     200  id=3 (system default)
GET /by-type/reception    200  id=4 (system default)
GET /by-type/garbage      400  Unknown template type
GET /2/background.pdf     200  166283 bytes, %PDF-1.3
GET /9999/background.pdf  404  Template not found
```

**Uploads** (real `certificate-marriage.pdf` as payload):

```
Upload #1 → 200, action=created, templateId=7 (new church override row)
Re-fetch  → resolution=church_override, churchId=46
Upload #2 → 200, action=updated, templateId=7 (same row, file replaced)
Cleanup   → deleted row + both staged files; church-46 dir removed
Bad PDF   → 400 "Uploaded file is not a valid PDF" (magic byte check)
```

Full server build clean; `vite build` clean; route imports verified. Backend restarted on prod, front-end `dist` mirrored — **works live now**.

## Out of scope (next work items)
- The portal cards still surface only **baptism / marriage / reception**. Chrismation + recognition exist DB-side (PR #851) but `RECORD_TYPE_DEFS` hasn't been extended. When that lands, the same `by-type` endpoint covers them with no further backend work.
- Customers uploading bespoke artwork still need field positions hand-tuned via the existing `PUT /:id/fields/:fieldId` (no drag-and-drop UI for the new flow yet — that's a larger follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
