### PR TITLE
CERT-DRAG-SCROLLBAR: scrollable field lists + father/mother fields on legacy generator

### DIFF
--- a/front-end/src/features/certificates/CertificateGeneratorPage.tsx
+++ b/front-end/src/features/certificates/CertificateGeneratorPage.tsx
@@ -62,6 +62,7 @@ import {
   MARRIAGE_FIELD_LABELS,
   formatDate,
   getRecordDisplayName,
+  splitParents,
 } from './certificateTypes';
 import GenerateReportWizard from './GenerateReportWizard';
 
@@ -180,6 +181,12 @@ const CertificateGeneratorPage: React.FC = () => {
         return formatDate(recordData.baptism_date || recordData.reception_date);
       case 'sponsors':
         return recordData.sponsors || recordData.godparents || '';
+      case 'fatherName':
+        return splitParents(recordData.parents)[0];
+      case 'motherName':
+        return splitParents(recordData.parents)[1];
+      case 'parents':
+        return recordData.parents || '';
       case 'clergyBy':
       case 'clergyRector':
       case 'clergy':
@@ -606,8 +613,22 @@ const CertificateGeneratorPage: React.FC = () => {
               </Typography>
               
               <Divider sx={{ my: 1 }} />
-              
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 0.5,
+                  // Cap the field list and let it scroll independently — the
+                  // baptism set has 11 fields and previously fell below the
+                  // viewport on shorter screens. min(60vh, 480px) keeps this
+                  // usable on laptop heights without dominating taller ones.
+                  maxHeight: 'min(60vh, 480px)',
+                  overflowY: 'auto',
+                  overflowX: 'hidden',
+                  pr: 0.5,
+                }}
+              >
                 {Object.keys(fieldLabels).map((fieldName) => {
                   const isPlaced = placedFields.has(fieldName);
                   const value = getFieldValue(fieldName);
@@ -673,7 +694,7 @@ const CertificateGeneratorPage: React.FC = () => {
               />
               
               {showCoordinates && placedFields.size > 0 && (
-                <Box sx={{ mt: 1, maxHeight: 150, overflow: 'auto' }}>
+                <Box sx={{ mt: 1, maxHeight: 'min(40vh, 280px)', overflowY: 'auto', overflowX: 'hidden', pr: 0.5 }}>
                   {Object.keys(fieldLabels).map((fieldName) => {
                     const pos = fieldPositions[fieldName];
                     if (!pos || !placedFields.has(fieldName)) return null;

--- a/front-end/src/features/certificates/certificateTypes.ts
+++ b/front-end/src/features/certificates/certificateTypes.ts
@@ -9,6 +9,9 @@ export const API_BASE = '/api/church';
 // Default field positions for baptism certificate
 export const BAPTISM_DEFAULT_POSITIONS: Record<string, { x: number; y: number }> = {
   fullName: { x: 400, y: 340 },
+  fatherName: { x: 300, y: 375 },
+  motherName: { x: 500, y: 375 },
+  parents: { x: 400, y: 375 },
   birthDate: { x: 530, y: 405 },
   birthplace: { x: 400, y: 405 },
   baptismDate: { x: 300, y: 510 },
@@ -31,6 +34,9 @@ export const MARRIAGE_DEFAULT_POSITIONS: Record<string, { x: number; y: number }
 // Field labels for display
 export const BAPTISM_FIELD_LABELS: Record<string, string> = {
   fullName: 'Full Name',
+  fatherName: "Father's Name",
+  motherName: "Mother's Name",
+  parents: 'Parents (combined)',
   birthDate: 'Birth Date',
   birthplace: 'Birthplace',
   baptismDate: 'Baptism Date',
@@ -94,6 +100,21 @@ export interface RecordData {
   witnesses?: string;
   churchName?: string;
   birthplace?: string;
+  parents?: string;
+}
+
+// Split a combined "A & B" / "A, B" / "A; B" string into [first, second].
+export function splitParents(combined: string | undefined | null): [string, string] {
+  if (!combined) return ['', ''];
+  const trimmed = String(combined).trim();
+  if (!trimmed) return ['', ''];
+  for (const sep of [' & ', '&', ';', ',']) {
+    if (trimmed.includes(sep)) {
+      const parts = trimmed.split(sep).map(s => s.trim()).filter(Boolean);
+      return [parts[0] || '', parts[1] || ''];
+    }
+  }
+  return [trimmed, ''];
 }
 
 export interface SearchCriteria {


### PR DESCRIPTION
## Summary
On `/portal/certificates/generate` (the legacy drag-and-drop generator):
- Drag-fields list ran off the bottom of the viewport on shorter screens — bottom entries were unreachable.
- Show-coordinates list was capped at 150px which clipped after ~5 fields.
- **Father's Name / Mother's Name weren't draggable at all** because they were never in `BAPTISM_FIELD_LABELS`.

## What changed

### Scrollable drag-fields list
The field-tile column now has `maxHeight: min(60vh, 480px)` + `overflow-y: auto`. Scrolls inside the card on any screen height; doesn't dominate tall ones.

### Roomier coordinates panel
Bumped from `maxHeight: 150` to `min(40vh, 280px)` so all 11 baptism field positions fit comfortably on a laptop.

### Father / Mother / Parents (combined) fields

`certificateTypes.ts`:
- Added `parents?: string` to `RecordData` (legacy fetch already returns it; this just unblocks TS access).
- Added entries to `BAPTISM_FIELD_LABELS`: `fatherName`, `motherName`, and a combined `parents` so operators can pick whichever fits their artwork (two boxes vs one line).
- Added `BAPTISM_DEFAULT_POSITIONS` placeholders: `fatherName` at `(300, 375)`, `motherName` at `(500, 375)`, `parents` at `(400, 375)`. The drift-warning UI surfaces these on first save anyway, so a few-pixel offset is fine for first paint.
- New `splitParents()` helper that splits `"A & B"` / `"A, B"` / `"A; B"` (mirrors the back-end `mapFields` combine logic so the round-trip is stable).

`CertificateGeneratorPage.tsx`:
- Imports `splitParents`.
- `getFieldValue()` handles `fatherName` / `motherName` (split from `record.parents`) and `parents` (raw combined string).

## Verification
- `tsc --noEmit -p front-end/tsconfig.json` — clean.
- `npx vite build` — clean (52.59s).
- `dist` mirrored to prod — works live without any backend redeploy. The legacy `POST /:id/preview` and `GET /:id/download` render whatever positions the UI sends; they don't care which `field_keys` exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)