### PR TITLE
CERT-RECORD-PAYLOAD: return full record from baptism + marriage previews

### DIFF
--- a/server/src/api/churchCertificates.js
+++ b/server/src/api/churchCertificates.js
@@ -828,19 +828,11 @@ router.post('/baptism/:id/preview', async (req, res) => {
       success: true,
       preview: `data:image/png;base64,${base64Image}`,
       positions: BAPTISM_POSITIONS,
-      record: {
-        id: record.id,
-        first_name: record.first_name,
-        last_name: record.last_name,
-        birth_date: record.birth_date,
-        birthplace: record.birthplace,
-        reception_date: record.reception_date,
-        baptism_date: record.baptism_date,
-        sponsors: record.sponsors,
-        godparents: record.godparents,
-        clergy: record.clergy,
-        churchName: record.churchName,
-      }
+      // Return the whole record so the front-end has every column it might
+      // want for drag-tile labels (parents, entry_type, etc.). Avoids the
+      // fragile per-field allowlist that previously dropped `parents` and
+      // left the new fatherName / motherName tiles empty.
+      record,
     });
 
   } catch (err) {
@@ -955,11 +947,8 @@ router.post('/marriage/:id/preview', async (req, res) => {
       success: true,
       preview: `data:image/png;base64,${base64Image}`,
       positions: MARRIAGE_POSITIONS,
-      record: {
-        id: record.id,
-        groom: `${record.fname_groom || ''} ${record.lname_groom || ''}`.trim(),
-        bride: `${record.fname_bride || ''} ${record.lname_bride || ''}`.trim(),
-      }
+      // Whole record (see baptism preview above for rationale).
+      record,
     });
 
   } catch (err) {


### PR DESCRIPTION
## Summary
On `/portal/certificates/generate`, the **Father's Name** / **Mother's Name** / **Parents** drag tiles I added in PR #856 only ever showed the placeholder label — never the actual values from the record.

## Root cause
`server/src/api/churchCertificates.js`'s preview endpoints hand-pick which record fields go back to the client:

```js
// Old baptism response — no `parents` field
record: {
  id, first_name, last_name, birth_date, birthplace,
  reception_date, baptism_date, sponsors, godparents,
  clergy, churchName,
}

// Old marriage response — only id + combined groom/bride strings
record: {
  id,
  groom: `${fname_groom} ${lname_groom}`,
  bride: `${fname_bride} ${lname_bride}`,
}
```

So `recordData.parents` was always `undefined` on the client, `splitParents(undefined)` returned `['', '']`, and the new tiles fell through to the `[Father's Name]` placeholder.

Marriage was even worse — `getFieldValue()` reads `recordData.fname_groom`, `recordData.marriage_date`, `recordData.witnesses`, `recordData.clergy`, etc., none of which were in the response. Most marriage drag tiles were silently broken too.

## Fix
Replace the per-field allowlists with `record` (the full tenant row from `SELECT *`). The front-end's `getFieldValue()` already filters to the fields it cares about, so the extra columns (`verified_by`, `ocr_confidence`, etc.) just get ignored. This also stops the every-new-drag-tile-needs-a-server-edit dance.

Both endpoints now do:
```js
res.json({ success: true, preview: ..., positions: ..., record });
```

## Verified live
Restarted backend, real Edmund Torrisi (id=740, om_church_46):
```
status: 200
record.first_name: Edmund
record.last_name : Torrisi
record.parents   : Nicholas Torrisi & Samantha Dominy
record.clergy    : Rev. James Parsells
```
Refreshing `/portal/certificates/generate?recordType=baptism&recordId=740&churchId=46` now shows the actual names on the Father's Name / Mother's Name / Parents drag tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)