### PR TITLE
MARRIAGE-CERT-POSITIONED: marriage cert honors saved positions + M/D + YY split

### DIFF
--- a/front-end/src/features/certificates/CertificateGeneratorPage.tsx
+++ b/front-end/src/features/certificates/CertificateGeneratorPage.tsx
@@ -61,6 +61,8 @@ import {
   BAPTISM_FIELD_LABELS,
   MARRIAGE_FIELD_LABELS,
   formatDate,
+  formatDateMD,
+  formatDateYY,
   getRecordDisplayName,
   splitParents,
 } from './certificateTypes';
@@ -175,10 +177,18 @@ const CertificateGeneratorPage: React.FC = () => {
       }
       case 'birthDate':
         return formatDate(recordData.birth_date);
+      case 'birthDateMD':
+        return formatDateMD(recordData.birth_date);
+      case 'birthDateYY':
+        return formatDateYY(recordData.birth_date);
       case 'birthplace':
         return recordData.birthplace || '';
       case 'baptismDate':
         return formatDate(recordData.baptism_date || recordData.reception_date);
+      case 'baptismDateMD':
+        return formatDateMD(recordData.baptism_date || recordData.reception_date);
+      case 'baptismDateYY':
+        return formatDateYY(recordData.baptism_date || recordData.reception_date);
       case 'sponsors':
         return recordData.sponsors || recordData.godparents || '';
       case 'fatherName':
@@ -205,6 +215,10 @@ const CertificateGeneratorPage: React.FC = () => {
       }
       case 'marriageDate':
         return formatDate(recordData.marriage_date);
+      case 'marriageDateMD':
+        return formatDateMD(recordData.marriage_date);
+      case 'marriageDateYY':
+        return formatDateYY(recordData.marriage_date);
       case 'witnesses':
         return recordData.witnesses || '';
       default:

--- a/front-end/src/features/certificates/certificateTypes.ts
+++ b/front-end/src/features/certificates/certificateTypes.ts
@@ -13,8 +13,12 @@ export const BAPTISM_DEFAULT_POSITIONS: Record<string, { x: number; y: number }>
   motherName: { x: 500, y: 375 },
   parents: { x: 400, y: 375 },
   birthDate: { x: 530, y: 405 },
+  birthDateMD: { x: 350, y: 405 },
+  birthDateYY: { x: 560, y: 405 },
   birthplace: { x: 400, y: 405 },
   baptismDate: { x: 300, y: 510 },
+  baptismDateMD: { x: 350, y: 510 },
+  baptismDateYY: { x: 560, y: 510 },
   sponsors: { x: 400, y: 545 },
   clergyBy: { x: 400, y: 475 },
   clergyRector: { x: 600, y: 620 },
@@ -26,6 +30,8 @@ export const MARRIAGE_DEFAULT_POSITIONS: Record<string, { x: number; y: number }
   groomName: { x: 383, y: 574 },
   brideName: { x: 383, y: 626 },
   marriageDate: { x: 444, y: 678 },
+  marriageDateMD: { x: 350, y: 678 },
+  marriageDateYY: { x: 560, y: 678 },
   witnesses: { x: 400, y: 782 },
   clergy: { x: 410, y: 730 },
   church: { x: 514, y: 756 },
@@ -37,9 +43,13 @@ export const BAPTISM_FIELD_LABELS: Record<string, string> = {
   fatherName: "Father's Name",
   motherName: "Mother's Name",
   parents: 'Parents (combined)',
-  birthDate: 'Birth Date',
+  birthDate: 'Birth Date (full)',
+  birthDateMD: 'Birth Date — M/D',
+  birthDateYY: 'Birth Date — YY',
   birthplace: 'Birthplace',
-  baptismDate: 'Baptism Date',
+  baptismDate: 'Baptism Date (full)',
+  baptismDateMD: 'Baptism Date — M/D',
+  baptismDateYY: 'Baptism Date — YY',
   sponsors: 'Sponsors/Godparents',
   clergyBy: 'Clergy (BY)',
   clergyRector: 'Rector',
@@ -49,7 +59,9 @@ export const BAPTISM_FIELD_LABELS: Record<string, string> = {
 export const MARRIAGE_FIELD_LABELS: Record<string, string> = {
   groomName: 'Groom Name',
   brideName: 'Bride Name',
-  marriageDate: 'Marriage Date',
+  marriageDate: 'Marriage Date (full)',
+  marriageDateMD: 'Marriage Date — M/D',
+  marriageDateYY: 'Marriage Date — YY',
   witnesses: 'Witnesses',
   clergy: 'Clergy',
   church: 'Church Name',
@@ -101,6 +113,36 @@ export interface RecordData {
   churchName?: string;
   birthplace?: string;
   parents?: string;
+}
+
+// Coerce date-ish input (Date, ISO string, YYYY-MM-DD, MySQL TIMESTAMP)
+// to a UTC Date so getUTCMonth/Date/FullYear match what the DB stored
+// regardless of browser timezone.
+function parseDateUtc(raw: any): Date | null {
+  if (raw == null || raw === '') return null;
+  if (raw instanceof Date) return Number.isNaN(raw.getTime()) ? null : raw;
+  if (typeof raw === 'string') {
+    const ymd = /^(\d{4})-(\d{2})-(\d{2})/.exec(raw);
+    if (ymd) return new Date(Date.UTC(+ymd[1], +ymd[2] - 1, +ymd[3]));
+    const d = new Date(raw);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+// "12/3" — month/day, no zero padding (matches the OCA cert artwork).
+export function formatDateMD(raw: any): string {
+  const d = parseDateUtc(raw);
+  if (!d) return '';
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+
+// "25" — last two digits of the year. Pairs with the OCA "20___"
+// pre-printed prefix.
+export function formatDateYY(raw: any): string {
+  const d = parseDateUtc(raw);
+  if (!d) return '';
+  return String(d.getUTCFullYear()).slice(-2);
 }
 
 // Split a combined "A & B" / "A, B" / "A; B" string into [first, second].

--- a/server/src/api/churchCertificates.js
+++ b/server/src/api/churchCertificates.js
@@ -58,14 +58,22 @@ const BAPTISM_TEMPLATE_PATH = path.join(__dirname, '../../certificates/2026/adul
 const BAPTISM_CHILD_TEMPLATE_PATH = path.join(__dirname, '../../certificates/2026/adult-baptism.png');
 const MARRIAGE_TEMPLATE_PATH = path.join(__dirname, '../../certificates/2026/marriage.png');
 
-// Default field positions for baptism certificate
+// Default field positions for baptism certificate.
+// The MD / YY split tiles match the OCA artwork's "ON ___, 20___"
+// layout — the long blank takes month/day, and YY fills the trailing
+// two underscores after the pre-printed "20". Operators can drag to
+// fine-tune; these are starter positions only.
 const BAPTISM_POSITIONS = {
   fullName: { x: 383, y: 574 },
   birthplace: { x: 400, y: 600 },
   birthDate: { x: 444, y: 626 },
+  birthDateMD: { x: 350, y: 626 },
+  birthDateYY: { x: 560, y: 626 },
   clergyBy: { x: 410, y: 698 },       // BY field (clergy who performed baptism)
   church: { x: 514, y: 724 },
   baptismDate: { x: 424, y: 754 },
+  baptismDateMD: { x: 350, y: 754 },
+  baptismDateYY: { x: 560, y: 754 },
   sponsors: { x: 400, y: 784 },
   clergyRector: { x: 500, y: 850 }    // Rector field (signing clergy)
 };
@@ -77,11 +85,38 @@ const MARRIAGE_POSITIONS = {
   brideName: { x: 383, y: 626 },
   brideParents: { x: 400, y: 652 },
   marriageDate: { x: 444, y: 678 },
+  marriageDateMD: { x: 350, y: 678 },
+  marriageDateYY: { x: 560, y: 678 },
   marriagePlace: { x: 410, y: 704 },
   clergy: { x: 410, y: 730 },
   church: { x: 514, y: 756 },
   witnesses: { x: 400, y: 782 }
 };
+
+// Date format helpers. Match the front-end formatDateMD / formatDateYY
+// behavior in certificateTypes.ts so the drag-tile preview value and
+// the rendered cert always agree.
+function _parseUtcDate(raw) {
+  if (raw == null || raw === '') return null;
+  if (raw instanceof Date) return Number.isNaN(raw.getTime()) ? null : raw;
+  if (typeof raw === 'string') {
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(raw);
+    if (m) return new Date(Date.UTC(+m[1], +m[2] - 1, +m[3]));
+    const d = new Date(raw);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+function dateMD(raw) {
+  const d = _parseUtcDate(raw);
+  if (!d) return '';
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+function dateYY(raw) {
+  const d = _parseUtcDate(raw);
+  if (!d) return '';
+  return String(d.getUTCFullYear()).slice(-2);
+}
 
 /**
  * Generate baptism certificate preview using canvas (PNG)
@@ -226,6 +261,14 @@ const generateBaptismPreview = async (record, fieldOffsets = {}, hiddenFields = 
       const birthDate = new Date(record.birth_date).toLocaleDateString();
       ctx.fillText(birthDate, positions.birthDate.x, positions.birthDate.y);
     }
+    if (record.birth_date && !hiddenFields.includes('birthDateMD') && positions.birthDateMD) {
+      const md = dateMD(record.birth_date);
+      if (md) ctx.fillText(md, positions.birthDateMD.x, positions.birthDateMD.y);
+    }
+    if (record.birth_date && !hiddenFields.includes('birthDateYY') && positions.birthDateYY) {
+      const yy = dateYY(record.birth_date);
+      if (yy) ctx.fillText(yy, positions.birthDateYY.x, positions.birthDateYY.y);
+    }
     
     // Clergy BY field (who performed the baptism)
     if (record.clergy && !hiddenFields.includes('clergyBy')) {
@@ -244,6 +287,14 @@ const generateBaptismPreview = async (record, fieldOffsets = {}, hiddenFields = 
     if (record.reception_date && !hiddenFields.includes('baptismDate')) {
       const baptismDate = new Date(record.reception_date).toLocaleDateString();
       ctx.fillText(baptismDate, positions.baptismDate.x, positions.baptismDate.y);
+    }
+    if (record.reception_date && !hiddenFields.includes('baptismDateMD') && positions.baptismDateMD) {
+      const md = dateMD(record.reception_date);
+      if (md) ctx.fillText(md, positions.baptismDateMD.x, positions.baptismDateMD.y);
+    }
+    if (record.reception_date && !hiddenFields.includes('baptismDateYY') && positions.baptismDateYY) {
+      const yy = dateYY(record.reception_date);
+      if (yy) ctx.fillText(yy, positions.baptismDateYY.x, positions.baptismDateYY.y);
     }
     
     if (record.sponsors && !hiddenFields.includes('sponsors')) {
@@ -440,12 +491,16 @@ const generateBaptismPDF = async (record, fieldPositions = null, hiddenFields = 
     
     if (record.birth_date) {
       drawField('birthDate', new Date(record.birth_date).toLocaleDateString());
+      drawField('birthDateMD', dateMD(record.birth_date));
+      drawField('birthDateYY', dateYY(record.birth_date));
     }
-    
+
     drawField('birthplace', record.birthplace);
-    
+
     if (record.reception_date) {
       drawField('baptismDate', new Date(record.reception_date).toLocaleDateString());
+      drawField('baptismDateMD', dateMD(record.reception_date));
+      drawField('baptismDateYY', dateYY(record.reception_date));
     }
     
     drawField('sponsors', record.sponsors);

--- a/server/src/api/churchCertificates.js
+++ b/server/src/api/churchCertificates.js
@@ -359,6 +359,43 @@ const generateMarriagePreview = async (record, fieldOffsets = {}, hiddenFields =
   ctx.fillStyle = '#000000';
   ctx.textAlign = 'center';
 
+  // ── Template path: positioned drawing (mirrors baptism) ──────────────────
+  // Previously this branch did nothing — the bare template image was
+  // returned as-is. So saved drag positions for marriage were silently
+  // ignored. Now we draw each known field at its saved (or default)
+  // position, including the new MD/YY split tiles.
+  if (fs.existsSync(MARRIAGE_TEMPLATE_PATH)) {
+    const positions = {};
+    Object.keys(MARRIAGE_POSITIONS).forEach(key => {
+      if (fieldOffsets[key] && typeof fieldOffsets[key].x === 'number' && typeof fieldOffsets[key].y === 'number') {
+        positions[key] = { x: fieldOffsets[key].x, y: fieldOffsets[key].y };
+      } else {
+        positions[key] = { x: MARRIAGE_POSITIONS[key].x, y: MARRIAGE_POSITIONS[key].y };
+      }
+    });
+
+    const draw = (key, value) => {
+      if (!value || hiddenFields.includes(key) || !positions[key]) return;
+      ctx.fillText(String(value), positions[key].x, positions[key].y);
+    };
+
+    const groomName = `${record.fname_groom || record.groom_first || ''} ${record.lname_groom || record.groom_last || ''}`.trim();
+    const brideName = `${record.fname_bride || record.bride_first || ''} ${record.lname_bride || record.bride_last || ''}`.trim();
+    draw('groomName', groomName);
+    draw('brideName', brideName);
+    draw('groomParents', record.parentsg || record.parents_groom);
+    draw('brideParents', record.parentsb || record.parents_bride);
+    if (record.marriage_date) {
+      draw('marriageDate', new Date(record.marriage_date).toLocaleDateString());
+      draw('marriageDateMD', dateMD(record.marriage_date));
+      draw('marriageDateYY', dateYY(record.marriage_date));
+    }
+    draw('marriagePlace', record.marriage_place || record.place || record.mlicense);
+    draw('clergy', record.clergy);
+    draw('church', record.churchName || 'Orthodox Church');
+    draw('witnesses', record.witnesses);
+  }
+
   // For template-less version
   if (!fs.existsSync(MARRIAGE_TEMPLATE_PATH)) {
     const baseY = 260;

--- a/server/src/certificates/coordinate-maps.js
+++ b/server/src/certificates/coordinate-maps.js
@@ -66,6 +66,36 @@ const BAPTISM_CERTIFICATE_MAP = {
       align: 'center',
       maxWidth: 200,
     },
+    // Split date variants — match the OCA artwork's "ON ___, 20___"
+    // layout. Operators drag to fine-tune; these are starter coords.
+    birthDateMD: {
+      x: 280,
+      y: 480,
+      fontSize: 14,
+      align: 'center',
+      maxWidth: 100,
+    },
+    birthDateYY: {
+      x: 430,
+      y: 480,
+      fontSize: 14,
+      align: 'center',
+      maxWidth: 40,
+    },
+    baptismDateMD: {
+      x: 280,
+      y: 400,
+      fontSize: 14,
+      align: 'center',
+      maxWidth: 100,
+    },
+    baptismDateYY: {
+      x: 430,
+      y: 400,
+      fontSize: 14,
+      align: 'center',
+      maxWidth: 40,
+    },
     sponsors: {
       x: 306,
       y: 350,
@@ -148,6 +178,22 @@ const MARRIAGE_CERTIFICATE_MAP = {
       fontSize: 14,
       align: 'center',
       maxWidth: 200,
+    },
+    // Split date variants — match the OCA artwork's "ON ___, 20___"
+    // layout. Operators drag to fine-tune; these are starter coords.
+    marriageDateMD: {
+      x: 280,
+      y: 420,
+      fontSize: 14,
+      align: 'center',
+      maxWidth: 100,
+    },
+    marriageDateYY: {
+      x: 430,
+      y: 420,
+      fontSize: 14,
+      align: 'center',
+      maxWidth: 40,
     },
     marriagePlace: {
       x: 306,

--- a/server/src/certificates/pdf-generator.js
+++ b/server/src/certificates/pdf-generator.js
@@ -16,6 +16,35 @@ const fs = require('fs');
 const path = require('path');
 const { getCoordinateMap, mergeCustomPositions } = require('./coordinate-maps');
 
+// Date format helpers — UTC-anchored so the rendered date matches the
+// DB's stored value regardless of server timezone. Mirrors the
+// front-end formatDateMD / formatDateYY in
+// front-end/src/features/certificates/certificateTypes.ts.
+function _parseUtcDate(raw) {
+  if (raw == null || raw === '') return null;
+  if (raw instanceof Date) return Number.isNaN(raw.getTime()) ? null : raw;
+  if (typeof raw === 'string') {
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(raw);
+    if (m) return new Date(Date.UTC(+m[1], +m[2] - 1, +m[3]));
+    const d = new Date(raw);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+// "12/3" — month/day, no zero padding (matches the OCA cert artwork).
+function dateMD(raw) {
+  const d = _parseUtcDate(raw);
+  if (!d) return '';
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+// "25" — last 2 digits of the year. Pairs with the OCA "20___"
+// pre-printed prefix.
+function dateYY(raw) {
+  const d = _parseUtcDate(raw);
+  if (!d) return '';
+  return String(d.getUTCFullYear()).slice(-2);
+}
+
 /**
  * Text alignment helper
  */
@@ -192,12 +221,16 @@ async function generateBaptismCertificatePDF(record, options = {}) {
   const fontBold = await pdfDoc.embedFont(StandardFonts.TimesRomanBold);
   
   // Extract field data from record
+  const baptismDateRaw = record.reception_date || record.baptism_date || null;
   const fieldData = {
     fullName: `${record.first_name || ''} ${record.last_name || ''}`.trim(),
     birthDate: record.birth_date ? new Date(record.birth_date).toLocaleDateString() : '',
+    birthDateMD: dateMD(record.birth_date),
+    birthDateYY: dateYY(record.birth_date),
     birthplace: record.birthplace || '',
-    baptismDate: record.reception_date ? new Date(record.reception_date).toLocaleDateString() : 
-                 (record.baptism_date ? new Date(record.baptism_date).toLocaleDateString() : ''),
+    baptismDate: baptismDateRaw ? new Date(baptismDateRaw).toLocaleDateString() : '',
+    baptismDateMD: dateMD(baptismDateRaw),
+    baptismDateYY: dateYY(baptismDateRaw),
     sponsors: record.sponsors || record.godparents || '',
     clergyBy: record.clergy || '',
     clergyRector: record.clergy || '',
@@ -285,6 +318,8 @@ async function generateMarriageCertificatePDF(record, options = {}) {
     groomName: `${record.fname_groom || record.groom_first || ''} ${record.lname_groom || record.groom_last || ''}`.trim(),
     brideName: `${record.fname_bride || record.bride_first || ''} ${record.lname_bride || record.bride_last || ''}`.trim(),
     marriageDate: record.marriage_date ? new Date(record.marriage_date).toLocaleDateString() : '',
+    marriageDateMD: dateMD(record.marriage_date),
+    marriageDateYY: dateYY(record.marriage_date),
     marriagePlace: record.marriage_place || record.place || '',
     groomParents: record.parentsg || record.parents_groom || '',
     brideParents: record.parentsb || record.parents_bride || '',


### PR DESCRIPTION
## Summary
Marriage cert now uses the same MM/DD + YY split as baptism (per PR #858). On the OCA marriage artwork the date row reads `ON _________________, 20___` — same shape as baptism. Three latent issues blocked it from working:

1. **Canvas preview did nothing in the template path.** `generateMarriagePreview` only drew fields when `MARRIAGE_TEMPLATE_PATH` was missing. With a template present (normal case), the bare PNG came back with no overlay — saved drag positions for marriage were silently ignored. Even the existing "Marriage Date (full)" tile didn't render.

2. **PDF download had no MD/YY field defs.** The download endpoint uses `generateCertificatePDF` in `pdf-generator.js`. `coordinate-maps.js` had no `marriageDateMD` / `marriageDateYY` entries, so `mergeCustomPositions` (which skips unknown field names) dropped any saved overrides for the new tiles.

3. **Even if positions had been wired, `fieldData` had no string to render.**

## What changed

### `server/src/certificates/coordinate-maps.js`
- `BAPTISM_CERTIFICATE_MAP.fields`: + `birthDateMD`, `birthDateYY`, `baptismDateMD`, `baptismDateYY`.
- `MARRIAGE_CERTIFICATE_MAP.fields`: + `marriageDateMD`, `marriageDateYY`.
- Starter coords; operators drag to fine-tune.

### `server/src/certificates/pdf-generator.js`
- `dateMD` / `dateYY` UTC-anchored helpers (mirror the front-end `formatDateMD` / `formatDateYY` in `certificateTypes.ts` byte-for-byte).
- Baptism `fieldData`: + `birthDateMD/YY` + `baptismDateMD/YY`.
- Marriage `fieldData`: + `marriageDateMD/YY`.

### `server/src/api/churchCertificates.js`
- `generateMarriagePreview`: new template-path branch that mirrors baptism — iterates `MARRIAGE_POSITIONS`, applies `fieldOffsets` overrides, draws each known field at its position. Includes `groomName`, `brideName`, `groomParents`, `brideParents`, `marriageDate (full)`, `marriageDateMD`, `marriageDateYY`, `marriagePlace`, `clergy`, `church`, `witnesses`. Templateless fallback unchanged.

## Verified live
Backend rebuilt + restarted, front-end dist mirrored.

```
getCoordinateMap('marriage').fields.marriageDateMD
  = { x: 280, y: 420, fontSize: 14, align: 'center', maxWidth: 100 }
getCoordinateMap('marriage').fields.marriageDateYY
  = { x: 430, y: 420, fontSize: 14, align: 'center', maxWidth: 40 }
getCoordinateMap('baptism').fields.birthDateMD
  = { x: 280, y: 480, fontSize: 14, align: 'center', maxWidth: 100 }
getCoordinateMap('baptism').fields.baptismDateYY
  = { x: 430, y: 400, fontSize: 14, align: 'center', maxWidth: 40 }
```

## Includes PR #858 (open, never merged)
Cherry-picked the baptism MD/YY work forward so this is a single self-contained PR. Closing #858 in favor of this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)