### PR TITLE
RECORDS-BAPTISM-FIXES: drop row Edit, fix Save row blanking, add priest filter

### DIFF
--- a/front-end/src/features/records-centralized/components/records/RecordsPage.tsx
+++ b/front-end/src/features/records-centralized/components/records/RecordsPage.tsx
@@ -34,6 +34,7 @@ import { useAgGridConfig } from './RecordsPage/useAgGridConfig';
 import { useRecordSave } from './RecordsPage/useRecordSave';
 import {
     Alert,
+    Autocomplete,
     Box,
     Button,
     Chip,
@@ -43,6 +44,7 @@ import {
     Snackbar,
     Stack,
     TablePagination,
+    TextField,
     Tooltip,
     Typography
 } from '@mui/material';
@@ -275,6 +277,7 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
   useEffect(() => {
     if (selectedRecordType) {
       setPage(0); // Reset to first page on type/church change
+      setSelectedPriest(null); // priest options change with type/church
       const dateSortKey = DEFAULT_DATE_SORT_FIELD[selectedRecordType] || 'id';
       setSortConfig({ key: dateSortKey, direction: 'desc' });
       fetchRecords(selectedRecordType, selectedChurch, undefined, 0, rowsPerPage, dateSortKey, 'desc');
@@ -358,8 +361,13 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
     } catch { return []; }
   }, [selectedRecordType]);
 
+  // Priest filter — when set, restrict displayed rows to those whose
+  // clergy field exactly matches the selected priest. Pulled from the
+  // same priestOptions list the edit dialog uses.
+  const [selectedPriest, setSelectedPriest] = useState<string | null>(null);
+
   // Server-sorted records — no client-side re-sorting (server handles ORDER BY)
-  // Only apply Best Matches client-side filter when searching
+  // Only apply Best Matches + priest client-side filters
   const filteredAndSortedRecords = useMemo(() => {
     let result = [...records];
 
@@ -368,8 +376,13 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
       result = result.filter(r => (r._matchedFields?.length || 0) >= 2);
     }
 
+    // Priest filter: client-side exact-match against the record's clergy field.
+    if (selectedPriest) {
+      result = result.filter(r => (r.clergy || '').trim() === selectedPriest);
+    }
+
     return result;
-  }, [records, debouncedSearch, showBestMatches]);
+  }, [records, debouncedSearch, showBestMatches, selectedPriest]);
 
   // Paginated records — server returns the exact page, no client-side slicing needed
   const paginatedRecords = filteredAndSortedRecords;
@@ -702,6 +715,31 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
             onCollaborativeReport={handleCollaborativeReport}
             onAdvancedGrid={() => setAdvancedGridOpen(true)}
           />
+
+          {/* Priest filter — narrows the table to records whose clergy
+              column exactly matches the selected priest. priestOptions
+              comes from LookupService.getClergy (one row per distinct
+              clergy value already present in this church's records). */}
+          {priestOptions.length > 0 && (
+            <Box sx={{ mb: 2, px: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Autocomplete
+                size="small"
+                sx={{ minWidth: 280, flex: '0 0 auto' }}
+                options={priestOptions}
+                value={selectedPriest}
+                onChange={(_e, val) => setSelectedPriest(val)}
+                clearOnEscape
+                renderInput={(params) => (
+                  <TextField {...params} label="Filter by priest" placeholder="All priests" />
+                )}
+              />
+              {selectedPriest && (
+                <Typography variant="caption" color="text.secondary">
+                  {filteredAndSortedRecords.length} of {records.length} match
+                </Typography>
+              )}
+            </Box>
+          )}
                 
           {/* Status Information */}
           {selectedRecordType && !loading && totalRecords > 0 && (

--- a/front-end/src/features/records-centralized/components/records/RecordsPage/useAgGridConfig.ts
+++ b/front-end/src/features/records-centralized/components/records/RecordsPage/useAgGridConfig.ts
@@ -5,7 +5,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { Box, Chip, IconButton, Tooltip, useTheme } from '@mui/material';
 import { ColDef, ICellRendererParams, themeQuartz } from 'ag-grid-community';
-import { Eye, FileText, Pencil, Trash2 } from '@/shared/ui/icons';
+import { Eye, FileText, Trash2 } from '@/shared/ui/icons';
 import { isRecordNewWithin24Hours, isRecordUpdatedWithin24Hours, getAgGridRowClassRules } from '@/features/records-centralized/common/recordsHighlighting';
 import { getCellValue, getColumnDefinitions } from './utils';
 import type { BaptismRecord } from './types';
@@ -78,13 +78,14 @@ export function useAgGridConfig({
     const iconSx = { opacity: 0.7, color: 'text.secondary', '&:hover': { opacity: 1, color: 'text.primary' } };
     const deleteSx = { opacity: 0.7, color: 'text.secondary', '&:hover': { opacity: 1, color: 'error.main' } };
 
+    // Inline Edit was removed from the row actions on purpose — operators
+    // edit only from the View dialog, which forces them to see the
+    // current values first. The View dialog has an Edit toggle that
+    // calls handleEditRecord on the underlying record.
     return React.createElement(Box, { sx: { display: 'flex', gap: 0.5, alignItems: 'center', height: '100%' } },
       React.createElement(Tooltip, { title: t('records.tooltip_view') },
         React.createElement(IconButton, { size: 'small', onClick: () => handleViewRecord(record), sx: iconSx },
           React.createElement(Eye, { size: 16, strokeWidth: 1.5 }))),
-      React.createElement(Tooltip, { title: t('records.tooltip_edit') },
-        React.createElement(IconButton, { size: 'small', onClick: () => handleEditRecord(record), sx: iconSx },
-          React.createElement(Pencil, { size: 16, strokeWidth: 1.5 }))),
       React.createElement(Tooltip, { title: t('records.tooltip_delete') },
         React.createElement(IconButton, { size: 'small', onClick: () => handleDeleteClick(record), sx: deleteSx },
           React.createElement(Trash2, { size: 16, strokeWidth: 1.5 }))),
@@ -94,7 +95,7 @@ export function useAgGridConfig({
               React.createElement(FileText, { size: 16, strokeWidth: 1.5 })))
         : null,
     );
-  }, [selectedRecordType, handleViewRecord, handleEditRecord, handleDeleteClick, handleGenerateCertificate, t]);
+  }, [selectedRecordType, handleViewRecord, handleDeleteClick, handleGenerateCertificate, t]);
 
   const agGridColumnDefs = useMemo(() => {
     const cols: ColDef[] = [];
@@ -119,7 +120,10 @@ export function useAgGridConfig({
     });
     cols.push({
       headerName: 'Actions', field: 'id',
-      minWidth: 180, width: 180, maxWidth: 180,
+      // Was 180px when the row had View / Edit / Delete / Certificate.
+      // With Edit gone this column needs less room; 140 fits the 3
+      // remaining icons with a little breathing space.
+      minWidth: 140, width: 140, maxWidth: 140,
       sortable: false, filter: false, pinned: 'right',
       cellRenderer: agGridActionsRenderer,
     });

--- a/front-end/src/features/records-centralized/components/records/RecordsPage/useRecordSave.ts
+++ b/front-end/src/features/records-centralized/components/records/RecordsPage/useRecordSave.ts
@@ -81,11 +81,19 @@ export function useRecordSave({
         const response = await apiService.updateRecord(selectedRecordType, editingRecord.id, updatedRecord);
 
         if (response.success && response.data) {
-          setRecords(prev => prev.map(r => r.id === editingRecord.id ? response.data as BaptismRecord : r));
+          // Merge: prefer the server's freshly-SELECT'd row but fall
+          // back to what we just sent so the grid never shows a blank
+          // row even if a backend variant returns a stub payload.
+          const merged = {
+            ...editingRecord,
+            ...updatedRecord,
+            ...(response.data as object),
+          } as BaptismRecord;
+          setRecords(prev => prev.map(r => r.id === editingRecord.id ? merged : r));
           showToast('Record updated successfully', 'success');
 
           if (viewDialogOpen && viewEditMode === 'edit') {
-            setViewingRecord(response.data as BaptismRecord);
+            setViewingRecord(merged);
             setViewEditMode('view');
           } else {
             setDialogOpen(false);

--- a/server/src/controllers/records.js
+++ b/server/src/controllers/records.js
@@ -300,9 +300,22 @@ const updateRecord = async (req, res) => {
 
     await promisePool.execute(`UPDATE ${table} SET ${setClause} WHERE id = ?`, values);
 
+    // Return the FULL updated row so the front-end can replace the grid
+    // entry without losing all its other fields. Previously we returned
+    // only { id, recordType, message } — RecordsPage's setRecords map
+    // would then overwrite the row with that stub and the cells would
+    // appear blank until the next refresh. Re-SELECT after UPDATE keeps
+    // the response consistent with whatever just landed (including
+    // computed columns like updated_at).
+    const [updatedRows] = await promisePool.execute(
+      `SELECT * FROM ${table} WHERE id = ?`,
+      [id],
+    );
+    const updated = updatedRows[0] || { id };
+
     res.json({
       success: true,
-      data: { id, recordType, message: `${recordType} record updated successfully` }
+      data: { ...updated, recordType, message: `${recordType} record updated successfully` },
     });
   } catch (error) {
     console.error('Error updating record:', error);


### PR DESCRIPTION
## Summary
Three reports on `/portal/records/baptism`, fixed together:

### 1. Drop the Edit pencil from each row
Operators now edit only via the View dialog (which forces them to see existing values first). Removed the row-level Edit IconButton from `useAgGridConfig.ts` so View → Edit is the single edit path. Actions column shrunk from 180px → 140px (3 icons left: View / Delete / Certificate).

### 2. Save → row no longer goes blank

**Reported:** clicking Save looked like nothing happened.

**Cause:** the backend's `PUT /api/churches/:churchId/records/:type/:id` returned only `{success: true, data: {id, recordType, message}}`. The front-end's `setRecords(prev.map(r => ... ? response.data : r))` then replaced the visible row with that 3-key stub, blanking every other column. The DB write actually succeeded — refresh would have shown the change. The user perceived "save isn't working" because nothing visibly updated.

**Fix:**
- Backend: after the `UPDATE`, re-`SELECT *` and return the full row. Verified live — response now carries 16 columns including `first_name`, `last_name`, `parents`, `clergy`, `reception_date`, etc.
- Front-end: defensive merge — `{ ...editingRecord, ...updatedRecord, ...(response.data) }` — so even a future backend variant that returns a stub still leaves the row populated. `setViewingRecord` uses the merged object too.

### 3. Priest column filter
Adds an Autocomplete control above the grid populated from `LookupService.getClergy` (the same `priestOptions` list the edit dialog already uses — one entry per distinct clergy value present in the church's records). Selecting a priest narrows `filteredAndSortedRecords` client-side via exact match on `record.clergy`. Reset to null whenever `selectedRecordType` or `selectedChurch` changes.

Implemented as an external filter rather than an AG Grid column-header dropdown because AG Grid Community ships only text-input filters; a true value-list dropdown needs Enterprise's `agSetColumnFilter` or a custom filter component. The external control is more discoverable anyway.

## Verified live
Real PUT for Edmund Torrisi (id=740, om_church_46):
```
status: 200
keys: id, source_scan_id, first_name, last_name, birth_date,
      reception_date, birthplace, entry_type, sponsors, parents,
      clergy, church_id, ocr_confidence, verified_by, verified_at,
      recordType, message
parents: "Nicholas Torrisi, Samantha Dominy"
clergy : "Rev. James Parsells"
reception_date: "2026-02-21T05:00:00.000Z"
```
Backend rebuilt + restarted, front-end dist mirrored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)