### PR TITLE
RECORDS-THREE-FIXES: cert back arrow + add-record priest/church + save actually fires

### DIFF
--- a/front-end/src/features/certificates/CertificateGeneratorPage.tsx
+++ b/front-end/src/features/certificates/CertificateGeneratorPage.tsx
@@ -528,7 +528,18 @@ const CertificateGeneratorPage: React.FC = () => {
     return `${recordData.first_name || recordData.person_first || ''} ${recordData.last_name || recordData.person_last || ''}`.trim();
   };
 
-  const handleGoBack = () => navigate(-1);
+  const handleGoBack = () => {
+    // navigate(-1) silently no-ops when there's no prior history (direct
+    // page load, browser refresh, or external link). Fall back to the
+    // matching records page so the button always does *something*.
+    const fallback = `/portal/records/${recordType || 'baptism'}`;
+    const hasHistory = typeof window !== 'undefined' && window.history.length > 1;
+    if (hasHistory) {
+      navigate(-1);
+    } else {
+      navigate(fallback);
+    }
+  };
 
   const getScreenPosition = (fieldName: string) => {
     if (!imageRef.current || !imageWrapperRef.current) return null;

--- a/front-end/src/features/records-centralized/components/records/RecordsPage.tsx
+++ b/front-end/src/features/records-centralized/components/records/RecordsPage.tsx
@@ -258,14 +258,21 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
   const fetchChurches = () => fetchChurchesApi({ setLoading, setChurches, setError, showToast });
   const fetchRecords = (recordType: string, churchId?: number, search?: string, serverPage?: number, serverLimit?: number, sortField?: string, sortDir?: string) =>
     fetchRecordsApi({ recordType, churchId, search, serverPage, serverLimit, sortField, sortDir }, fetchCb);
-  const fetchPriestOptions = (recordType: string) => fetchPriestOptionsApi(recordType, selectedChurch, setPriestOptions);
 
-  // Effective church ID — resolves 0 to the single real church when only 1 exists
+  // Effective church ID — resolves 0 ("All Churches") to the single real
+  // church when only 1 exists. Used by every flow that needs a CONCRETE
+  // church (priest fetch, save, edit-dialog church-name display).
   const effectiveChurchId = useMemo(() => {
     if (selectedChurch && selectedChurch !== 0) return selectedChurch;
     const realChurches = churches.filter(c => c.id !== 0);
     return realChurches.length === 1 ? realChurches[0].id : 0;
   }, [selectedChurch, churches]);
+
+  // Use the effective church for the clergy lookup so the dropdown is
+  // populated even when the user implicitly has the "All Churches"
+  // option selected and only one real church exists.
+  const fetchPriestOptions = (recordType: string) =>
+    fetchPriestOptionsApi(recordType, effectiveChurchId || null, setPriestOptions);
 
   // Effects
   useEffect(() => {
@@ -283,7 +290,9 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
       fetchRecords(selectedRecordType, selectedChurch, undefined, 0, rowsPerPage, dateSortKey, 'desc');
       fetchPriestOptions(selectedRecordType);
     }
-  }, [selectedRecordType, selectedChurch]);
+    // effectiveChurchId added so the priest fetch retries once the
+    // churches list resolves (selectedChurch=0 → real church id).
+  }, [selectedRecordType, selectedChurch, effectiveChurchId]);
 
   // Debounce search term: update debouncedSearch 300ms after typing stops
   useEffect(() => {
@@ -430,7 +439,10 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
       godparentNames: '',
       priest: '',
       registryNumber: '',
-      churchId: selectedChurch ? selectedChurch.toString() : '',
+      // effectiveChurchId resolves the implicit "All Churches" (id=0)
+      // to the real parish when only one exists, so the new record
+      // gets associated with the right church without operator click.
+      churchId: effectiveChurchId ? effectiveChurchId.toString() : '',
       notes: '',
       customPriest: false,
     });
@@ -595,7 +607,11 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
   });
 
   const handleSaveRecord = useRecordSave({
-    selectedRecordType, selectedChurch, churches, editingRecord, formData,
+    // Pass the effective church (resolves 0 → real church id when only
+    // one parish exists) so save isn't blocked by the implicit
+    // "All Churches" selection. selectedChurch (the literal toggle state)
+    // is preserved everywhere else for UI rendering.
+    selectedRecordType, selectedChurch: effectiveChurchId, churches, editingRecord, formData,
     viewDialogOpen, viewEditMode,
     setLoading, setRecords, setDialogOpen, setViewingRecord, setViewEditMode,
     showToast, handleRowSelect,
@@ -942,7 +958,10 @@ const RecordsPage: React.FC<RecordsPageProps> = ({ defaultRecordType = 'baptism'
               setFormData={setFormData}
               priestOptions={priestOptions}
               churches={churches}
-              selectedChurch={selectedChurch}
+              // Pass the effective church so the dialog's "Church" field
+              // displays the real parish name even when the user is on
+              // the implicit "All Churches" selection (selectedChurch=0).
+              selectedChurch={effectiveChurchId}
               loading={loading}
               onSave={handleSaveRecord}
               isDarkMode={isDarkMode}


### PR DESCRIPTION
## Summary
Three reports — **two of them share one root cause.**

### 1. Certificate generator back arrow (`/portal/certificates/generate`)
`handleGoBack` was `navigate(-1)`, which silently no-ops when there's no prior history (direct page load, refresh, external link). Now tries `-1` when `window.history.length > 1`, otherwise falls back to `/portal/records/<recordType>` so the button always does *something*.

### 2 + 3. Add-record priest/church empty + Save still not working — **same root cause**
When a user has only one parish, RecordsPage's church selector shows the implicit "All Churches" (id=0). The page already had `effectiveChurchId` (resolves `0` → real church id when only one parish exists), but the value wasn't threaded through to:

| Spot | Symptom |
|---|---|
| `fetchPriestOptions` | bailed on `if (!selectedChurch)`, set `priestOptions = []` → **empty dropdown** |
| `useRecordSave` | bailed on `if (!churchId \|\| churchId === '0')` with toast "Please select a church before saving records" — the user never saw the PUT fire. **This is what "Save still not working" was.** PR #860's full-row response + defensive merge was live but unreachable. |
| `EditRecordDialog` Church field | `churches.find(c => c.id === selectedChurch)?.church_name` finds nothing for id=0 → "no church" placeholder |
| `handleAddRecord` | seeded `formData.churchId = ''` on Add — same save block when clicking Save on a new record |

## Fix
Threaded `effectiveChurchId` through every data-routing path that needs a concrete church. The literal `selectedChurch` (possibly `0`) stays preserved in every UI-rendering path that doesn't care.

```diff
- fetchPriestOptionsApi(recordType, selectedChurch, ...)
+ fetchPriestOptionsApi(recordType, effectiveChurchId || null, ...)

- useRecordSave({ ..., selectedChurch, ... })
+ useRecordSave({ ..., selectedChurch: effectiveChurchId, ... })

- <EditRecordDialog ... selectedChurch={selectedChurch} />
+ <EditRecordDialog ... selectedChurch={effectiveChurchId} />

- churchId: selectedChurch ? selectedChurch.toString() : ''
+ churchId: effectiveChurchId ? effectiveChurchId.toString() : ''
```

Plus: the `useEffect` that drives the fetches now depends on `effectiveChurchId` too, so the priest fetch retries once `churches` resolves and the implicit `0 → real-id` flip happens.

## Verified
- `tsc --noEmit` clean (no errors in modified files).
- `npx vite build` clean (`cf42685617bbfec5` dist hash).
- Front-end dist mirrored to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)