### PR TITLE
EDIT-PAGE-CRASH-FIXES: destructure saveLoading + ship missing church-branding endpoint

### DIFF
--- a/front-end/src/features/records-centralized/common/ModernRecordViewerModal.tsx
+++ b/front-end/src/features/records-centralized/common/ModernRecordViewerModal.tsx
@@ -82,6 +82,12 @@ const ModernRecordViewerModal: React.FC<ModernRecordViewerModalProps> = ({
   accentColor,
   mode: externalMode,
   onModeChange,
+  // These were declared in the props interface but the previous patch
+  // forgot to destructure them — referencing `saveLoading` / `onSave`
+  // in the JSX threw a ReferenceError at render time, blowing up the
+  // page when a user tried to enter Edit mode.
+  onSave,
+  saveLoading = false,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -596,6 +596,12 @@ console.log('✅ [Server] Mounted /api/admin/orthodox-schedule-guidelines route'
 app.use('/api/admin/change-sets', changeSetsRouter);
 console.log('✅ [Server] Mounted /api/admin/change-sets route (SDLC delivery container)');
 app.use('/api/churches', churchesRouter);
+// Church metadata header — used by ChurchContext on every page load.
+// Lives at /api/church-branding/* so it doesn't collide with the
+// per-church static logo serve at /church-branding (no /api prefix).
+const churchBrandingRouter = require('./routes/church-branding');
+app.use('/api/church-branding', churchBrandingRouter);
+console.log('✅ [Server] Mounted /api/church-branding route (church metadata header)');
 // Mount churches router at /api/my to handle /api/my/churches
 // UI Preferences — per-user UI settings (FAB positions, etc.) (mount BEFORE /api/my catchall)
 const uiPreferencesRouter = require('./routes/ui-preferences');

--- a/server/src/routes/church-branding.js
+++ b/server/src/routes/church-branding.js
@@ -1,0 +1,67 @@
+'use strict';
+
+/**
+ * /api/church-branding/header/:churchId
+ *
+ * Lightweight church-metadata endpoint used by the front-end's
+ * ChurchContext to render the church header (name, logo, theme color,
+ * calendar type) on every page that loads church-scoped data.
+ *
+ * The front-end has been calling this path since long before this
+ * router existed — the only mount under "/church-branding" was a
+ * static-file server for uploaded logos, with no "/api" prefix. So
+ * every page that initialised ChurchContext logged a "Failed to fetch
+ * church data" 404 in the console. Harmless (ChurchContext fell back
+ * to "System Admin" defaults), but noisy.
+ *
+ * Schema-shape mapping:
+ *   churches.id              -> church_id
+ *   churches.church_name     -> church_name
+ *   churches.name            -> church_name_display (operators have set
+ *                               either column over the years)
+ *   churches.logo_path       -> logo_url
+ *   churches.primary_color   -> primary_theme_color
+ *   churches.database_name   -> database_name
+ *   churches.calendar_type   -> calendar_type
+ *
+ * Read-only. requireAuth so we don't hand church metadata out to
+ * anonymous callers (matches the rest of /api/churches/*).
+ */
+
+const express = require('express');
+const router = express.Router();
+const { getAppPool } = require('../config/db-compat');
+const { requireAuth } = require('../middleware/auth');
+
+router.get('/header/:churchId', requireAuth, async (req, res) => {
+  try {
+    const churchId = parseInt(req.params.churchId, 10);
+    if (!Number.isFinite(churchId) || churchId <= 0) {
+      return res.status(400).json({ success: false, error: 'Invalid church id' });
+    }
+
+    const [rows] = await getAppPool().query(
+      `SELECT id           AS church_id,
+              church_name  AS church_name,
+              name         AS church_name_display,
+              logo_path    AS logo_url,
+              primary_color AS primary_theme_color,
+              database_name,
+              calendar_type
+         FROM churches
+        WHERE id = ?
+        LIMIT 1`,
+      [churchId],
+    );
+
+    if (!rows.length) {
+      return res.status(404).json({ success: false, error: 'Church not found' });
+    }
+    res.json({ success: true, data: rows[0] });
+  } catch (err) {
+    console.error('[church-branding] /header error:', err && err.message ? err.message : err);
+    res.status(500).json({ success: false, error: 'Failed to load church metadata' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
Two issues, both surfaced when clicking Edit on a baptism record.

### 1. ReferenceError crash blocking Edit mode
```
ReferenceError: saveLoading is not defined
  at ni (RecordsPage-CanhQPjB.js:21:37545)
```
PR #862 referenced `saveLoading` and `onSave` in JSX but **only declared them in the props interface** — never destructured them in the component signature of `ModernRecordViewerModal`. References at render time threw at runtime, the `RecordsRouteErrorBoundary` caught it and replaced the entire page with its "Records Page Error" fallback.

**Fix:** add `onSave` and `saveLoading = false` to the destructured props in the component signature.

### 2. `/api/church-branding/header/:id` 404 spam
`ChurchContext` fetches this on every page that loads church-scoped data. The path never existed on the backend — the only mount under `/church-branding` was a static-file serve for uploaded logos (no `/api` prefix). Every page load logged a "Failed to fetch church data" 404 in the console. Harmless (ChurchContext fell back to "System Admin" defaults), but noisy and confusing during debugging.

**Fix:** new `server/src/routes/church-branding.js` mounted at `/api/church-branding`. Returns the exact `{ success, data }` shape ChurchContext expects:

```
{ church_id, church_name, church_name_display, logo_url,
  primary_theme_color, database_name, calendar_type }
```

Schema mapping (the columns ChurchContext expects don't all exist by those names — mapping does the renames):
| frontend field | DB column |
|---|---|
| `church_id` | `id` |
| `church_name` | `church_name` |
| `church_name_display` | `name` |
| `logo_url` | `logo_path` |
| `primary_theme_color` | `primary_color` |
| `database_name` | `database_name` |
| `calendar_type` | `calendar_type` |

`requireAuth` matches the rest of `/api/churches/*`. The legacy static logo serve at `/church-branding` stays — prefixes don't collide.

## Verified live
```
GET /api/church-branding/header/46  (no auth) → 401 ✓
GET /api/church-branding/header/46  (auth)    → 200
  data: { church_id: 46,
          church_name: "Saints Peter & Paul",
          church_name_display: "Saints Peter & Paul Orthodox Church",
          logo_url: null,
          primary_theme_color: null,
          database_name: "om_church_46",
          calendar_type: "Revised Julian" }
```
Backend rebuilt + restarted, front-end dist mirrored to prod. Edit dialog now opens cleanly — no ReferenceError, no church-data 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)