### PR TITLE
CLERGY-HONORIFIC-DEDUP: don't double-prefix existing honorifics in Recent Activity

### DIFF
--- a/front-end/src/features/portal/ChurchPortalHub.tsx
+++ b/front-end/src/features/portal/ChurchPortalHub.tsx
@@ -218,6 +218,24 @@ function ToolItem({ icon: Icon, label, description, onClick }: {
   );
 }
 
+/**
+ * Format a clergy name for display in Recent Activity / search results.
+ * Adds the "Fr." honorific only when the value doesn't already start
+ * with one — otherwise we end up with double-prefixed entries like
+ * "Fr. Rev. James Parsells".
+ *
+ * Honorifics matched (case-insensitive, leading whitespace tolerated):
+ *   Fr / Father / Rev / Reverend / V.Rev / Very Reverend / Archpriest /
+ *   Hieromonk / Hierodeacon / Deacon / Bishop / Metropolitan
+ */
+const HONORIFIC_RE = /^(?:fr|father|rev|reverend|v\.?\s*rev|very\s+reverend|archpriest|protopresbyter|hieromonk|hierodeacon|deacon|protodeacon|bishop|archbishop|metropolitan)\b\.?/i;
+function formatClergy(name?: string | null): string | undefined {
+  if (!name) return undefined;
+  const trimmed = String(name).trim();
+  if (!trimmed) return undefined;
+  return HONORIFIC_RE.test(trimmed) ? trimmed : `Fr. ${trimmed}`;
+}
+
 /* ══════════════════════════════════════════════════════════
    Main Dashboard Component
    ══════════════════════════════════════════════════════════ */
@@ -328,7 +346,7 @@ const ChurchPortalHub: React.FC = () => {
               id: r.id,
               label: r.child_name || r.first_name || [r.first_name, r.last_name].filter(Boolean).join(' ') || '\u2014',
               date: r.reception_date || r.baptism_date || r.date_entered || '',
-              sub: r.clergy ? `Fr. ${r.clergy}` : r.priest_name ? `Fr. ${r.priest_name}` : undefined,
+              sub: formatClergy(r.clergy) ?? formatClergy(r.priest_name),
               type: 'baptism',
             });
           });
@@ -344,7 +362,7 @@ const ChurchPortalHub: React.FC = () => {
                 [r.brideFirstName || r.fname_bride, r.brideLastName || r.lname_bride].filter(Boolean).join(' '),
               ].filter(Boolean).join(' & ') || '\u2014',
               date: r.mdate || r.marriage_date || r.date_entered || '',
-              sub: r.clergy ? `Fr. ${r.clergy}` : r.priest_name ? `Fr. ${r.priest_name}` : undefined,
+              sub: formatClergy(r.clergy) ?? formatClergy(r.priest_name),
               type: 'marriage',
             });
           });
@@ -357,7 +375,7 @@ const ChurchPortalHub: React.FC = () => {
               id: r.id,
               label: r.name || r.deceased_name || [r.name, r.lastname].filter(Boolean).join(' ') || '\u2014',
               date: r.burial_date || r.funeral_date || r.deceased_date || '',
-              sub: r.clergy ? `Fr. ${r.clergy}` : r.priest_name ? `Fr. ${r.priest_name}` : undefined,
+              sub: formatClergy(r.clergy) ?? formatClergy(r.priest_name),
               type: 'funeral',
             });
           });
@@ -417,7 +435,7 @@ const ChurchPortalHub: React.FC = () => {
             id: r.id,
             label: r.child_name || r.first_name || [r.first_name, r.last_name].filter(Boolean).join(' ') || '\u2014',
             date: r.reception_date || r.baptism_date || r.date_entered || '',
-            sub: r.clergy ? `Fr. ${r.clergy}` : r.priest_name ? `Fr. ${r.priest_name}` : undefined,
+            sub: formatClergy(r.clergy) ?? formatClergy(r.priest_name),
             type: 'baptism' as const,
           })),
         );
@@ -435,7 +453,7 @@ const ChurchPortalHub: React.FC = () => {
               [r.brideFirstName || r.fname_bride, r.brideLastName || r.lname_bride].filter(Boolean).join(' '),
             ].filter(Boolean).join(' & ') || '\u2014',
             date: r.mdate || r.marriage_date || r.date_entered || '',
-            sub: r.clergy ? `Fr. ${r.clergy}` : r.priest_name ? `Fr. ${r.priest_name}` : undefined,
+            sub: formatClergy(r.clergy) ?? formatClergy(r.priest_name),
             type: 'marriage' as const,
           })),
         );
@@ -450,7 +468,7 @@ const ChurchPortalHub: React.FC = () => {
             id: r.id,
             label: r.name || r.deceased_name || [r.name, r.lastname].filter(Boolean).join(' ') || '\u2014',
             date: r.burial_date || r.funeral_date || r.deceased_date || '',
-            sub: r.clergy ? `Fr. ${r.clergy}` : r.priest_name ? `Fr. ${r.priest_name}` : undefined,
+            sub: formatClergy(r.clergy) ?? formatClergy(r.priest_name),
             type: 'funeral' as const,
           })),
         );


### PR DESCRIPTION
## Summary
Recent Activity entries showed `Fr. Rev. James Parsells` because `ChurchPortalHub.tsx` had six identical lines that unconditionally prepended `Fr.`:

```ts
sub: r.clergy ? `Fr. ${r.clergy}` : r.priest_name ? `Fr. ${r.priest_name}` : undefined
```

SSPPOC's clergy column already stores `Rev. James Parsells`, so the prepend created a double-prefix.

## Fix
New `formatClergy(name)` helper checks for an existing honorific via a case-insensitive prefix regex and only adds `Fr.` when none is present.

Honorifics matched: **Fr / Father / Rev / Reverend / V.Rev / Very Reverend / Archpriest / Protopresbyter / Hieromonk / Hierodeacon / Deacon / Protodeacon / Bishop / Archbishop / Metropolitan**.

All six callsites collapse to:
```ts
sub: formatClergy(r.clergy) ?? formatClergy(r.priest_name)
```

### Examples
| Input | Output |
|---|---|
| `Rev. James Parsells` | `Rev. James Parsells` |
| `Fr. John Smith` | `Fr. John Smith` |
| `John Smith` | `Fr. John Smith` |
| `Archpriest Andrew` | `Archpriest Andrew` |
| `''` / `null` | `undefined` |

## Verified
`vite build` clean (`23973fc41b6ce8c2`). Deployed to prod dist. The `Baptism · Fr. Rev. James Parsells` entry the user was seeing now reads `Baptism · Rev. James Parsells`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)