### PR TITLE
PORTAL-POLISH: cert undefined, baptism icon, smaller welcome, rector tenure

### DIFF
--- a/front-end/src/features/certificates/CertificateGeneratorPage.tsx
+++ b/front-end/src/features/certificates/CertificateGeneratorPage.tsx
@@ -265,12 +265,24 @@ const CertificateGeneratorPage: React.FC = () => {
     try {
       const data = await apiClient.get<any>(`/church/${churchId}/certificate/positions/${recordType}`);
       if (data.success && data.positions && !data.isDefault) {
-        setSavedPositions(data.positions);
-        setFieldPositions(data.positions);
-        setPlacedFields(new Set(Object.keys(data.positions)));
+        // Drop any keys that aren't in this record type's field labels.
+        // The certificate_positions row for some churches got corrupted
+        // by an old save bug that stored a JSON-stringified object as
+        // a character-indexed map ({ "0": "{", "1": "\"", ... }) — those
+        // numeric keys would render as "[undefined]" labels otherwise.
+        const cleaned: Record<string, { x: number; y: number }> = {};
+        for (const k of Object.keys(data.positions)) {
+          if (fieldLabels[k] && data.positions[k] && typeof data.positions[k] === 'object'
+              && typeof data.positions[k].x === 'number' && typeof data.positions[k].y === 'number') {
+            cleaned[k] = data.positions[k];
+          }
+        }
+        setSavedPositions(cleaned);
+        setFieldPositions(cleaned);
+        setPlacedFields(new Set(Object.keys(cleaned)));
         setSavedPositionsLoaded(true);
         setShowCoordinates(true); // Show coordinates by default when saved positions exist
-        return data.positions;
+        return cleaned;
       }
     } catch (err) {
       console.warn('Could not load saved positions:', err);
@@ -840,9 +852,12 @@ const CertificateGeneratorPage: React.FC = () => {
                 />
                 
                 {imageLoaded && Array.from(placedFields).map((fieldName) => {
+                  // Skip stale keys not in this record type's labels —
+                  // otherwise they render as "[undefined]" overlays.
+                  if (!fieldLabels[fieldName]) return null;
                   const screenPos = getScreenPosition(fieldName);
                   if (!screenPos) return null;
-                  
+
                   const value = getFieldValue(fieldName);
                   const displayValue = value || `[${fieldLabels[fieldName]}]`;
                   

--- a/front-end/src/features/portal/ChurchPortalHub.tsx
+++ b/front-end/src/features/portal/ChurchPortalHub.tsx
@@ -25,6 +25,7 @@ import {
   ChevronRight,
   ClipboardList,
   Cross,
+  Droplets,
   Eye,
   Heart,
   Plus,
@@ -276,6 +277,28 @@ const ChurchPortalHub: React.FC = () => {
   }, [activeChurchId, metaChurchName]);
 
   const churchName = resolvedChurchName;
+
+  /* ── Rector tenure resolution ──
+     Computes "Rector at <church> for N years" by asking the server
+     for the earliest year the current user's last name appears as
+     clergy in any sacrament record. Returns null when the user
+     isn't a clergy member of this parish. */
+  const [rectorYears, setRectorYears] = useState<number | null>(null);
+  useEffect(() => {
+    if (!activeChurchId) { setRectorYears(null); return; }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res: any = await apiClient.get(`/churches/${activeChurchId}/clergy-tenure`);
+        const data = res?.data ?? res;
+        const years = data?.years;
+        if (!cancelled) setRectorYears(typeof years === 'number' && years >= 0 ? years : null);
+      } catch {
+        if (!cancelled) setRectorYears(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [activeChurchId]);
 
   /* ── Records data ── */
   const [recentBaptism, setRecentBaptism] = useState<RecentRecord[]>([]);
@@ -539,12 +562,21 @@ const ChurchPortalHub: React.FC = () => {
       <section className="mb-8">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div>
-            <h1 className="font-['Inter'] text-[17px] font-semibold text-gray-900 dark:text-white mb-0.5">
+            {/* Greeting: was text-[17px] font-semibold which the user
+                described as "way too large". Down to 14px / medium so
+                it reads as a quiet header rather than a hero title. */}
+            <h1 className="font-['Inter'] text-[14px] font-medium text-gray-900 dark:text-white mb-0.5">
               {greeting}
             </h1>
+            {/* Replace the bare church name with a rector-tenure
+                subtitle when the current user has clergy records in
+                this parish. Falls back to the church name only when
+                tenure data isn't available (lay user, no records, etc). */}
             {churchName && (
               <p className="font-['Inter'] text-[14px] font-medium text-gray-700 dark:text-gray-200 mb-0.5">
-                {churchName}
+                {rectorYears != null
+                  ? `Rector at ${churchName} for ${rectorYears} ${rectorYears === 1 ? 'year' : 'years'}`
+                  : churchName}
               </p>
             )}
             <div className="flex items-center gap-2 text-[12px] font-['Inter'] text-gray-400 dark:text-gray-500">
@@ -723,7 +755,7 @@ const ChurchPortalHub: React.FC = () => {
                 <RecordCard
                   title={t('portal.baptisms')}
                   count={counts.baptism}
-                  icon={Users}
+                  icon={Droplets}
                   iconColor="bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
                   records={recentBaptism.slice(0, 3)}
                   loading={recordsLoading}

--- a/front-end/src/ui/icons.ts
+++ b/front-end/src/ui/icons.ts
@@ -137,6 +137,7 @@ export {
   Coffee,
   Cross,
   Crown,
+  Droplets,
   Fish,
   Flame,
   History,

--- a/server/src/api/churchCertificates.js
+++ b/server/src/api/churchCertificates.js
@@ -385,15 +385,19 @@ const generateMarriagePreview = async (record, fieldOffsets = {}, hiddenFields =
     draw('brideName', brideName);
     draw('groomParents', record.parentsg || record.parents_groom);
     draw('brideParents', record.parentsb || record.parents_bride);
-    if (record.marriage_date) {
-      draw('marriageDate', new Date(record.marriage_date).toLocaleDateString());
-      draw('marriageDateMD', dateMD(record.marriage_date));
-      draw('marriageDateYY', dateYY(record.marriage_date));
+    // marriage_records uses `mdate` (not marriage_date) and `witness`
+    // (not witnesses). Honor both shapes so refactors don't silently
+    // empty the cert.
+    const mDateRaw = record.mdate || record.marriage_date;
+    if (mDateRaw) {
+      draw('marriageDate', new Date(mDateRaw).toLocaleDateString());
+      draw('marriageDateMD', dateMD(mDateRaw));
+      draw('marriageDateYY', dateYY(mDateRaw));
     }
     draw('marriagePlace', record.marriage_place || record.place || record.mlicense);
     draw('clergy', record.clergy);
     draw('church', record.churchName || 'Orthodox Church');
-    draw('witnesses', record.witnesses);
+    draw('witnesses', record.witness || record.witnesses);
   }
 
   // For template-less version
@@ -988,7 +992,16 @@ router.get('/baptism/:id/download', async (req, res) => {
       hiddenFields,
     });
 
-    const filename = `baptism_certificate_${record.first_name || 'unknown'}_${record.last_name || 'unknown'}_${id}.pdf`;
+    // Filename: firstname+lastname+dateofbaptism.pdf — matches what
+    // operators expect when archiving / emailing the certificate.
+    const safeFirst = String(record.first_name || 'baptism').trim().replace(/[^A-Za-z0-9]+/g, '');
+    const safeLast  = String(record.last_name  || '').trim().replace(/[^A-Za-z0-9]+/g, '');
+    const dateRaw = record.reception_date || record.baptism_date;
+    const safeDate = dateRaw
+      ? new Date(dateRaw).toISOString().slice(0, 10) // YYYY-MM-DD
+      : '';
+    const filenameParts = [safeFirst, safeLast, safeDate].filter(Boolean);
+    const filename = `${filenameParts.join('+') || 'baptism_certificate'}.pdf`;
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.send(Buffer.from(pdfBytes));
@@ -1104,9 +1117,13 @@ router.get('/marriage/:id/download', async (req, res) => {
       hiddenFields,
     });
 
-    const groomName = `${record.fname_groom || 'unknown'}_${record.lname_groom || ''}`.trim();
-    const brideName = `${record.fname_bride || 'unknown'}_${record.lname_bride || ''}`.trim();
-    const filename = `marriage_certificate_${groomName}_${brideName}_${id}.pdf`;
+    // Filename: marriage-cert-groomslastname+brideslastname.pdf
+    const safeGroom = String(record.lname_groom || '').trim().replace(/[^A-Za-z0-9]+/g, '');
+    const safeBride = String(record.lname_bride || '').trim().replace(/[^A-Za-z0-9]+/g, '');
+    const lastNameParts = [safeGroom, safeBride].filter(Boolean);
+    const filename = lastNameParts.length
+      ? `marriage-cert-${lastNameParts.join('+')}.pdf`
+      : 'marriage-certificate.pdf';
     
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);

--- a/server/src/certificates/pdf-generator.js
+++ b/server/src/certificates/pdf-generator.js
@@ -317,13 +317,13 @@ async function generateMarriageCertificatePDF(record, options = {}) {
   const fieldData = {
     groomName: `${record.fname_groom || record.groom_first || ''} ${record.lname_groom || record.groom_last || ''}`.trim(),
     brideName: `${record.fname_bride || record.bride_first || ''} ${record.lname_bride || record.bride_last || ''}`.trim(),
-    marriageDate: record.marriage_date ? new Date(record.marriage_date).toLocaleDateString() : '',
-    marriageDateMD: dateMD(record.marriage_date),
-    marriageDateYY: dateYY(record.marriage_date),
-    marriagePlace: record.marriage_place || record.place || '',
+    marriageDate: (record.mdate || record.marriage_date) ? new Date(record.mdate || record.marriage_date).toLocaleDateString() : '',
+    marriageDateMD: dateMD(record.mdate || record.marriage_date),
+    marriageDateYY: dateYY(record.mdate || record.marriage_date),
+    marriagePlace: record.marriage_place || record.place || record.mlicense || '',
     groomParents: record.parentsg || record.parents_groom || '',
     brideParents: record.parentsb || record.parents_bride || '',
-    witnesses: record.witnesses || '',
+    witnesses: record.witness || record.witnesses || '',
     clergy: record.clergy || '',
     church: record.churchName || 'Orthodox Church',
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -865,6 +865,9 @@ app.use('/api/churches/:churchId/charts', omChartsRouter); // OM Charts
 console.log('✅ [Server] Mounted /api/churches/:churchId/charts routes (OM Charts)');
 app.use('/api/churches/:churchId/dashboard', dashboardHomeRouter); // Dashboard Home
 console.log('✅ [Server] Mounted /api/churches/:churchId/dashboard routes (Dashboard Home)');
+const clergyTenureRouter = require('./routes/clergy-tenure');
+app.use('/api/churches/:churchId/clergy-tenure', clergyTenureRouter);
+console.log('✅ [Server] Mounted /api/churches/:churchId/clergy-tenure route (rector tenure)');
 
 // Other authenticated routes
 app.use('/api/user', userRouter);

--- a/server/src/routes/clergy-tenure.js
+++ b/server/src/routes/clergy-tenure.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * GET /api/churches/:churchId/clergy-tenure
+ *
+ * Returns how many years the authenticated user has appeared as
+ * clergy in this church's records — i.e., the difference between
+ * the current year and the earliest year their name shows up in
+ * any of the three sacrament tables (baptism / marriage / funeral).
+ *
+ * Used by the portal hub to render "Rector at <church> for N years"
+ * under the welcome header. Returns { years: null } when no records
+ * mention the user — e.g. a lay admin viewing the page.
+ *
+ * Auth required. Matches against the user's last_name (and falls back
+ * to first_name if last_name is missing) using a LIKE %name%. The
+ * clergy column on records typically reads "Rev. James Parsells",
+ * while users.first_name for that user is "Fr James" — so first-name
+ * matching alone doesn't work. Last-name match is more robust.
+ */
+
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+const { getAppPool } = require('../config/db-compat');
+const { getChurchPool } = require('../db/pool');
+const { requireAuth } = require('../middleware/auth');
+
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const churchId = parseInt(req.params.churchId, 10);
+    if (!Number.isFinite(churchId) || churchId <= 0) {
+      return res.status(400).json({ success: false, error: 'Invalid church id' });
+    }
+
+    // Permit only members of this church (or platform admins) to query.
+    const role = req.user && req.user.role;
+    const userChurchId = req.user && req.user.church_id;
+    const isPlatformAdmin = role === 'super_admin' || role === 'admin';
+    if (!isPlatformAdmin && userChurchId !== churchId) {
+      return res.status(403).json({ success: false, error: 'Forbidden' });
+    }
+
+    const lastName = (req.user && (req.user.last_name || '')) || '';
+    const firstName = (req.user && (req.user.first_name || '')) || '';
+    const matchTerm = (lastName.trim() || firstName.trim() || '').trim();
+    if (!matchTerm) {
+      return res.json({ success: true, data: { years: null, reason: 'no_user_name' } });
+    }
+
+    // Verify the church exists + has a tenant DB before querying it.
+    const [churchRows] = await getAppPool().query(
+      'SELECT id, name, church_name, database_name FROM churches WHERE id = ? LIMIT 1',
+      [churchId],
+    );
+    if (!churchRows.length || !churchRows[0].database_name) {
+      return res.status(404).json({ success: false, error: 'Church not found or has no tenant DB' });
+    }
+    const churchName = churchRows[0].church_name || churchRows[0].name || null;
+
+    const tenantPool = getChurchPool(churchId);
+    const like = `%${matchTerm}%`;
+
+    // Earliest year across the three tables. Each query is wrapped so
+    // a missing column (e.g. unusual schema variant) just yields null
+    // for that table rather than failing the whole response.
+    async function safeMin(sql) {
+      try {
+        const [rows] = await tenantPool.query(sql, [like]);
+        const v = rows && rows[0] && rows[0].y;
+        return v == null ? null : Number(v);
+      } catch {
+        return null;
+      }
+    }
+
+    const [yBaptism, yMarriage, yFuneral] = await Promise.all([
+      safeMin('SELECT MIN(YEAR(reception_date)) AS y FROM baptism_records WHERE clergy LIKE ?'),
+      safeMin('SELECT MIN(YEAR(mdate)) AS y FROM marriage_records WHERE clergy LIKE ?'),
+      safeMin('SELECT MIN(YEAR(deceased_date)) AS y FROM funeral_records WHERE clergy LIKE ?'),
+    ]);
+
+    const candidates = [yBaptism, yMarriage, yFuneral].filter((y) => Number.isFinite(y));
+    if (candidates.length === 0) {
+      return res.json({
+        success: true,
+        data: { years: null, reason: 'no_matches', matchTerm, churchName },
+      });
+    }
+
+    const firstYear = Math.min(...candidates);
+    const currentYear = new Date().getUTCFullYear();
+    const years = Math.max(0, currentYear - firstYear);
+
+    res.json({
+      success: true,
+      data: {
+        years,
+        firstYear,
+        currentYear,
+        churchName,
+        matchTerm,
+      },
+    });
+  } catch (err) {
+    console.error('[clergy-tenure] error:', err && err.message ? err.message : err);
+    res.status(500).json({ success: false, error: 'Failed to compute clergy tenure' });
+  }
+});
+
+module.exports = router;

--- a/server/src/routes/lookup.js
+++ b/server/src/routes/lookup.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { getAppPool } = require('../config/db-compat');
 const { getTenantPool } = require('../config/db');
+const { requireAuth } = require('../middleware/auth');
 const router = express.Router();
 
 // ═══════════════════════════════════════════════════════════════
@@ -8,13 +9,11 @@ const router = express.Router();
 // Mounted at /api/lookup
 // ═══════════════════════════════════════════════════════════════
 
-// Auth guard — require session (applied to all routes in this router)
-router.use((req, res, next) => {
-    if (!req.session?.user) {
-        return res.status(401).json({ error: 'NO_SESSION', message: 'Authentication required' });
-    }
-    next();
-});
+// Use the canonical requireAuth middleware (session OR JWT) instead of
+// a session-only check. The previous router-level session guard 401'd
+// any caller authenticated by JWT — which was happening intermittently
+// for the records edit dialog's clergy fetch.
+router.use(requireAuth);
 
 // ───────────────────────────────────────────────────────────────
 // GET /api/lookup/clergy
@@ -33,7 +32,9 @@ const CLERGY_TABLE_MAP = {
 
 router.get('/clergy', async (req, res) => {
     try {
-        const churchId = req.query.church_id || req.session?.user?.church_id;
+        const churchId = req.query.church_id
+            || req.session?.user?.church_id
+            || req.user?.church_id;
         if (!churchId) {
             return res.status(400).json({ error: 'church_id is required (query param or session)' });
         }


### PR DESCRIPTION
## Summary
Four small portal/cert fixes flagged together.

### 1. `[undefined]` overlay on the certificate generator (gone)
SSPPOC's `certificate_positions` row had been corrupted by an old save bug — `JSON.stringify(positionsObject)` got spread character-by-character into the saved payload, leaving **243 numeric-string keys** (`"0"`, `"1"`, ..., `"242"`) alongside the real field names. Those stale keys had no `fieldLabels` entry, so the placed-fields overlay rendered `[undefined]` once per garbage key.

Three-pronged fix:
- `loadSavedPositions` drops any key not in `fieldLabels` AND any value that isn't `{x:number, y:number}` before setting state.
- Placed-fields render branch short-circuits unknown keys with `if (!fieldLabels[fieldName]) return null;` — defense in depth.
- The corrupt row in `certificate_positions` was rewritten via `JSON_OBJECT(...)` to keep only the 11 legitimate keys (one-time SQL during this work).

### 2. Baptism icon
`ChurchPortalHub` used `Users` for baptism — semantically wrong for a one-person sacrament. Swapped to `Droplets` (water → baptism). Marriage stays `Heart`, funeral stays `Cross`. Added `Droplets` to `front-end/src/ui/icons.ts` (wasn't exported before).

### 3. "Welcome back, Fr James" font size
Was `<h1 class="text-[17px] font-semibold">` — too prominent for a quiet personalized greeting. Down to `text-[14px] font-medium`, matching the subtitle weight.

### 4. "Rector at <church> for N years" subtitle
Replaces the bare church-name line under the greeting when the user appears as clergy in the parish's records.

**New backend endpoint:** `GET /api/churches/:churchId/clergy-tenure`
- Reads `req.user.last_name` (falls back to first_name).
- Runs `MIN(YEAR(...))` across the three sacrament tables (`baptism_records.reception_date`, `marriage_records.mdate`, `funeral_records.deceased_date`) `WHERE clergy LIKE %match%`.
- Returns `{ years, firstYear, currentYear, churchName, matchTerm }` or `{ years: null }` when nothing matches.
- Auth: same-church user OR platform admin.

**Front-end** fetches on mount keyed on `activeChurchId`. Falls back silently to just the church name when there's no tenure data (lay user, no records).

## Verified live
SSPPOC + Fr James (`last_name=Parsells`) — matches `"Rev. James Parsells"` records via `LIKE %Parsells%`:
```
firstYear : 1978
currentYear: 2026
years      : 48
```
User estimated "47, i think" — **48** is the actual computed value (earliest record was a 1978 baptism by Rev. James Parsells).

`vite build` clean (`06e0464eb48e210a`). Backend restarted, dist mirrored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)