### PR TITLE
Homepage hero rotating panel + hide pricing dollar amounts

### DIFF
--- a/front-end/src/components/frontend-pages/homepage/HomepageHero.tsx
+++ b/front-end/src/components/frontend-pages/homepage/HomepageHero.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 import { PUBLIC_ROUTES } from '@/config/publicRoutes';
@@ -75,37 +76,155 @@ const HomepageHero = () => {
       <style>{AMBIENT_KEYFRAMES}</style>
 
       <div className="relative z-10 max-w-7xl mx-auto px-6 py-24 md:py-32">
-        <div className="max-w-3xl">
-          <div className="inline-flex items-center gap-2 bg-[rgba(212,175,55,0.15)] dark:bg-[rgba(212,175,55,0.2)] px-4 py-2 rounded-full mb-6">
-            <span className="w-2 h-2 bg-[#d4af37] rounded-full"></span>
-            <EditableText contentKey="hero.badge" as="span" className="font-['Inter'] text-[14px] text-[#d4af37]">
-              {t('home.hero_badge')}
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          <div>
+            <div className="inline-flex items-center gap-2 bg-[rgba(212,175,55,0.15)] dark:bg-[rgba(212,175,55,0.2)] px-4 py-2 rounded-full mb-6">
+              <span className="w-2 h-2 bg-[#d4af37] rounded-full"></span>
+              <EditableText contentKey="hero.badge" as="span" className="font-['Inter'] text-[14px] text-[#d4af37]">
+                {t('home.hero_badge')}
+              </EditableText>
+            </div>
+            <EditableText contentKey="hero.title" as="h1" className="font-['Georgia'] text-5xl md:text-6xl leading-tight mb-6">
+              {t('home.hero_title')}
             </EditableText>
+            <EditableText contentKey="hero.subtitle" as="p" className="font-['Inter'] text-xl text-[rgba(255,255,255,0.9)] leading-relaxed mb-8" multiline>
+              {t('home.hero_subtitle')}
+            </EditableText>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <Link
+                to={PUBLIC_ROUTES.TOUR}
+                className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-[#d4af37] text-[#2d1b4e] rounded-lg font-['Inter'] font-medium text-[16px] hover:bg-[#c29d2f] transition-colors no-underline"
+              >
+                {t('home.hero_cta_tour')}
+                <ArrowRight size={20} />
+              </Link>
+              <Link
+                to={PUBLIC_ROUTES.CONTACT}
+                className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white/10 backdrop-blur-sm border border-white/20 text-white rounded-lg font-['Inter'] font-medium text-[16px] hover:bg-white/20 transition-colors no-underline"
+              >
+                {t('home.hero_cta_demo')}
+              </Link>
+            </div>
           </div>
-          <EditableText contentKey="hero.title" as="h1" className="font-['Georgia'] text-5xl md:text-6xl leading-tight mb-6">
-            {t('home.hero_title')}
-          </EditableText>
-          <EditableText contentKey="hero.subtitle" as="p" className="font-['Inter'] text-xl text-[rgba(255,255,255,0.9)] leading-relaxed mb-8" multiline>
-            {t('home.hero_subtitle')}
-          </EditableText>
-          <div className="flex flex-col sm:flex-row gap-4">
-            <Link
-              to={PUBLIC_ROUTES.TOUR}
-              className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-[#d4af37] text-[#2d1b4e] rounded-lg font-['Inter'] font-medium text-[16px] hover:bg-[#c29d2f] transition-colors no-underline"
-            >
-              {t('home.hero_cta_tour')}
-              <ArrowRight size={20} />
-            </Link>
-            <Link
-              to={PUBLIC_ROUTES.CONTACT}
-              className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white/10 backdrop-blur-sm border border-white/20 text-white rounded-lg font-['Inter'] font-medium text-[16px] hover:bg-white/20 transition-colors no-underline"
-            >
-              {t('home.hero_cta_demo')}
-            </Link>
-          </div>
+
+          <CanonicalDutyCarousel />
         </div>
       </div>
     </section>
+  );
+};
+
+// Right-side rotating panel: cycles a pull-quote → canonical-duty
+// background → modern-jurisdiction guidance, then loops. Each
+// transition slides the active slide out the top while the next
+// one slides up from below — including the wrap-around from the
+// last slide back to the first, which is why we track `prev`
+// rather than relying on a simple key remount.
+const SLIDE_DURATIONS_MS = [9000, 18000, 18000];
+
+const CanonicalDutyCarousel = () => {
+  const [active, setActive] = useState(0);
+  const [prev, setPrev] = useState(-1);
+  const [paused, setPaused] = useState(false);
+
+  useEffect(() => {
+    if (paused) return;
+    const id = window.setTimeout(() => {
+      setPrev(active);
+      setActive((a) => (a + 1) % 3);
+    }, SLIDE_DURATIONS_MS[active]);
+    return () => window.clearTimeout(id);
+  }, [active, paused]);
+
+  const slideClass = (i: number) => {
+    const base =
+      'absolute inset-0 p-6 md:p-8 overflow-y-auto transition-all duration-700 ease-out';
+    if (i === active) return `${base} translate-y-0 opacity-100`;
+    if (i === prev) return `${base} -translate-y-full opacity-0`;
+    return `${base} translate-y-full opacity-0`;
+  };
+
+  return (
+    <div
+      className="relative h-[480px] md:h-[540px] rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 overflow-hidden"
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      aria-roledescription="carousel"
+      aria-label="Canonical duty rotating panel"
+    >
+      <div className={slideClass(0)} aria-hidden={active !== 0}>
+        <div className="flex h-full items-center">
+          <p className="font-['Georgia'] italic text-2xl md:text-3xl leading-snug text-[#f4d77a]">
+            “Fulfill your canonical duty with modern efficiency. From scanning existing paper records to managing your parish&apos;s digital footprint, ensure your Metrical Records are safe, searchable, and compliant with jurisdictional statutes.”
+          </p>
+        </div>
+      </div>
+
+      <div className={slideClass(1)} aria-hidden={active !== 1}>
+        <p className="font-['Inter'] text-[15px] md:text-[16px] leading-relaxed text-white/90 mb-4">
+          Orthodox parishes are required by canon law and administrative tradition to keep accurate records, specifically Metrical Books (records of baptism, chrismation, marriage, and burial). While no single ancient, universally codified &ldquo;canon&rdquo; exists in the same way modern civil law works, these requirements are enforced through local synodical regulations, episcopal directives, and the general canonical obligation to maintain order in the Church.
+        </p>
+        <ul className="space-y-3 font-['Inter'] text-[14px] md:text-[15px] text-white/85">
+          <li className="flex gap-2">
+            <span className="text-[#d4af37] mt-1">•</span>
+            <span><strong className="text-white">Metrical Records:</strong> Priests are obliged to keep detailed records of all sacraments performed. These act as proof of membership and standing within the Church.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[#d4af37] mt-1">•</span>
+            <span><strong className="text-white">Purpose:</strong> These registers are considered permanent, historical documents essential for verifying membership, sacramental life, and legal/pastoral accountability.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[#d4af37] mt-1">•</span>
+            <span><strong className="text-white">Authority:</strong> While not always in the oldest ecumenical canons, maintaining accurate records is upheld by the authority of local bishops and synods to regulate parish life.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[#d4af37] mt-1">•</span>
+            <span><strong className="text-white">Parish Responsibility:</strong> Each Orthodox parish is expected to maintain these, often in a safe, fire-proof location.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div className={slideClass(2)} aria-hidden={active !== 2}>
+        <p className="font-['Inter'] text-[15px] md:text-[16px] leading-relaxed text-white/90 mb-4">
+          Modern Orthodox jurisdictions, such as the Orthodox Church in America (OCA) and the Greek Orthodox Archdiocese of America, have explicit statutes requiring priests to &ldquo;personally maintain&rdquo; Metrical Records for every baptism, chrismation, marriage, and burial.
+        </p>
+        <ul className="space-y-3 font-['Inter'] text-[14px] md:text-[15px] text-white/85">
+          <li className="flex gap-2">
+            <span className="text-[#d4af37] mt-1">•</span>
+            <span><strong className="text-white">Canonical Custody:</strong> Under the OCA Statute (Article XII), the parish priest is legally &ldquo;entrusted with the care, custody, and maintenance&rdquo; of both sacramental and administrative records.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[#d4af37] mt-1">•</span>
+            <span><strong className="text-white">Permanent Preservation:</strong> Because metrical registers are considered permanent, historical records, churches are increasingly encouraged to create digital duplicates to protect against physical loss from fire, age, or disaster.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[#d4af37] mt-1">•</span>
+            <span><strong className="text-white">Accurate Reporting:</strong> Parishes must provide yearly sacramental statistics to their diocese. A digital tool like ours makes this metadata management significantly more efficient.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[#d4af37] mt-1">•</span>
+            <span><strong className="text-white">Verification of Status:</strong> Since Ancient Canons (such as Apostolic Canons 17 &amp; 18) prohibit certain roles based on sacramental history, having searchable, accurate records is a theological necessity for ensuring the integrity of the Church&apos;s life.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-2 z-10">
+        {[0, 1, 2].map((i) => (
+          <button
+            key={i}
+            type="button"
+            aria-label={`Show slide ${i + 1}`}
+            onClick={() => {
+              setPrev(active);
+              setActive(i);
+            }}
+            className={`h-2 rounded-full transition-all ${
+              active === i ? 'w-6 bg-[#d4af37]' : 'w-2 bg-white/30 hover:bg-white/50'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
   );
 };
 

--- a/front-end/src/features/pages/frontend-pages/Pricing.tsx
+++ b/front-end/src/features/pages/frontend-pages/Pricing.tsx
@@ -5,6 +5,12 @@ import { HeroSection, CTASection } from '@/components/frontend-pages/shared/sect
 import EditableText from '@/components/frontend-pages/shared/EditableText';
 import { useLanguage } from '@/context/LanguageContext';
 
+// Pricing temporarily hidden by request (2026-05-03). The plan tier
+// + features still ship; just the dollar amounts and billing notes
+// are masked so visitors are routed to Contact for a quote. Flip
+// back to false to restore the published prices in one place.
+const HIDE_PRICES = true;
+
 const PagePricing = () => {
   const { t } = useLanguage();
 
@@ -63,13 +69,19 @@ const PagePricing = () => {
                 </p>
               </div>
               <div className="mb-6">
-                <div className="flex items-baseline gap-2">
-                  <span className="font-['Georgia'] text-5xl">{t('pricing.plan_medium_price')}</span>
-                  <span className="font-['Inter'] text-[16px] text-[rgba(255,255,255,0.8)] dark:text-[rgba(45,27,78,0.8)]">{t('pricing.per_month')}</span>
-                </div>
-                <p className="font-['Inter'] text-[14px] text-[rgba(255,255,255,0.8)] dark:text-[rgba(45,27,78,0.8)] mt-2">
-                  {t('pricing.plan_medium_billing')}
-                </p>
+                {HIDE_PRICES ? (
+                  <p className="font-['Georgia'] text-3xl">Contact for Pricing</p>
+                ) : (
+                  <>
+                    <div className="flex items-baseline gap-2">
+                      <span className="font-['Georgia'] text-5xl">{t('pricing.plan_medium_price')}</span>
+                      <span className="font-['Inter'] text-[16px] text-[rgba(255,255,255,0.8)] dark:text-[rgba(45,27,78,0.8)]">{t('pricing.per_month')}</span>
+                    </div>
+                    <p className="font-['Inter'] text-[14px] text-[rgba(255,255,255,0.8)] dark:text-[rgba(45,27,78,0.8)] mt-2">
+                      {t('pricing.plan_medium_billing')}
+                    </p>
+                  </>
+                )}
               </div>
               <ul className="space-y-4 mb-8">
                 {MEDIUM_FEAT_KEYS.map((i) => (
@@ -190,11 +202,17 @@ function PricingCard({ name, description, price, perMonth, billingNote, features
         <p className="font-['Inter'] text-[15px] text-[#4a5565] dark:text-gray-400">{description}</p>
       </div>
       <div className="mb-6">
-        <div className="flex items-baseline gap-2">
-          <span className="font-['Georgia'] text-5xl text-[#2d1b4e] dark:text-white">{price}</span>
-          <span className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400">{perMonth}</span>
-        </div>
-        <p className="font-['Inter'] text-[14px] text-[#4a5565] dark:text-gray-400 mt-2">{billingNote}</p>
+        {HIDE_PRICES ? (
+          <p className="font-['Georgia'] text-3xl text-[#2d1b4e] dark:text-white">Contact for Pricing</p>
+        ) : (
+          <>
+            <div className="flex items-baseline gap-2">
+              <span className="font-['Georgia'] text-5xl text-[#2d1b4e] dark:text-white">{price}</span>
+              <span className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400">{perMonth}</span>
+            </div>
+            <p className="font-['Inter'] text-[14px] text-[#4a5565] dark:text-gray-400 mt-2">{billingNote}</p>
+          </>
+        )}
       </div>
       <ul className="space-y-4 mb-8">
         {features.map((f, i) => (


### PR DESCRIPTION
## Summary

Two public-page changes per operator request:

### 1. Homepage hero — canonical-duty rotating panel
\`/frontend-pages/homepage\`'s hero section was a single max-w-3xl column. Reformatted into a 2-column grid on lg+:
- **Left** (anchored): existing badge / title / subtitle / Tour + Demo CTAs.
- **Right** (new): a rotating panel that cycles three slides every 9 / 18 / 18 seconds.

The three slides:

1. **Pull-quote** — italic Georgia in gold:
   *"Fulfill your canonical duty with modern efficiency. From scanning existing paper records to managing your parish's digital footprint, ensure your Metrical Records are safe, searchable, and compliant with jurisdictional statutes."*
2. **Canonical-duty background** — paragraph + bullet list (Metrical Records / Purpose / Authority / Parish Responsibility).
3. **Modern jurisdictions** — paragraph + bullet list (Canonical Custody / Permanent Preservation / Accurate Reporting / Verification of Status).

Transitions slide the previous slide out the top while the incoming one slides up from the bottom. \`prev\` is tracked explicitly (not via key remount) so the wrap-around (slide 3 → 1) keeps the scroll-up feel rather than reversing direction.

UX touches:
- Hovering the panel pauses the rotation.
- Click-to-jump dots at the bottom.
- Mobile (< lg) stacks vertically.

Content lives inline (not in \`/api/i18n\`) — domain-specific text the operator wrote, no localization needed yet.

### 2. Pricing page — hide dollar amounts for now
Hide the six published prices (\$49 / \$59 / \$99 / \$119 / \$199 / \$239) on \`/frontend-pages/pricing\` while pricing is being reworked. Plan names, descriptions, feature bullets, comparison table, and CTAs stay — only the price block on each card is replaced with **"Contact for Pricing"**.

Implemented with a single \`HIDE_PRICES = true\` constant at the top of \`Pricing.tsx\` — flip to false to restore. The Get Started buttons already point to \`/contact\`, so the conversion path is unbroken. The dollar amounts live only in \`/api/i18n\` keys (\`pricing.plan_{small,medium,large}_{price,billing}\`); they're gated at the JSX level rather than removed from the i18n table, so when new pricing is decided the operator edits the translations and flips the flag.

## Test plan
- [ ] Visit \`/frontend-pages/homepage\` — hero shows left-aligned content + right-side rotating panel that cycles every 9 / 18 / 18 sec.
- [ ] Hover the panel — rotation pauses; mouse-leave resumes.
- [ ] Click the dots at the bottom — jumps to the chosen slide.
- [ ] Mobile width — panel stacks below the hero text.
- [ ] Visit \`/frontend-pages/pricing\` — all three cards show "Contact for Pricing" instead of dollar amounts; comparison table + FAQ + CTA still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)