### PR TITLE
Themes: GREEN_THEME → Pentecost green, BLUE_THEME → aqua

### DIFF
--- a/front-end/src/layouts/full/shared/customizer/Customizer.tsx
+++ b/front-end/src/layouts/full/shared/customizer/Customizer.tsx
@@ -103,7 +103,7 @@ const Customizer: FC = () => {
     },
     {
       id: 2,
-      bgColor: "#A4C639",
+      bgColor: "#2E7D32", // Pentecost green — match LightThemeColors GREEN_THEME
       disp: "GREEN_THEME",
     },
     {
@@ -118,7 +118,7 @@ const Customizer: FC = () => {
     },
     {
       id: 5,
-      bgColor: "#1E6B8C",
+      bgColor: "#00ACC1", // Aqua blue — match LightThemeColors BLUE_THEME
       disp: "BLUE_THEME",
     },
     {

--- a/front-end/src/shared/ui/OrthodoxThemeToggle.tsx
+++ b/front-end/src/shared/ui/OrthodoxThemeToggle.tsx
@@ -66,10 +66,10 @@ const OrthodoxThemeToggle: React.FC<OrthodoxThemeToggleProps> = ({
 
   const themes = [
     { key: 'WHITE_THEME', name: 'Resurrection White', color: '#F5F5F0' },
-    { key: 'GREEN_THEME', name: 'Ordinary Time Green', color: '#A4C639' },
+    { key: 'GREEN_THEME', name: 'Pentecost Green', color: '#2E7D32' },
     { key: 'PURPLE_THEME', name: 'Lenten Purple', color: '#6B2D75' },
     { key: 'RED_THEME', name: 'Martyrs Red', color: '#B22234' },
-    { key: 'BLUE_THEME', name: 'Theotokos Blue', color: '#1E6B8C' },
+    { key: 'BLUE_THEME', name: 'Aqua Blue', color: '#00ACC1' },
     { key: 'GOLD_THEME', name: 'Royal Gold', color: '#C9A227' },
     { key: 'LENT_THEME', name: 'Great Lent', color: '#1a1a1a' },
   ];

--- a/front-end/src/store/useTableStyleStore.ts
+++ b/front-end/src/store/useTableStyleStore.ts
@@ -140,9 +140,9 @@ export const ORTHODOX_PRESETS: OrthodoxPreset[] = [
 export const THEME_TO_ACCENT_MAP: Record<string, string> = {
   PURPLE_THEME: '#bd56fa',
   AQUA_THEME:   '#E6E8EB',
-  GREEN_THEME:  '#2E7D32',
+  GREEN_THEME:  '#2E7D32', // Pentecost green
   ORANGE_THEME: '#6E0E1A',
-  BLUE_THEME:   '#6EC6FF',
+  BLUE_THEME:   '#00ACC1', // Aqua
   CYAN_THEME:   '#E0B84A',
 };
 

--- a/front-end/src/theme/DarkThemeColors.tsx
+++ b/front-end/src/theme/DarkThemeColors.tsx
@@ -24,10 +24,13 @@ const DarkThemeColors = [
   {
     name: 'GREEN_THEME',
     palette: {
+      // Pentecost green (dark variant) — same #2E7D32 main as light
+      // theme; light slot uses a deep shadow color so dark-mode card
+      // backgrounds stay readable behind primary text.
       primary: {
-        main: '#A4C639',
-        light: '#2d3518',
-        dark: '#8DB32E',
+        main: '#2E7D32',
+        light: '#1a2e1c',
+        dark: '#1B5E20',
         contrastText: '#ffffff',
       },
       secondary: {
@@ -90,10 +93,11 @@ const DarkThemeColors = [
   {
     name: 'BLUE_THEME',
     palette: {
+      // Aqua blue (dark variant) — same #00ACC1 main as light theme.
       primary: {
-        main: '#1E6B8C',
-        light: '#152535',
-        dark: '#1A5C7A',
+        main: '#00ACC1',
+        light: '#0a2730',
+        dark: '#00838F',
         contrastText: '#ffffff',
       },
       secondary: {
@@ -118,10 +122,11 @@ const DarkThemeColors = [
         dark: '#B8931F',
         contrastText: '#ffffff',
       },
+      // Secondary tracks BLUE_THEME's aqua primary for visual consistency.
       secondary: {
-        main: '#1E6B8C',
-        light: '#152535',
-        dark: '#1A5C7A',
+        main: '#00ACC1',
+        light: '#0a2730',
+        dark: '#00838F',
         contrastText: '#ffffff',
       },
       background: {

--- a/front-end/src/theme/LightThemeColors.tsx
+++ b/front-end/src/theme/LightThemeColors.tsx
@@ -19,10 +19,13 @@ const LightThemeColors = [
   {
     name: 'GREEN_THEME',
     palette: {
+      // Pentecost green — the deep, vibrant evergreen used liturgically
+      // for Pentecost / Holy Spirit feasts. Replaces the chartreuse #A4C639
+      // which read as "spring lime" rather than "feast green".
       primary: {
-        main: '#A4C639',
-        light: '#E8F5C8',
-        dark: '#8DB32E',
+        main: '#2E7D32',
+        light: '#C8E6C9',
+        dark: '#1B5E20',
         contrastText: '#ffffff',
       },
       secondary: {
@@ -70,10 +73,13 @@ const LightThemeColors = [
   {
     name: 'BLUE_THEME',
     palette: {
+      // Aqua blue — bright cyan-leaning blue, replacing the previous
+      // steel-blue #1E6B8C. Aligns with the user-facing label
+      // "Aqua / Theotokos" in OrthodoxThemeToggle.
       primary: {
-        main: '#1E6B8C',
-        light: '#D6E8F0',
-        dark: '#1A5C7A',
+        main: '#00ACC1',
+        light: '#B2EBF2',
+        dark: '#00838F',
         contrastText: '#ffffff',
       },
       secondary: {
@@ -93,10 +99,12 @@ const LightThemeColors = [
         dark: '#B8931F',
         contrastText: '#ffffff',
       },
+      // Secondary tracks BLUE_THEME's primary so the gold/blue pairing
+      // stays consistent across both themes.
       secondary: {
-        main: '#1E6B8C',
-        light: '#D6E8F0',
-        dark: '#1A5C7A',
+        main: '#00ACC1',
+        light: '#B2EBF2',
+        dark: '#00838F',
         contrastText: '#ffffff',
       },
     },

--- a/front-end/src/theme/ThemeColors.tsx
+++ b/front-end/src/theme/ThemeColors.tsx
@@ -17,10 +17,11 @@ const ThemeColors = [
   {
     name: 'GREEN_THEME',
     palette: {
+      // Pentecost green — see LightThemeColors.tsx for the rationale.
       primary: {
-        main: '#A4C639',
-        light: '#E8F5C8',
-        dark: '#8DB32E',
+        main: '#2E7D32',
+        light: '#C8E6C9',
+        dark: '#1B5E20',
       },
       secondary: {
         main: '#F5F5F0',
@@ -62,10 +63,11 @@ const ThemeColors = [
   {
     name: 'BLUE_THEME',
     palette: {
+      // Aqua blue — see LightThemeColors.tsx for the rationale.
       primary: {
-        main: '#1E6B8C',
-        light: '#D6E8F0',
-        dark: '#1A5C7A',
+        main: '#00ACC1',
+        light: '#B2EBF2',
+        dark: '#00838F',
       },
       secondary: {
         main: '#C9A227',
@@ -83,9 +85,9 @@ const ThemeColors = [
         dark: '#B8931F',
       },
       secondary: {
-        main: '#1E6B8C',
-        light: '#D6E8F0',
-        dark: '#1A5C7A',
+        main: '#00ACC1',
+        light: '#B2EBF2',
+        dark: '#00838F',
       },
     },
   },


### PR DESCRIPTION
## Summary

Two color updates to the user-facing theme picker (Settings → Theme Colors / Customizer). All MUI palette files, the table-style accent map, the theme-toggle labels, and the customizer swatches were updated together so they don't drift.

| Theme | Was | Now |
|---|---|---|
| **GREEN_THEME** | \`#A4C639\` (chartreuse / spring lime) | \`#2E7D32\` (Pentecost green — deep evergreen used liturgically for Pentecost / Holy Spirit feasts) |
| **BLUE_THEME** | \`#1E6B8C\` (steel / petrol blue) | \`#00ACC1\` (aqua — bright cyan-leaning blue) |

Light/dark slot variants tracked the main color appropriately.

## Files

- \`theme/LightThemeColors.tsx\` — primary palette (and GOLD_THEME's secondary which paired with the old blue).
- \`theme/DarkThemeColors.tsx\` — same updates for the dark variant.
- \`theme/ThemeColors.tsx\` — third palette source kept in sync.
- \`store/useTableStyleStore.ts\` — \`THEME_TO_ACCENT_MAP.BLUE_THEME\` swapped to aqua so Records grid accents follow the site theme.
- \`shared/ui/OrthodoxThemeToggle.tsx\` — swatch labels updated: "Ordinary Time Green" → "Pentecost Green", "Theotokos Blue" → "Aqua Blue".
- \`layouts/full/shared/customizer/Customizer.tsx\` — the GREEN/BLUE swatches in the Settings drawer now match the palette.

## Out of scope

Liturgical-calendar files (\`LiturgicalCalendarPage\`, \`Toolbar\`, \`DaySidebar\`, \`liturgical-calendar.css\`) still reference \`#A4C639\` / \`#1E6B8C\` — those are feast-day color codes, not theme-picker state. Intentionally left alone.

## Contact form

User's third request — "send results to info@orthodoxmetrics.com" — was already in place. The route at \`server/src/index.ts:910\` calls \`sendContactEmail()\` which hardcodes \`to: 'info@orthodoxmetrics.com'\` at \`server/src/utils/emailService.js:894\`. No change needed; verified by inspection.

## Test plan

- [ ] Settings → Theme Colors → click the green swatch — UI primary turns deep evergreen.
- [ ] Settings → Theme Colors → click the blue swatch — UI primary turns aqua.
- [ ] Confirm Records grid accent matches the active theme (table-style store).
- [ ] OrthodoxThemeToggle dropdown shows the new labels.
- [ ] Submit the contact form → email arrives at info@orthodoxmetrics.com (existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)