### PR TITLE
OMD-1375: mute react-helmet-async PURE-annotation warnings in Vite build

### DIFF
--- a/front-end/vite.config.ts
+++ b/front-end/vite.config.ts
@@ -114,6 +114,18 @@ export default defineConfig(({ mode }) => {
         },
         rollupOptions: {
             external: [],
+            onwarn(warning, warn) {
+                // react-helmet-async ships pre-minified ESM with /*#__PURE__*/
+                // comments that Rollup can't position-validate. Harmless; mute them.
+                if (
+                    warning.code === 'INVALID_ANNOTATION' &&
+                    typeof warning.message === 'string' &&
+                    warning.message.includes('react-helmet-async')
+                ) {
+                    return;
+                }
+                warn(warning);
+            },
             output: {
                 manualChunks: {
                     vendor: ['react', 'react-dom', 'react-router-dom'],


### PR DESCRIPTION
## Summary
- Adds a `rollupOptions.onwarn` filter to `front-end/vite.config.ts` that drops `INVALID_ANNOTATION` warnings emitted by `react-helmet-async/lib/index.module.js`.
- The package ships pre-minified ESM where `/*#__PURE__*/` comments end up in positions Rollup can't validate; the warnings are noise (Rollup just skips the optional tree-shaking hint, runtime is unchanged).
- All other warnings still flow through Rollup's default `warn()` so we don't blanket-mute.

## Test plan
- [x] `npx vite build` no longer logs `INVALID_ANNOTATION` lines about `react-helmet-async/lib/index.module.js`.
- [x] Build still completes successfully and emits assets.
- [ ] Other warning categories (chunk-size, etc.) continue to log — confirm in CI.

OMD-1375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)