### PR TITLE
OMD-1378: render fatherName on baptism cert — register missing fields + tolerant merge

### DIFF
--- a/server/src/certificates/coordinate-maps.js
+++ b/server/src/certificates/coordinate-maps.js
@@ -45,6 +45,31 @@ const BAPTISM_CERTIFICATE_MAP = {
       align: 'center',
       maxWidth: 400,
     },
+    // Parents — exposed in BAPTISM_FIELD_LABELS so the operator can
+    // drag any combination of these onto the template. Defaults sit
+    // just below fullName so the cert is readable even before the
+    // operator saves a custom layout.
+    fatherName: {
+      x: 280,
+      y: 488,
+      fontSize: 14,
+      align: 'center',
+      maxWidth: 250,
+    },
+    motherName: {
+      x: 430,
+      y: 488,
+      fontSize: 14,
+      align: 'center',
+      maxWidth: 250,
+    },
+    parents: {
+      x: 306,
+      y: 488,
+      fontSize: 14,
+      align: 'center',
+      maxWidth: 400,
+    },
     birthDate: {
       x: 350,
       y: 480,
@@ -275,20 +300,37 @@ function mergeCustomPositions(coordinateMap, customPositions) {
   if (!customPositions || Object.keys(customPositions).length === 0) {
     return coordinateMap;
   }
-  
+
   const merged = JSON.parse(JSON.stringify(coordinateMap)); // Deep clone
-  
+
+  // Sane defaults for any field the front-end exposes but the
+  // back-end map hasn't been taught about — prevents silently
+  // dropping a saved position when the front-end ships a new field
+  // before coordinate-maps catches up.
+  const defaultFieldStyle = {
+    fontSize: 14,
+    align: 'center',
+    maxWidth: 300,
+  };
+
   Object.keys(customPositions).forEach(fieldName => {
-    if (merged.fields[fieldName] && customPositions[fieldName]) {
-      // Merge custom x, y while preserving other field properties
+    const pos = customPositions[fieldName];
+    if (!pos || typeof pos.x !== 'number' || typeof pos.y !== 'number') return;
+    if (merged.fields[fieldName]) {
       merged.fields[fieldName] = {
         ...merged.fields[fieldName],
-        x: customPositions[fieldName].x,
-        y: customPositions[fieldName].y,
+        x: pos.x,
+        y: pos.y,
+      };
+    } else {
+      merged.fields[fieldName] = {
+        ...defaultFieldStyle,
+        x: pos.x,
+        y: pos.y,
       };
     }
   });
-  
+
   return merged;
 }
 

--- a/server/src/certificates/pdf-generator.js
+++ b/server/src/certificates/pdf-generator.js
@@ -291,7 +291,11 @@ async function generateBaptismCertificatePDF(record, options = {}) {
     church: record.churchName || 'Orthodox Church',
     fatherName,
     motherName,
-    parents: record.parents || '',
+    // Only emit the combined "parents" string when splitParents
+    // actually produced two names. A single-name record.parents
+    // (e.g. "Robert Smith") is treated as fatherName only — otherwise
+    // we'd double-render the same text in two places.
+    parents: motherName ? (record.parents || '') : '',
   };
   
   // Draw each field


### PR DESCRIPTION
## Summary
Follow-up to OMD-1376 / PR #874. After that PR landed, baptism `fieldData` exposed `fatherName` / `motherName` / `parents` from `splitParents(record.parents)`, but `BAPTISM_CERTIFICATE_MAP.fields` in `server/src/certificates/coordinate-maps.js` only ever defined 12 fields. `mergeCustomPositions` does `if (merged.fields[fieldName])` and **silently drops** any custom position whose key isn't already in the base map — so the operator-placed `fatherName` at `{484, 956}` for church 46 record 713 was thrown away before drawing.

## Changes
1. **coordinate-maps.js** — add `fatherName`, `motherName`, `parents` entries to `BAPTISM_CERTIFICATE_MAP.fields` with Times Roman 14pt center-align defaults sitting just below `fullName`.
2. **coordinate-maps.js** — `mergeCustomPositions` now accepts unknown keys with default styling instead of dropping them. Stops this exact bug class from recurring when the front-end ships a new field before the back-end map catches up.
3. **pdf-generator.js** — only emit the combined `parents` string when `splitParents` actually produced two names. A single-name `record.parents` (e.g. `"Robert Smith"`) is rendered as `fatherName` only — otherwise we'd double-render the same text at both the saved `fatherName` position **and** the default `parents` position.

## Test plan
- [x] Local: `pdftotext` on regenerated baptism PDF for record 713 lists `Robert Smith` exactly once at the operator-saved position.
- [ ] Visual check on production after deploy: `/portal/certificates/generate?recordType=baptism&recordId=713&churchId=46` shows the father's name in the dragged location.
- [ ] Test a record with compound parents (e.g. `"John & Mary Smith"`): both `fatherName` and `motherName` render at their placed positions; `parents` renders only if explicitly placed.

OMD-1378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)