### PR TITLE
OMD-1379: marriage cert — drop parents overlap + add Rector clergy slot

### DIFF
--- a/front-end/src/features/certificates/certificateTypes.ts
+++ b/front-end/src/features/certificates/certificateTypes.ts
@@ -34,6 +34,7 @@ export const MARRIAGE_DEFAULT_POSITIONS: Record<string, { x: number; y: number }
   marriageDateYY: { x: 560, y: 678 },
   witnesses: { x: 400, y: 782 },
   clergy: { x: 410, y: 730 },
+  clergyRector: { x: 600, y: 870 },
   church: { x: 514, y: 756 },
 };
 
@@ -63,7 +64,8 @@ export const MARRIAGE_FIELD_LABELS: Record<string, string> = {
   marriageDateMD: 'Marriage Date — M/D',
   marriageDateYY: 'Marriage Date — YY',
   witnesses: 'Witnesses',
-  clergy: 'Clergy',
+  clergy: 'Clergy (By)',
+  clergyRector: 'Rector',
   church: 'Church Name',
 };
 

--- a/server/src/certificates/coordinate-maps.js
+++ b/server/src/certificates/coordinate-maps.js
@@ -220,27 +220,6 @@ const MARRIAGE_CERTIFICATE_MAP = {
       align: 'center',
       maxWidth: 40,
     },
-    marriagePlace: {
-      x: 306,
-      y: 390,
-      fontSize: 14,
-      align: 'center',
-      maxWidth: 300,
-    },
-    groomParents: {
-      x: 306,
-      y: 350,
-      fontSize: 12,
-      align: 'center',
-      maxWidth: 400,
-    },
-    brideParents: {
-      x: 306,
-      y: 325,
-      fontSize: 12,
-      align: 'center',
-      maxWidth: 400,
-    },
     witnesses: {
       x: 306,
       y: 280,
@@ -255,6 +234,16 @@ const MARRIAGE_CERTIFICATE_MAP = {
       fontSize: 14,
       align: 'center',
       maxWidth: 300,
+    },
+    // Marriage cert has two clergy slots — the officiating priest on
+    // the "By" line (rendered as `clergy`) and a second signature on
+    // the "Rector" line at the bottom. Same value as `clergy`.
+    clergyRector: {
+      x: 450,
+      y: 150,
+      fontSize: 12,
+      align: 'left',
+      maxWidth: 200,
     },
     church: {
       x: 306,

--- a/server/src/certificates/pdf-generator.js
+++ b/server/src/certificates/pdf-generator.js
@@ -382,18 +382,26 @@ async function generateMarriageCertificatePDF(record, options = {}) {
   const font = await pdfDoc.embedFont(StandardFonts.TimesRoman);
   const fontBold = await pdfDoc.embedFont(StandardFonts.TimesRomanBold);
   
-  // Extract field data from record
+  // Extract field data from record. groomParents/brideParents/marriagePlace
+  // are intentionally omitted — they are not exposed in
+  // MARRIAGE_FIELD_LABELS so the operator cannot place them, and their
+  // old default coordinates collided with the groomName/brideName saved
+  // positions (visible as overlapping text on every cert before this
+  // change).
+  const clergyName = record.clergy || '';
   const fieldData = {
     groomName: `${record.fname_groom || record.groom_first || ''} ${record.lname_groom || record.groom_last || ''}`.trim(),
     brideName: `${record.fname_bride || record.bride_first || ''} ${record.lname_bride || record.bride_last || ''}`.trim(),
     marriageDate: (record.mdate || record.marriage_date) ? new Date(record.mdate || record.marriage_date).toLocaleDateString() : '',
     marriageDateMD: dateMD(record.mdate || record.marriage_date),
     marriageDateYY: dateYY(record.mdate || record.marriage_date),
-    marriagePlace: record.marriage_place || record.place || record.mlicense || '',
-    groomParents: record.parentsg || record.parents_groom || '',
-    brideParents: record.parentsb || record.parents_bride || '',
     witnesses: record.witness || record.witnesses || '',
-    clergy: record.clergy || '',
+    clergy: clergyName,
+    // Second clergy slot — the OCA template has both a "By" line
+    // (officiating priest) and a "Rector" line at the bottom. Same
+    // value as `clergy`; the operator drags the two markers to the
+    // two locations.
+    clergyRector: clergyName,
     church: record.churchName || 'Orthodox Church',
   };
   


### PR DESCRIPTION
## Summary
Three issues reported on `/portal/certificates/generate?recordType=marriage&recordId=119&churchId=46`:

1. **Groom/bride parents overlapping the names.** `groomParents` ("Osbaldo & Dessiree") and `brideParents` ("Jessie") auto-rendered at coordinate-map defaults even though MARRIAGE_FIELD_LABELS never exposed them as draggable. Their default Y values landed on top of the operator's saved `groomName`/`brideName`, producing garbled lines. **Removed `groomParents`, `brideParents`, and `marriagePlace`** from both the coord-map and the renderer `fieldData` — purely subtractive since they were never wired to the front-end labels.
2. **Rector signature line was always empty.** OCA template has two clergy slots — a "By" line (officiating priest, already rendered as `clergy`) and a "Rector" line at the bottom. Added a second clergy slot `clergyRector` plumbed through the coord-map, renderer `fieldData` (same value as `clergy` — `record.clergy`), MARRIAGE_FIELD_LABELS (label `Rector`, with the existing `clergy` relabeled `Clergy (By)` so the editor distinguishes the two), and MARRIAGE_DEFAULT_POSITIONS.
3. **Marriage date / witnesses appeared "missing".** They were rendering correctly, but the parents-overlap mess camouflaged them. After (1) the operator-placed `marriageDateMD` + `marriageDateYY` and `witnesses` are unambiguously visible.

## Verification
Rendered marriage cert for record 119 with the fix applied:
- "Angel Cesar Rosado" (groom) — clean, no trailing parents
- "Sarah Jane Jerone" (bride) — clean
- "By  Rev. James Parsells" — first clergy
- "On  8/25 , 20 24" — date M/D + YY visible
- "Witnesses  Alexander Torrisi Ann Torrisi" — visible
- "Rector  Rev. James Parsells" — second clergy (after operator drags the new marker)

## Test plan
- [x] Render marriage cert for record 119 / church 46 — no parents overlap, all expected fields render.
- [ ] Visual check on production after deploy.
- [ ] Operator drags the new "Rector" marker into the Rector line area in the editor and re-saves positions. Previously saved church positions stay valid (additive only).

## Operator note
Any church that wants the Rector line populated needs to drag the new "Rector" marker into the bottom-right signature area in the editor and click Save. Existing saved positions are unaffected.

OMD-1379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)