### PR TITLE
ADMIN-USER-DELETE-FK: cascade church_users + 409 on audit-bearing rows

### DIFF
--- a/server/src/api/admin.js
+++ b/server/src/api/admin.js
@@ -461,11 +461,56 @@ router.delete('/users/:id', requireAdmin, async (req, res) => {
             }
         }
 
-        // Delete user
-        await getAppPool().query(
-            'DELETE FROM orthodoxmetrics_db.users WHERE id = ?',
-            [userId]
-        );
+        // Delete user inside a transaction so dependent rows are cleaned atomically.
+        // Schema has 3 RESTRICT FKs into users.id that block a bare DELETE:
+        //   - church_users.user_id        (membership rows; safe to remove with the user)
+        //   - interactive_reports.created_by_user_id (audit-bearing; refuse and ask admin to reassign)
+        //   - backup_jobs.requested_by    (audit-bearing; refuse and ask admin to reassign)
+        // Other FKs (refresh_tokens, user_roles, password_resets, etc.) already CASCADE or SET NULL.
+        const conn = await getAppPool().getConnection();
+        try {
+            await conn.beginTransaction();
+
+            const [reportRows] = await conn.query(
+                'SELECT COUNT(*) AS n FROM orthodoxmetrics_db.interactive_reports WHERE created_by_user_id = ?',
+                [userId]
+            );
+            const [backupRows] = await conn.query(
+                'SELECT COUNT(*) AS n FROM orthodoxmetrics_db.backup_jobs WHERE requested_by = ?',
+                [userId]
+            );
+            const reportCount = reportRows[0].n;
+            const backupCount = backupRows[0].n;
+
+            if (reportCount > 0 || backupCount > 0) {
+                await conn.rollback();
+                const blockers = [];
+                if (reportCount > 0) blockers.push(`${reportCount} interactive report(s)`);
+                if (backupCount > 0) blockers.push(`${backupCount} backup job(s)`);
+                return res.status(409).json({
+                    success: false,
+                    message: `Cannot delete user: ${blockers.join(' and ')} are owned by this user. Reassign or archive them first.`,
+                    code: 'DELETE_BLOCKED_BY_DEPENDENCIES',
+                    dependencies: { interactive_reports: reportCount, backup_jobs: backupCount },
+                });
+            }
+
+            await conn.query(
+                'DELETE FROM orthodoxmetrics_db.church_users WHERE user_id = ?',
+                [userId]
+            );
+            await conn.query(
+                'DELETE FROM orthodoxmetrics_db.users WHERE id = ?',
+                [userId]
+            );
+
+            await conn.commit();
+        } catch (txErr) {
+            await conn.rollback();
+            throw txErr;
+        } finally {
+            conn.release();
+        }
 
         console.log(`✅ User deleted: ${targetUser.email} by ${currentUser.email} (role: ${currentUser.role})`);
 


### PR DESCRIPTION
## Summary
- DELETE /admin/users/:id was issuing a bare \`DELETE FROM users\`, which fails when the user has \`church_users\` rows (FK \`church_users_ibfk_2\`) — this is the error reported on the OMAI access-control delete dialog.
- Wrap the delete in a transaction: clean up \`church_users\` (membership rows are user-scoped, safe to remove with the user) and **refuse** with HTTP 409 + per-table counts when audit-bearing tables (\`interactive_reports.created_by_user_id\`, \`backup_jobs.requested_by\`) still reference the user, so the admin can reassign before retrying.
- Other 17 FKs into \`users.id\` already use CASCADE or SET NULL — no extra handling needed.

## Why this shape
Church memberships are meaningless without the user, so cascading them is the right default. Interactive reports and backup jobs carry audit value tied to who created them — silently deleting them would lose history, so we refuse with an actionable message instead of forcing a hard choice in code.

## Test plan
- [ ] Delete a user with only \`church_users\` rows → succeeds; memberships cleaned; user gone.
- [ ] Delete a user with \`interactive_reports\` rows → 409 with \`code: DELETE_BLOCKED_BY_DEPENDENCIES\` and \`dependencies.interactive_reports\` count.
- [ ] Delete a user with \`backup_jobs\` rows → 409 with \`dependencies.backup_jobs\` count.
- [ ] Delete a user with both → 409 lists both counts.
- [ ] Delete a user with no FK references → succeeds (no regression).
- [ ] CASCADE/SET NULL FKs (refresh_tokens, user_roles, password_resets, etc.) handled by the schema as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)