### PR TITLE
INTERACTIVE-REPORTS-PORTAL-LAYOUT: switch layout by role, keep church staff in portal chrome

### DIFF
--- a/front-end/src/routes/Router.tsx
+++ b/front-end/src/routes/Router.tsx
@@ -202,6 +202,19 @@ function AccountLayoutSwitcher() {
   return <ChurchPortalLayout />;
 }
 
+/**
+ * Interactive Reports layout switcher.
+ * super_admin / admin → FullLayout admin shell.
+ * Everyone else (church_admin, priest, deacon, …) → ChurchPortalLayout, so
+ * church staff using Interactive Reports never leave their portal chrome.
+ */
+function InteractiveReportsLayoutSwitcher() {
+  const { user } = useAuth();
+  const role = user?.role;
+  if (role === 'super_admin' || role === 'admin') return <FullLayout />;
+  return <ChurchPortalLayout />;
+}
+
 const Router = [
   // Root: unauthenticated visitors see the marketing Homepage; authenticated
   // users are redirected to their role-appropriate dashboard. Renders its own
@@ -772,9 +785,23 @@ const Router = [
           </ProtectedRoute>
         )
       },
-      // Interactive Reports
+      // Interactive Reports — moved out of FullLayout block so non-admin users
+      // (priest, church_admin, …) render inside ChurchPortalLayout instead of
+      // the admin shell. See InteractiveReportsLayoutSwitcher block below.
+      { path: '/apps/records/manager', element: <DynamicRecordsManager /> },
+      { path: '/apps/records/modern-manager', element: <ModernDynamicRecordsManager /> },
+      { path: '/apps/records/editable', element: <EditableRecordPage /> },
+    ],
+  },
+  // ── Church Portal (extracted to portalRoutes.tsx) ──
+  portalRoute,
+  // ── Interactive Reports — admins use FullLayout, church staff stay in portal ──
+  {
+    path: '/apps/records/interactive-reports',
+    element: <InteractiveReportsLayoutSwitcher />,
+    children: [
       {
-        path: '/apps/records/interactive-reports',
+        index: true,
         element: (
           <ProtectedRoute requiredRole={['admin', 'super_admin', 'church_admin', 'priest']}>
             <EnvironmentAwarePage
@@ -785,10 +812,10 @@ const Router = [
               <InteractiveReportsPage />
             </EnvironmentAwarePage>
           </ProtectedRoute>
-        )
+        ),
       },
       {
-        path: '/apps/records/interactive-reports/:reportId',
+        path: ':reportId',
         element: (
           <ProtectedRoute requiredRole={['admin', 'super_admin', 'church_admin', 'priest']}>
             <EnvironmentAwarePage
@@ -799,15 +826,10 @@ const Router = [
               <InteractiveReportReview />
             </EnvironmentAwarePage>
           </ProtectedRoute>
-        )
+        ),
       },
-      { path: '/apps/records/manager', element: <DynamicRecordsManager /> },
-      { path: '/apps/records/modern-manager', element: <ModernDynamicRecordsManager /> },
-      { path: '/apps/records/editable', element: <EditableRecordPage /> },
     ],
   },
-  // ── Church Portal (extracted to portalRoutes.tsx) ──
-  portalRoute,
   // ── Account Hub — super_admin uses FullLayout, others use portal ──
   {
     path: '/account',


### PR DESCRIPTION
## Summary
\`/apps/records/interactive-reports\` was always wrapped in **FullLayout** (admin shell with sidebar). When a priest or church_admin navigated there from the portal hub, they got yanked out of the portal chrome and into the admin shell — exactly the cross-context jump we want to avoid.

This PR moves the route out of the FullLayout block and mounts it under a new \`InteractiveReportsLayoutSwitcher\`:

- **super_admin / admin** → \`FullLayout\` (unchanged)
- **everyone else** (priest, church_admin, deacon, editor, …) → \`ChurchPortalLayout\`

Mirrors the existing \`AccountLayoutSwitcher\` pattern already used for \`/account\`. Path stays \`/apps/records/interactive-reports[/:reportId]\` so the portal hub link (\`ChurchPortalHub.tsx:872\`) and any deep links keep working.

## Why this shape
- Path-preserving — no route renames, no link updates, no menu changes.
- Mirrors an existing pattern in the same file, so reviewers can grep for \`LayoutSwitcher\` and see the family.
- \`requiredRole\` gating is unchanged (still \`['admin', 'super_admin', 'church_admin', 'priest']\`); this PR only changes the chrome around the page.

## Test plan
- [ ] super_admin opens \`/apps/records/interactive-reports\` → FullLayout (sidebar visible).
- [ ] admin opens it → FullLayout.
- [ ] priest (\`frjames@ssppoc.org\`) opens it → ChurchPortalLayout (HpHeader + container + SiteFooter; **no sidebar**).
- [ ] church_admin opens it → ChurchPortalLayout.
- [ ] Portal Hub "Interactive Reports" tile → lands on the page in ChurchPortalLayout for non-admins.
- [ ] Deep link to \`/apps/records/interactive-reports/:reportId\` respects role + layout the same way.
- [ ] Roles outside the allow-list still get the \`ProtectedRoute\` redirect.

## Out of scope (flagged for follow-up)
The same problem likely applies to other \`/apps/...\` pages that non-admins can reach (certificates, etc.). This PR fixes only the reported page; if you'd like a sweep, ping me and I'll audit the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)