### PR TITLE
DEPLOYMENT-FINGERPRINT-BAR: super_admin top-of-shell build identifier (OM side)

### DIFF
--- a/front-end/public/version.json
+++ b/front-end/public/version.json
@@ -1,0 +1,8 @@
+{
+  "app": "om",
+  "target": "frontend",
+  "gitSha": "dev",
+  "gitBranch": "dev",
+  "builtAt": null,
+  "buildHost": null
+}

--- a/front-end/src/components/admin/DeploymentFingerprintBar.tsx
+++ b/front-end/src/components/admin/DeploymentFingerprintBar.tsx
@@ -1,0 +1,123 @@
+import { FC, useMemo } from 'react';
+import { Box, Chip, Stack, Tooltip, Typography, useTheme, alpha } from '@mui/material';
+import { useAuth } from '@/context/AuthContext';
+import useDeploymentFingerprint, { type BuildFingerprint } from '@/hooks/useDeploymentFingerprint';
+
+/**
+ * DeploymentFingerprintBar — thin, compact strip at the top of the OM admin
+ * shell. Visible to super_admin only. Shows what FE + BE builds are
+ * currently running so a developer can decide whether OM needs another
+ * frontend or backend deploy after a merge.
+ *
+ * NOT a "is this stale vs main" indicator — Tier 2 (polling main) is
+ * intentionally out of scope for this iteration.
+ */
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return 'no time';
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return 'no time';
+  const diffMs = Date.now() - t;
+  const sec = Math.round(diffMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 48) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  return `${day}d ago`;
+}
+
+interface BuildVersionChipProps {
+  label: string;
+  fingerprint: BuildFingerprint | null;
+  showTime?: boolean;
+}
+
+const BuildVersionChip: FC<BuildVersionChipProps> = ({ label, fingerprint, showTime }) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+  const fg = isDark ? theme.palette.grey[300] : theme.palette.grey[800];
+  const bg = isDark ? alpha(theme.palette.grey[700], 0.4) : alpha(theme.palette.grey[300], 0.5);
+
+  const value = showTime
+    ? formatRelative(fingerprint?.builtAt ?? null)
+    : fingerprint?.gitSha?.slice(0, 7) || 'unknown';
+
+  const tooltipLines = fingerprint
+    ? [
+        `${fingerprint.app}/${fingerprint.target}`,
+        `commit: ${fingerprint.gitSha}`,
+        `branch: ${fingerprint.gitBranch}`,
+        fingerprint.builtAt ? `built: ${fingerprint.builtAt}` : 'built: —',
+        fingerprint.buildHost ? `host: ${fingerprint.buildHost}` : '',
+      ].filter(Boolean).join('\n')
+    : `${label} unavailable — version.json missing or fetch failed`;
+
+  return (
+    <Tooltip title={<pre style={{ margin: 0, fontFamily: 'monospace', fontSize: 11 }}>{tooltipLines}</pre>} arrow>
+      <Chip
+        size="small"
+        label={
+          <Box component="span" sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
+            <Box component="span" sx={{ opacity: 0.7, mr: 0.5 }}>{label}</Box>
+            <Box component="span" sx={{ fontWeight: 600 }}>{value}</Box>
+          </Box>
+        }
+        sx={{
+          height: 20,
+          color: fg,
+          bgcolor: bg,
+          border: `1px solid ${alpha(fg, 0.15)}`,
+          '& .MuiChip-label': { px: 1, py: 0 },
+        }}
+      />
+    </Tooltip>
+  );
+};
+
+const DeploymentFingerprintBar: FC = () => {
+  const { user, isSuperAdmin } = useAuth();
+  const enabled = !!user && isSuperAdmin();
+  const { frontend, backend, loading } = useDeploymentFingerprint(enabled);
+
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+
+  const barStyles = useMemo(
+    () => ({
+      bgcolor: isDark ? alpha('#000', 0.35) : alpha(theme.palette.grey[100], 0.85),
+      borderBottom: `1px solid ${isDark ? alpha('#fff', 0.06) : alpha('#000', 0.06)}`,
+      px: 2,
+      py: 0.5,
+      display: 'flex',
+      alignItems: 'center',
+      gap: 1,
+      minHeight: 28,
+      backdropFilter: 'blur(6px)',
+      position: 'sticky' as const,
+      top: 0,
+      zIndex: theme.zIndex.appBar + 1,
+    }),
+    [theme, isDark],
+  );
+
+  if (!enabled) return null;
+  if (loading) return null;
+
+  return (
+    <Box sx={barStyles} role="status" aria-label="Deployment fingerprint (super_admin)">
+      <Typography variant="caption" sx={{ fontWeight: 700, fontSize: '0.65rem', letterSpacing: '0.5px', textTransform: 'uppercase', color: 'text.secondary', mr: 0.5 }}>
+        OM build
+      </Typography>
+      <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap">
+        <BuildVersionChip label="fe" fingerprint={frontend} />
+        <BuildVersionChip label="fe@" fingerprint={frontend} showTime />
+        <BuildVersionChip label="be" fingerprint={backend} />
+        <BuildVersionChip label="be@" fingerprint={backend} showTime />
+      </Stack>
+    </Box>
+  );
+};
+
+export default DeploymentFingerprintBar;

--- a/front-end/src/hooks/useDeploymentFingerprint.ts
+++ b/front-end/src/hooks/useDeploymentFingerprint.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useDeploymentFingerprint — fetch the running build's identity for the
+ * super_admin DeploymentFingerprintBar. Compares two sources:
+ *
+ *   - frontend: GET /version.json   (static file written into dist/ at build)
+ *   - backend:  GET /api/admin/deployment-fingerprint   (super_admin route)
+ *
+ * Returns { frontend, backend, loading } — fields are null while loading and
+ * also null when fetches fail. The bar renders 'unknown' chips in that case
+ * rather than blocking the whole page.
+ */
+
+export interface BuildFingerprint {
+  app: 'om' | 'omai' | string;
+  target: 'frontend' | 'backend' | string;
+  gitSha: string;
+  gitBranch: string;
+  builtAt: string | null;
+  buildHost: string | null;
+}
+
+export interface DeploymentFingerprintState {
+  frontend: BuildFingerprint | null;
+  backend: BuildFingerprint | null;
+  loading: boolean;
+}
+
+const FE_URL = '/version.json';
+const BE_URL = '/api/admin/deployment-fingerprint';
+
+export default function useDeploymentFingerprint(enabled: boolean): DeploymentFingerprintState {
+  const [state, setState] = useState<DeploymentFingerprintState>({
+    frontend: null,
+    backend: null,
+    loading: enabled,
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      setState({ frontend: null, backend: null, loading: false });
+      return;
+    }
+    let cancelled = false;
+    Promise.allSettled([
+      fetch(FE_URL, { cache: 'no-store', credentials: 'same-origin' }).then(r => (r.ok ? r.json() : null)),
+      fetch(BE_URL, { cache: 'no-store', credentials: 'same-origin' }).then(r => (r.ok ? r.json() : null)),
+    ]).then(([fe, be]) => {
+      if (cancelled) return;
+      const feData = fe.status === 'fulfilled' && fe.value ? (fe.value as BuildFingerprint) : null;
+      const beData =
+        be.status === 'fulfilled' && be.value && (be.value as any).fingerprint
+          ? ((be.value as any).fingerprint as BuildFingerprint)
+          : null;
+      setState({ frontend: feData, backend: beData, loading: false });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return state;
+}

--- a/front-end/src/layouts/full/FullLayout.tsx
+++ b/front-end/src/layouts/full/FullLayout.tsx
@@ -8,6 +8,7 @@ import ScrollToTop from '@/shared/ui/ScrollToTop';
 import { CustomizerContext } from '@/context/CustomizerContext';
 import config from '@/context/config';
 import ImpersonationBanner from '@/components/ImpersonationBanner';
+import DeploymentFingerprintBar from '@/components/admin/DeploymentFingerprintBar';
 import { getPageTitle } from '@/config/pageTitles';
 import { OmAssistant } from '@/components/OmAssistant';
 import WorkSessionPrompt from '@/components/layout/WorkSessionPrompt';
@@ -62,6 +63,10 @@ const FullLayout: FC = () => {
             }),
           }}
         >
+          {/* ------------------------------------------- */}
+          {/* Deployment Fingerprint Bar (super_admin only) */}
+          {/* ------------------------------------------- */}
+          <DeploymentFingerprintBar />
           {/* ------------------------------------------- */}
           {/* Impersonation Banner (pushes content down when active) */}
           {/* ------------------------------------------- */}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -666,6 +666,11 @@ const buildStatusRouter = require('./routes/admin/buildStatus');
 app.use('/api/admin', buildStatusRouter);
 console.log('✅ [Server] Mounted /api/admin/build-status route');
 
+// Deployment fingerprint (super_admin only) — used by DeploymentFingerprintBar
+const deploymentFingerprintRouter = require('./routes/admin/deployment-fingerprint');
+app.use('/api/admin', deploymentFingerprintRouter);
+console.log('✅ [Server] Mounted /api/admin/deployment-fingerprint route');
+
 const buildApprovalRouter = require('./routes/admin/build-approval');
 app.use('/api/admin/build-approval', buildApprovalRouter);
 console.log('✅ [Server] Mounted /api/admin/build-approval route');

--- a/server/src/routes/admin/deployment-fingerprint.js
+++ b/server/src/routes/admin/deployment-fingerprint.js
@@ -1,0 +1,57 @@
+/**
+ * Deployment Fingerprint API
+ * GET /api/admin/deployment-fingerprint
+ *
+ * Returns the running OM backend's build fingerprint (gitSha, builtAt, etc.)
+ * so the super_admin DeploymentFingerprintBar can show what code is actually
+ * deployed. Pairs with /version.json (frontend), which is a static file
+ * stamped by the same deploy script.
+ *
+ * super_admin only — this is a developer reminder, not user-facing data.
+ */
+
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const router = express.Router();
+const { requireAuth, requireRole } = require('../../middleware/auth');
+
+const requireSuperAdmin = requireRole(['super_admin']);
+
+// version.json is written by om-deploy.sh into <server>/version.json. The
+// compiled file lives at server/dist/routes/admin/deployment-fingerprint.js,
+// so '../../../version.json' resolves to server/version.json.
+const VERSION_FILE = path.resolve(__dirname, '../../../version.json');
+
+router.get('/deployment-fingerprint', requireAuth, requireSuperAdmin, (req, res) => {
+  let fingerprint = {
+    app: 'om',
+    target: 'backend',
+    gitSha: 'unknown',
+    gitBranch: 'unknown',
+    builtAt: null,
+    buildHost: null,
+  };
+
+  try {
+    if (fs.existsSync(VERSION_FILE)) {
+      const raw = fs.readFileSync(VERSION_FILE, 'utf8');
+      const parsed = JSON.parse(raw);
+      fingerprint = {
+        app: parsed.app || 'om',
+        target: parsed.target || 'backend',
+        gitSha: parsed.gitSha || 'unknown',
+        gitBranch: parsed.gitBranch || 'unknown',
+        builtAt: parsed.builtAt || null,
+        buildHost: parsed.buildHost || null,
+      };
+    }
+  } catch (_err) {
+    // Leave defaults — no sensitive info to leak; the bar will show 'unknown'.
+  }
+
+  res.set('Cache-Control', 'no-store');
+  return res.json({ success: true, fingerprint });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
Adds a compact **Deployment Fingerprint Bar** at the top of the OM admin shell so super_admin developers can see at a glance which OM frontend + OM backend builds are currently running. Helps decide whether OM needs another FE or BE rebuild after merging PRs.

**Visible to super_admin only.** Non-super_admin users see nothing. Public and church-portal pages are unaffected (the bar only mounts inside \`FullLayout\`, which super_admin gating tests confirm — non-super_admin users land in \`ChurchPortalLayout\` per existing routing rules).

This is **Tier 1** — "what's running". A separate Tier 2 stale-vs-main indicator (polling cron + comparison) was intentionally not built; not needed for the workflow you described.

## Pieces in this PR
- \`server/src/routes/admin/deployment-fingerprint.js\` — new \`GET /api/admin/deployment-fingerprint\` (super_admin gated). Reads \`server/version.json\` stamped by \`om-deploy.sh\` at deploy. Returns \`{ app, target, gitSha, gitBranch, builtAt, buildHost }\`. Falls back to "unknown" rather than 500ing if the file is missing.
- \`server/src/index.ts\` — mount the router on \`/api/admin\`.
- \`front-end/src/hooks/useDeploymentFingerprint.ts\` — fetches both \`/version.json\` (static, frontend) and \`/api/admin/deployment-fingerprint\` (auth, backend) in parallel via \`Promise.allSettled\`.
- \`front-end/src/components/admin/DeploymentFingerprintBar.tsx\` — thin sticky strip; 4 chips (FE-SHA, FE-time, BE-SHA, BE-time) using monospace; tooltips show full SHA + branch + buildHost; light/dark clean (uses MUI palette).
- \`front-end/src/layouts/full/FullLayout.tsx\` — mounts above \`ImpersonationBanner\`.
- \`front-end/public/version.json\` — placeholder so dev/local builds show \`dev/dev\`; \`om-deploy.sh\` overwrites this with real values before the Vite build.

## Pairs with
- **omai-ops** PR (separate) — adds the \`stamp_version_json\` deploy helper and calls it before each FE/BE build for both repos.
- **OMAI** PR (separate, against \`nexty1982/omai\`) — adds the same bar to the OMAI shell and a sibling \`/api/platform/deployment-fingerprint\` endpoint.

**Merge order:** omai-ops first (so the deploy helper exists), then this PR + the OMAI PR. Without the omai-ops change, the bar will just show "unknown" everywhere — the bar is harmless (won't break anything) without the deploy support.

## Test plan
- [ ] Sign in as super_admin → load any \`/dashboards/...\` or \`/apps/...\` page under \`FullLayout\`. Bar appears at top with 4 chips.
- [ ] Sign in as non-super_admin (priest/church_admin/etc.) → no bar (non-super_admin users render in \`ChurchPortalLayout\`, but verify also that role check inside the bar component would suppress it).
- [ ] Hover a chip → tooltip shows full SHA, branch, builtAt, host.
- [ ] Light mode + dark mode → bar styling readable in both.
- [ ] After OM frontend deploy → \`fe\` chip SHA + age update.
- [ ] After OM backend deploy → \`be\` chip SHA + age update.
- [ ] Without omai-ops merged: bar shows \`fe: dev\` (placeholder) and \`be: unknown\` (file missing) — both harmless.

## Out of scope (Tier 2 follow-up)
- Polling main for stale-vs-fresh diff.
- Comparing FE-SHA vs BE-SHA to flag mismatched deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)