### PR TITLE
GITIGNORE-SERVER-VERSION-JSON: ignore server/version.json (deploy build artifact)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,10 @@ front-end/public/index.html
 front-end/dist-latest/
 front-end/dist-stable/
 front-end/dist-backup/
+# om-deploy.sh's stamp_version_json writes this each backend deploy — mirrors
+# the OMAI gitignore for _runtime/server/version.json. Without it, the next
+# deploy would see the file as untracked.
+server/version.json
 front-end/dupes/
 
 # --- Test / scratch data ---


### PR DESCRIPTION
## Summary
\`om-deploy.sh\`'s \`stamp_version_json\` writes \`server/version.json\` each backend deploy. It's a build-time artifact — not source — and should not be tracked. Without this entry the file shows up as untracked on every fresh deploy. OM's branch-enforce path happens to be permissive enough today that it skates by, but it's a latent timebomb (any agent-mode / CI run that uses stricter dirty-tree checks would bail — that's what just bit the OMAI deploy).

Mirrors OMAI's \`_runtime/server/version.json\` gitignore added in [nexty1982/omai#156](https://github.com/nexty1982/omai/pull/156).

## Test plan
- [ ] After merge, \`git check-ignore -v server/version.json\` reports the new \`.gitignore\` rule.
- [ ] \`om-deploy.sh\` runs cleanly (already does today; this PR just removes the latent risk).
- [ ] No change to the contents of \`server/version.json\` or to the \`/api/admin/deployment-fingerprint\` endpoint behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)