### PR TITLE
FIX-CONVERSATION-LOG-STRAY-BRACE: remove unmatched }; that broke tsc parse (closes #882)

### DIFF
--- a/front-end/src/features/devel-tools/conversation-log/ConversationLogPage.tsx
+++ b/front-end/src/features/devel-tools/conversation-log/ConversationLogPage.tsx
@@ -729,8 +729,6 @@ const ConversationLogPage: React.FC = () => {
     );
   };
 
-  };
-
   return (
     <Box ref={topRef} sx={{ p: 3 }}>
       {/* Header */}


### PR DESCRIPTION
Closes #882.

## Summary
\`ConversationLogPage.tsx\` had a stray \`};\` at **line 732**, sitting between the close of \`highlightQuery\` (line 730) and the component's \`return (...)\` (line 734). Likely left over from a refactor that removed an inner block.

The effect: the component's outer \`};\` at line 907 became unreachable to the parser (depth was already at 0), so tsc reported \`TS1128 "Declaration or statement expected"\`. That single syntax error caused tsc to **abort before type-checking**, hiding the rest of the codebase's type errors and weakening every PR's type-check pass — exactly what #882 was about.

## Diff
\`\`\`diff
       </>
     );
   };

-  };
-
   return (
\`\`\`

## ⚠ Heads-up (out of scope, but newly visible)
With the syntax error gone, tsc can complete a full pass for the first time. It now surfaces **~2234 pre-existing type errors across ~577 files** — those were ALREADY THERE, just hidden by tsc bailing early. None are caused by this change.

The errors fall into a few buckets:
- \`@/api/utils/axiosInstance\` (alias drift / missing module) — many files.
- Visual-testing files referring to \`DiffResult\` / \`createCanvas\` / etc. that no longer exist.
- Tab component prop-type drift (e.g., \`ConversationsTabProps\`, \`TasksTabProps\` shape changed but parents still pass old shape).
- Implicit-any in a few small spots.

These are real type-debt entries to triage in follow-up work; **filing them is out of scope here** because (a) it would balloon this PR way beyond the surgical fix #882 asked for, and (b) we want to land the syntax fix first so future PRs can at least see new type errors against a baseline.

## Test plan
- [x] \`npx tsc --noEmit\` against the single file → 0 errors (was 1: TS1128).
- [x] \`npx tsc --noEmit -p tsconfig.json\` against the whole frontend → completes a full pass instead of aborting at line 907.
- [ ] After merge, future PRs that touch unrelated files should no longer have TS1128 in the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)