### PR TITLE
[OMOD-1447] Privacy + Terms real legal copy (Effective 2026-05-06)

### DIFF
--- a/front-end/src/features/pages/frontend-pages/Privacy.tsx
+++ b/front-end/src/features/pages/frontend-pages/Privacy.tsx
@@ -1,8 +1,15 @@
 import { HeroSection } from '@/components/frontend-pages/shared/sections';
-import EditableText from '@/components/frontend-pages/shared/EditableText';
 import PageContainer from '@/shared/ui/PageContainer';
 import PublicSeo from '@/components/seo/PublicSeo';
 import { useLanguage } from '@/context/LanguageContext';
+
+// Legal copy below is intentionally NOT i18n-driven. Translating a privacy
+// policy requires per-jurisdiction legal review; until that exists the
+// English text here is the source of truth. Hero badge/title/subtitle stay
+// in i18n because they're presentational.
+const EFFECTIVE_DATE = 'May 6, 2026';
+const COMPANY = 'Orthodox Metrics LLC';
+const CONTACT_EMAIL = 'info@orthodoxmetrics.com';
 
 const Privacy = () => {
   const { t } = useLanguage();
@@ -11,7 +18,7 @@ const Privacy = () => {
     <PageContainer title="Privacy Policy" description="Orthodox Metrics privacy policy">
       <PublicSeo
         title="Privacy Policy"
-        description="How Orthodox Metrics handles parish data, sacramental records, accounts, and analytics."
+        description="Privacy Policy for Orthodox Metrics — what we collect, how we use it, payment processing, church/member data, sharing, retention, and your choices."
         path="/privacy"
       />
       <HeroSection
@@ -22,31 +29,159 @@ const Privacy = () => {
       />
 
       <section className="py-20 om-section-base">
-        <div className="max-w-3xl mx-auto px-6">
-          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-6 mb-8">
-            <EditableText contentKey="privacy.draft_notice" as="p" className="font-['Inter'] text-[15px] text-amber-900 dark:text-amber-200 leading-relaxed" multiline>
-              {t('privacy.draft_notice')}
-            </EditableText>
-          </div>
-
-          <EditableText contentKey="privacy.body_p1" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
-            {t('privacy.body_p1')}
-          </EditableText>
-          <EditableText contentKey="privacy.body_p2" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
-            {t('privacy.body_p2')}
-          </EditableText>
-
-          <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mt-8">
-            {t('privacy.contact_prefix')}{' '}
-            <a href="mailto:legal@orthodoxmetrics.com" className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline">
-              legal@orthodoxmetrics.com
-            </a>
-            .
+        <div className="max-w-3xl mx-auto px-6 om-legal-prose">
+          <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-2">
+            <strong>Effective Date:</strong> {EFFECTIVE_DATE}
           </p>
+          <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-2">
+            <strong>Website:</strong> https://orthodoxmetrics.com
+          </p>
+          <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-8">
+            <strong>Company:</strong> {COMPANY}
+          </p>
+
+          <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-10">
+            Orthodox Metrics respects your privacy. This Privacy Policy explains how we collect,
+            use, store, and protect information when you use our website, software platform, and
+            related services.
+          </p>
+
+          <Section title="1. Information We Collect">
+            <p>We may collect the following types of information:</p>
+            <ul>
+              <li>Name, email address, phone number, organization name, and account details</li>
+              <li>Church, parish, clergy, administrator, and member information entered into the platform</li>
+              <li>Sacramental, administrative, certificate, record, OCR, and document-processing data submitted by authorized users</li>
+              <li>Billing and subscription information</li>
+              <li>Technical data such as IP address, browser type, device information, log data, and usage activity</li>
+              <li>Communications you send to us through forms, email, support requests, or account interactions</li>
+            </ul>
+          </Section>
+
+          <Section title="2. Payment Information">
+            <p>
+              We use Stripe or another third-party payment processor to process payments. We do
+              not intentionally store full credit card numbers on our own servers. Payment
+              information is handled by our payment processor according to its own privacy and
+              security practices.
+            </p>
+          </Section>
+
+          <Section title="3. How We Use Information">
+            <p>We use collected information to:</p>
+            <ul>
+              <li>Provide and operate the Orthodox Metrics platform</li>
+              <li>Manage user accounts, churches, subscriptions, billing, and support</li>
+              <li>Process and organize church records, certificates, documents, and administrative workflows</li>
+              <li>Improve security, reliability, performance, and user experience</li>
+              <li>Communicate with users about accounts, support, updates, and service notices</li>
+              <li>Comply with legal, security, tax, and operational obligations</li>
+            </ul>
+          </Section>
+
+          <Section title="4. Church and Member Data">
+            <p>
+              Churches and authorized administrators are responsible for the accuracy,
+              authorization, and lawful use of data they enter into Orthodox Metrics. We process
+              this information only to provide the platform and related services.
+            </p>
+          </Section>
+
+          <Section title="5. Sharing of Information">
+            <p>We do not sell personal information.</p>
+            <p>We may share information with:</p>
+            <ul>
+              <li>Payment processors</li>
+              <li>Hosting, infrastructure, email, analytics, and support providers</li>
+              <li>Authorized church administrators or account users</li>
+              <li>Legal, regulatory, or security authorities when required</li>
+              <li>Successors in the event of a merger, acquisition, restructuring, or sale of assets</li>
+            </ul>
+          </Section>
+
+          <Section title="6. Cookies and Analytics">
+            <p>
+              We may use cookies, session storage, analytics tools, and similar technologies to
+              keep users signed in, improve the website, understand platform usage, and maintain
+              security.
+            </p>
+          </Section>
+
+          <Section title="7. Data Security">
+            <p>
+              We use reasonable administrative, technical, and organizational safeguards to
+              protect information. No system is completely secure, and we cannot guarantee
+              absolute security.
+            </p>
+          </Section>
+
+          <Section title="8. Data Retention">
+            <p>
+              We retain information for as long as needed to provide services, comply with legal
+              obligations, resolve disputes, maintain backups, and enforce agreements. Churches
+              may request deletion or export of their data subject to account status, legal
+              requirements, and technical limitations.
+            </p>
+          </Section>
+
+          <Section title="9. Your Choices">
+            <p>
+              You may contact us to request access, correction, export, or deletion of personal
+              information, where legally and technically applicable.
+            </p>
+          </Section>
+
+          <Section title="10. Children’s Privacy">
+            <p>
+              Orthodox Metrics is intended for use by churches, clergy, administrators, and
+              authorized adult users. We do not knowingly collect information directly from
+              children under 13 without appropriate authorization.
+            </p>
+          </Section>
+
+          <Section title="11. Third-Party Links">
+            <p>
+              Our website or platform may link to third-party websites or services. We are not
+              responsible for the privacy practices of those third parties.
+            </p>
+          </Section>
+
+          <Section title="12. Changes to This Policy">
+            <p>
+              We may update this Privacy Policy from time to time. Updated versions will be
+              posted on this page with a revised effective date.
+            </p>
+          </Section>
+
+          <Section title="13. Contact">
+            <p>For privacy questions, contact:</p>
+            <address className="not-italic">
+              {COMPANY}<br />
+              48 Limerick Ln<br />
+              Email:{' '}
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline"
+              >
+                {CONTACT_EMAIL}
+              </a>
+            </address>
+          </Section>
         </div>
       </section>
     </PageContainer>
   );
 };
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-10">
+      <h2 className="font-['Georgia'] text-2xl text-[#2d1b4e] dark:text-white mb-3">{title}</h2>
+      <div className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed space-y-3 [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:space-y-1 [&_ul>li]:marker:text-[#d4af37]">
+        {children}
+      </div>
+    </section>
+  );
+}
 
 export default Privacy;

--- a/front-end/src/features/pages/frontend-pages/Terms.tsx
+++ b/front-end/src/features/pages/frontend-pages/Terms.tsx
@@ -1,8 +1,15 @@
 import { HeroSection } from '@/components/frontend-pages/shared/sections';
-import EditableText from '@/components/frontend-pages/shared/EditableText';
 import PageContainer from '@/shared/ui/PageContainer';
 import PublicSeo from '@/components/seo/PublicSeo';
 import { useLanguage } from '@/context/LanguageContext';
+
+// Legal copy below is intentionally NOT i18n-driven. Translating terms of
+// service requires per-jurisdiction legal review; until that exists the
+// English text here is the source of truth.
+const EFFECTIVE_DATE = 'May 6, 2026';
+const COMPANY = 'Orthodox Metrics LLC';
+const CONTACT_EMAIL = 'info@orthodoxmetrics.com';
+const GOVERNING_STATE = 'New Jersey';
 
 const Terms = () => {
   const { t } = useLanguage();
@@ -11,7 +18,7 @@ const Terms = () => {
     <PageContainer title="Terms of Service" description="Orthodox Metrics terms of service">
       <PublicSeo
         title="Terms of Service"
-        description="Terms of use for Orthodox Metrics — parish accounts, records storage, and platform responsibilities."
+        description="Terms of Service for Orthodox Metrics — accounts, customer data, billing, acceptable use, third parties, IP, liability, and governing law."
         path="/terms"
       />
       <HeroSection
@@ -22,31 +29,224 @@ const Terms = () => {
       />
 
       <section className="py-20 om-section-base">
-        <div className="max-w-3xl mx-auto px-6">
-          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-6 mb-8">
-            <EditableText contentKey="terms.draft_notice" as="p" className="font-['Inter'] text-[15px] text-amber-900 dark:text-amber-200 leading-relaxed" multiline>
-              {t('terms.draft_notice')}
-            </EditableText>
-          </div>
-
-          <EditableText contentKey="terms.body_p1" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
-            {t('terms.body_p1')}
-          </EditableText>
-          <EditableText contentKey="terms.body_p2" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
-            {t('terms.body_p2')}
-          </EditableText>
-
-          <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mt-8">
-            {t('terms.contact_prefix')}{' '}
-            <a href="mailto:legal@orthodoxmetrics.com" className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline">
-              legal@orthodoxmetrics.com
-            </a>
-            .
+        <div className="max-w-3xl mx-auto px-6 om-legal-prose">
+          <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-2">
+            <strong>Effective Date:</strong> {EFFECTIVE_DATE}
           </p>
+          <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-2">
+            <strong>Website:</strong> https://orthodoxmetrics.com
+          </p>
+          <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-8">
+            <strong>Company:</strong> {COMPANY}
+          </p>
+
+          <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-10">
+            These Terms of Service govern your use of Orthodox Metrics, including our website,
+            software platform, tools, and related services.
+          </p>
+
+          <Section title="1. Acceptance of Terms">
+            <p>
+              By accessing or using Orthodox Metrics, you agree to these Terms. If you do not
+              agree, do not use the service.
+            </p>
+          </Section>
+
+          <Section title="2. Description of Service">
+            <p>
+              Orthodox Metrics provides software tools for Orthodox churches and church
+              administrators, including parish records management, sacramental records,
+              certificate tools, OCR-assisted document processing, administrative workflows,
+              reporting, and related operational features.
+            </p>
+          </Section>
+
+          <Section title="3. Accounts and Authorized Users">
+            <p>
+              You are responsible for maintaining the confidentiality of your account
+              credentials. You are responsible for all activity under your account.
+            </p>
+            <p>
+              Churches and organizations are responsible for determining which users are
+              authorized to access their data.
+            </p>
+          </Section>
+
+          <Section title="4. Customer Data">
+            <p>You retain ownership of the data you submit to Orthodox Metrics.</p>
+            <p>
+              You grant us permission to host, process, store, transmit, and display your data
+              only as needed to provide, secure, maintain, and improve the service.
+            </p>
+            <p>
+              You are responsible for ensuring that you have the right to submit and manage any
+              church, parish, clergy, member, sacramental, document, or administrative data
+              entered into the platform.
+            </p>
+          </Section>
+
+          <Section title="5. Accuracy of Records">
+            <p>
+              Orthodox Metrics provides software tools to assist with recordkeeping and
+              administration. We do not guarantee that records, certificates, OCR output,
+              reports, or generated documents are legally, ecclesiastically, or administratively
+              correct.
+            </p>
+            <p>
+              You are responsible for reviewing and verifying all records, certificates,
+              reports, and documents before relying on them.
+            </p>
+          </Section>
+
+          <Section title="6. Subscriptions, Billing, and Payments">
+            <p>
+              Some services may require paid subscriptions or fees. By purchasing a
+              subscription, you authorize us and our payment processor to charge applicable
+              fees.
+            </p>
+            <p>
+              Fees, billing cycles, cancellation terms, and subscription details may be shown
+              during checkout or within your account.
+            </p>
+            <p>
+              Unless otherwise stated, fees are non-refundable except where required by law or
+              agreed in writing.
+            </p>
+          </Section>
+
+          <Section title="7. Acceptable Use">
+            <p>You agree not to:</p>
+            <ul>
+              <li>Use the service for unlawful purposes</li>
+              <li>Access data without authorization</li>
+              <li>Attempt to disrupt, damage, reverse engineer, or compromise the platform</li>
+              <li>Upload malicious code or harmful content</li>
+              <li>Misrepresent your identity or authority</li>
+              <li>Use the service to violate privacy, security, or data protection obligations</li>
+            </ul>
+          </Section>
+
+          <Section title="8. Service Availability">
+            <p>
+              We aim to provide reliable service, but we do not guarantee uninterrupted
+              availability. We may modify, suspend, or discontinue parts of the service as
+              needed for maintenance, security, upgrades, or operational reasons.
+            </p>
+          </Section>
+
+          <Section title="9. Third-Party Services">
+            <p>
+              Orthodox Metrics may integrate with third-party services such as payment
+              processors, email providers, hosting providers, analytics tools, or other
+              software services. Your use of those services may be subject to their own terms
+              and policies.
+            </p>
+          </Section>
+
+          <Section title="10. Intellectual Property">
+            <p>
+              Orthodox Metrics, including its software, design, branding, workflows,
+              documentation, and platform features, is owned by {COMPANY} or its licensors.
+            </p>
+            <p>
+              You may not copy, modify, distribute, resell, or create derivative works from the
+              platform except as expressly permitted.
+            </p>
+          </Section>
+
+          <Section title="11. Confidentiality">
+            <p>
+              Users may have access to sensitive church, administrative, or member information.
+              You agree to use such information only for authorized purposes and to protect it
+              from unauthorized access or disclosure.
+            </p>
+          </Section>
+
+          <Section title="12. Termination">
+            <p>
+              We may suspend or terminate access if you violate these Terms, fail to pay
+              required fees, misuse the platform, create security risk, or use the service
+              unlawfully.
+            </p>
+            <p>
+              You may stop using the service at any time. Data export or deletion may be subject
+              to account status, technical limits, backup retention, and legal obligations.
+            </p>
+          </Section>
+
+          <Section title="13. Disclaimer of Warranties">
+            <p>
+              The service is provided “as is” and “as available.” To the maximum extent
+              permitted by law, we disclaim warranties of merchantability, fitness for a
+              particular purpose, non-infringement, accuracy, availability, and error-free
+              operation.
+            </p>
+          </Section>
+
+          <Section title="14. Limitation of Liability">
+            <p>
+              To the maximum extent permitted by law, {COMPANY} will not be liable for indirect,
+              incidental, special, consequential, punitive, or lost-profit damages.
+            </p>
+            <p>
+              Our total liability for any claim related to the service will not exceed the
+              amount paid by you to us for the service during the three months before the claim
+              arose.
+            </p>
+          </Section>
+
+          <Section title="15. Indemnification">
+            <p>
+              You agree to indemnify and hold harmless {COMPANY} from claims, damages,
+              liabilities, and expenses arising from your use of the service, your data, your
+              violation of these Terms, or your violation of applicable law or third-party
+              rights.
+            </p>
+          </Section>
+
+          <Section title="16. Governing Law">
+            <p>
+              These Terms are governed by the laws of the State of {GOVERNING_STATE}, without
+              regard to conflict-of-law rules.
+            </p>
+          </Section>
+
+          <Section title="17. Changes to Terms">
+            <p>
+              We may update these Terms from time to time. Updated versions will be posted on
+              this page with a revised effective date.
+            </p>
+          </Section>
+
+          <Section title="18. Contact">
+            <p>For questions about these Terms, contact:</p>
+            <address className="not-italic">
+              {COMPANY}<br />
+              48 Limerick Ln, Phillipsburg NJ 08865<br />
+              Email:{' '}
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline"
+              >
+                {CONTACT_EMAIL}
+              </a>
+            </address>
+          </Section>
         </div>
       </section>
     </PageContainer>
   );
 };
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-10">
+      <h2 className="font-['Georgia'] text-2xl text-[#2d1b4e] dark:text-white mb-3">{title}</h2>
+      <div className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed space-y-3 [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:space-y-1 [&_ul>li]:marker:text-[#d4af37]">
+        {children}
+      </div>
+    </section>
+  );
+}
 
 export default Terms;


### PR DESCRIPTION
Closes #893. Follow-up to #892 (OMOD-1446, already merged).

Replaces the placeholder two-paragraph stubs and the orange "draft notice" banners on `/privacy` and `/terms` with the operator-supplied legal text.

## What's in here

- **Privacy** — 13 sections covering: information we collect, payment processing (Stripe + third parties), how we use info, church/member data, sharing, cookies/analytics, data security, retention, your choices, children's privacy, third-party links, change policy, and contact.
- **Terms** — 18 sections covering: acceptance, description, accounts, customer data, accuracy disclaimer, billing, acceptable use, availability, third parties, IP, confidentiality, termination, warranty disclaimer, liability cap (3-month fee), indemnification, governing law (NJ), change policy, and contact.

## Decisions encoded

- Effective date: **May 6, 2026**.
- Company: **Orthodox Metrics LLC**.
- Contact email: **info@orthodoxmetrics.com** (replaces the prior stub's `legal@orthodoxmetrics.com`, matching the operator-supplied text).
- Contact address: **48 Limerick Ln, Phillipsburg NJ 08865**.
- Governing state (Terms §16): **New Jersey** — derived from the contact address. Operator placeholder `[State]` was filled in to avoid shipping `[State]` literal in production.
- `[Legal Company Name]` placeholder in Terms §10 / §14 / §15 → resolved to `Orthodox Metrics LLC` for consistency with the rest of the doc.

## Why hardcoded JSX, not i18n

Legal copy is intentionally hardcoded as JSX rather than driven through `t()`. Translating a privacy policy / terms of service requires per-jurisdiction legal review and is out of scope until that exists. Hero `badge` / `title` / `subtitle` remain i18n-driven (presentational only).

## Heading structure

Hero `<h1>` continues to come from `HeroSection`; section headings inside the body use `<h2>` so the document outline stays single-h1. PublicSeo descriptions tightened to reflect that these are now the official policy / terms, not drafts.

## Files changed

- `front-end/src/features/pages/frontend-pages/Privacy.tsx` — full rewrite (60% diff).
- `front-end/src/features/pages/frontend-pages/Terms.tsx` — full rewrite (61% diff).

## Test plan

- [ ] Build + deploy fe via `om-deploy.sh fe`.
- [ ] `curl -skI` /privacy and /terms — confirm 200 + id="root".
- [ ] Visual check: effective date 2026-05-06, no "draft" banner, all section headings render.
- [ ] Verify `info@orthodoxmetrics.com` mailto links open, no broken anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)