### PR TITLE
[OMOD-1449] Drop hero on Privacy/Terms + rewrite Security page

### DIFF
--- a/front-end/src/features/pages/frontend-pages/Privacy.tsx
+++ b/front-end/src/features/pages/frontend-pages/Privacy.tsx
@@ -1,19 +1,14 @@
-import { HeroSection } from '@/components/frontend-pages/shared/sections';
 import PageContainer from '@/shared/ui/PageContainer';
 import PublicSeo from '@/components/seo/PublicSeo';
-import { useLanguage } from '@/context/LanguageContext';
 
 // Legal copy below is intentionally NOT i18n-driven. Translating a privacy
 // policy requires per-jurisdiction legal review; until that exists the
-// English text here is the source of truth. Hero badge/title/subtitle stay
-// in i18n because they're presentational.
+// English text here is the source of truth.
 const EFFECTIVE_DATE = 'May 6, 2026';
 const COMPANY = 'Orthodox Metrics LLC';
 const CONTACT_EMAIL = 'info@orthodoxmetrics.com';
 
 const Privacy = () => {
-  const { t } = useLanguage();
-
   return (
     <PageContainer title="Privacy Policy" description="Orthodox Metrics privacy policy">
       <PublicSeo
@@ -21,15 +16,13 @@ const Privacy = () => {
         description="Privacy Policy for Orthodox Metrics — what we collect, how we use it, payment processing, church/member data, sharing, retention, and your choices."
         path="/privacy"
       />
-      <HeroSection
-        badge={t('privacy.hero_badge')}
-        title={t('privacy.hero_title')}
-        subtitle={t('privacy.hero_subtitle')}
-        editKeyPrefix="privacy.hero"
-      />
 
       <section className="py-20 om-section-base">
         <div className="max-w-3xl mx-auto px-6 om-legal-prose">
+          <h1 className="font-['Georgia'] text-4xl md:text-5xl text-[#2d1b4e] dark:text-white mb-8">
+            Privacy Policy
+          </h1>
+
           <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-2">
             <strong>Effective Date:</strong> {EFFECTIVE_DATE}
           </p>

--- a/front-end/src/features/pages/frontend-pages/Security.tsx
+++ b/front-end/src/features/pages/frontend-pages/Security.tsx
@@ -1,52 +1,198 @@
-import { HeroSection } from '@/components/frontend-pages/shared/sections';
-import EditableText from '@/components/frontend-pages/shared/EditableText';
 import PageContainer from '@/shared/ui/PageContainer';
 import PublicSeo from '@/components/seo/PublicSeo';
-import { useLanguage } from '@/context/LanguageContext';
+
+// Security copy below is intentionally NOT i18n-driven. The text describes
+// concrete operational practices and contact addresses that should not drift
+// across translations without explicit review.
+const EFFECTIVE_DATE = 'May 6, 2026';
+const CONTACT_EMAIL = 'info@orthodoxmetrics.com';
 
 const Security = () => {
-  const { t } = useLanguage();
-
   return (
     <PageContainer title="Security" description="Orthodox Metrics security and trust">
       <PublicSeo
         title="Security"
-        description="How Orthodox Metrics secures parish data — encrypted storage, role-based access, multi-tenant isolation, and operational practices."
+        description="How Orthodox Metrics secures parish data — secure access, encryption, payment security, data protection, backups, monitoring, and responsible disclosure."
         path="/security"
-      />
-      <HeroSection
-        badge={t('security.hero_badge')}
-        title={t('security.hero_title')}
-        subtitle={t('security.hero_subtitle')}
-        editKeyPrefix="security.hero"
       />
 
       <section className="py-20 om-section-base">
-        <div className="max-w-3xl mx-auto px-6">
-          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-6 mb-8">
-            <EditableText contentKey="security.draft_notice" as="p" className="font-['Inter'] text-[15px] text-amber-900 dark:text-amber-200 leading-relaxed" multiline>
-              {t('security.draft_notice')}
-            </EditableText>
-          </div>
+        <div className="max-w-3xl mx-auto px-6 om-legal-prose">
+          <h1 className="font-['Georgia'] text-4xl md:text-5xl text-[#2d1b4e] dark:text-white mb-8">
+            Security
+          </h1>
 
-          <EditableText contentKey="security.body_p1" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
-            {t('security.body_p1')}
-          </EditableText>
-          <EditableText contentKey="security.body_p2" as="p" className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-4" multiline>
-            {t('security.body_p2')}
-          </EditableText>
-
-          <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mt-8">
-            {t('security.contact_prefix')}{' '}
-            <a href="mailto:security@orthodoxmetrics.com" className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline">
-              security@orthodoxmetrics.com
-            </a>
-            .
+          <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-2">
+            <strong>Effective Date:</strong> {EFFECTIVE_DATE}
           </p>
+          <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-8">
+            <strong>Website:</strong> https://orthodoxmetrics.com
+          </p>
+
+          <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed mb-10">
+            Orthodox Metrics takes security seriously. Our platform is designed to help Orthodox
+            churches manage sensitive administrative, parish, sacramental, and document-related
+            data in a secure and responsible way.
+          </p>
+
+          <Section title="1. Secure Access">
+            <p>
+              Orthodox Metrics uses authenticated user accounts to control access to the platform.
+              Access to church records, administrative tools, and account data is limited to
+              authorized users based on their assigned permissions.
+            </p>
+            <p>
+              Users are responsible for protecting their login credentials and ensuring that only
+              authorized personnel access their church or organization account.
+            </p>
+          </Section>
+
+          <Section title="2. Encryption">
+            <p>
+              We use HTTPS/TLS encryption to protect data transmitted between your browser and our
+              platform.
+            </p>
+            <p>
+              Where appropriate, sensitive data is protected using industry-standard security
+              practices for storage, transmission, and access control.
+            </p>
+          </Section>
+
+          <Section title="3. Payment Security">
+            <p>
+              Payments are processed through Stripe or another trusted third-party payment
+              processor. Orthodox Metrics does not intentionally store full credit card numbers on
+              its own servers.
+            </p>
+            <p>
+              Payment information is handled by the payment processor according to its own
+              security and compliance standards.
+            </p>
+          </Section>
+
+          <Section title="4. Data Protection">
+            <p>
+              Orthodox Metrics applies reasonable administrative, technical, and organizational
+              safeguards to protect customer data from unauthorized access, misuse, loss, or
+              disclosure.
+            </p>
+            <p>These safeguards may include:</p>
+            <ul>
+              <li>Account authentication</li>
+              <li>Role-based access controls</li>
+              <li>Secure server configuration</li>
+              <li>Database access restrictions</li>
+              <li>Activity logging</li>
+              <li>Backup procedures</li>
+              <li>Software updates and maintenance</li>
+              <li>Separation of customer and administrative access where appropriate</li>
+            </ul>
+          </Section>
+
+          <Section title="5. Church and Member Records">
+            <p>
+              Churches may use Orthodox Metrics to manage sensitive records, including parish,
+              clergy, member, sacramental, certificate, OCR, and document-processing information.
+            </p>
+            <p>
+              Each church or organization is responsible for determining who is authorized to
+              access, edit, export, or manage its records.
+            </p>
+          </Section>
+
+          <Section title="6. Backups and Availability">
+            <p>
+              We use backup and recovery practices intended to reduce the risk of data loss and
+              support service continuity.
+            </p>
+            <p>
+              No system can guarantee uninterrupted operation, but we work to maintain a reliable
+              and secure platform.
+            </p>
+          </Section>
+
+          <Section title="7. Monitoring and Maintenance">
+            <p>
+              We may monitor platform activity, system logs, authentication activity, and
+              operational health to detect errors, abuse, unauthorized access attempts, or
+              security issues.
+            </p>
+            <p>
+              We also perform maintenance, updates, and infrastructure improvements to help keep
+              the platform secure and stable.
+            </p>
+          </Section>
+
+          <Section title="8. Third-Party Providers">
+            <p>
+              Orthodox Metrics may use trusted third-party providers for hosting, payment
+              processing, email delivery, analytics, infrastructure, monitoring, and support.
+            </p>
+            <p>
+              These providers are used only as needed to operate, secure, and improve the service.
+            </p>
+          </Section>
+
+          <Section title="9. Responsible Disclosure">
+            <p>
+              If you believe you have discovered a security issue, please contact us immediately.
+            </p>
+            <p>
+              Do not attempt to access, modify, delete, or disclose data that does not belong to
+              you. We ask that security reports be made responsibly and in good faith.
+            </p>
+            <p>Security reports can be sent to:</p>
+            <p>
+              <strong>Email:</strong>{' '}
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline"
+              >
+                {CONTACT_EMAIL}
+              </a>
+            </p>
+          </Section>
+
+          <Section title="10. No Absolute Guarantee">
+            <p>
+              While we take security seriously and use reasonable safeguards, no internet-based
+              service can be guaranteed to be completely secure.
+            </p>
+            <p>
+              Customers should use strong passwords, limit user access to trusted individuals, and
+              promptly notify us of any suspected unauthorized access.
+            </p>
+          </Section>
+
+          <Section title="11. Contact">
+            <p>For security questions, contact:</p>
+            <address className="not-italic">
+              <strong>Orthodox Metrics</strong>
+              <br />
+              <strong>Email:</strong>{' '}
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="text-[#2d1b4e] dark:text-[#d4af37] font-medium no-underline hover:underline"
+              >
+                {CONTACT_EMAIL}
+              </a>
+            </address>
+          </Section>
         </div>
       </section>
     </PageContainer>
   );
 };
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-10">
+      <h2 className="font-['Georgia'] text-2xl text-[#2d1b4e] dark:text-white mb-3">{title}</h2>
+      <div className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 leading-relaxed space-y-3 [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:space-y-1 [&_ul>li]:marker:text-[#d4af37]">
+        {children}
+      </div>
+    </section>
+  );
+}
 
 export default Security;

--- a/front-end/src/features/pages/frontend-pages/Terms.tsx
+++ b/front-end/src/features/pages/frontend-pages/Terms.tsx
@@ -1,7 +1,5 @@
-import { HeroSection } from '@/components/frontend-pages/shared/sections';
 import PageContainer from '@/shared/ui/PageContainer';
 import PublicSeo from '@/components/seo/PublicSeo';
-import { useLanguage } from '@/context/LanguageContext';
 
 // Legal copy below is intentionally NOT i18n-driven. Translating terms of
 // service requires per-jurisdiction legal review; until that exists the
@@ -12,8 +10,6 @@ const CONTACT_EMAIL = 'info@orthodoxmetrics.com';
 const GOVERNING_STATE = 'New Jersey';
 
 const Terms = () => {
-  const { t } = useLanguage();
-
   return (
     <PageContainer title="Terms of Service" description="Orthodox Metrics terms of service">
       <PublicSeo
@@ -21,15 +17,13 @@ const Terms = () => {
         description="Terms of Service for Orthodox Metrics — accounts, customer data, billing, acceptable use, third parties, IP, liability, and governing law."
         path="/terms"
       />
-      <HeroSection
-        badge={t('terms.hero_badge')}
-        title={t('terms.hero_title')}
-        subtitle={t('terms.hero_subtitle')}
-        editKeyPrefix="terms.hero"
-      />
 
       <section className="py-20 om-section-base">
         <div className="max-w-3xl mx-auto px-6 om-legal-prose">
+          <h1 className="font-['Georgia'] text-4xl md:text-5xl text-[#2d1b4e] dark:text-white mb-8">
+            Terms of Service
+          </h1>
+
           <p className="font-['Inter'] text-[14px] text-[#6b7280] dark:text-gray-500 mb-2">
             <strong>Effective Date:</strong> {EFFECTIVE_DATE}
           </p>


### PR DESCRIPTION
## Summary

Operator request 2026-05-06.

- **Privacy + Terms** — remove the badge / title / subtitle `<HeroSection>` block at the top of each page (visually redundant against the Effective Date / Website / Company body header that immediately follows). Replace with a single inline `<h1>` so each page still has exactly one h1 for accessibility / SEO.
- **Security** — same hero removal, plus a **full body rewrite** with the operator-supplied 11-section policy (Effective May 6 2026; `info@orthodoxmetrics.com`). The previous body was placeholder/draft text wrapped in `EditableText` with a yellow draft notice — gone.
- Drops the `privacy.hero_*` / `terms.hero_*` / `security.hero_*` i18n keys from these three pages. The rest of the legal copy is already not i18n-driven (per-jurisdiction translation needs explicit legal review), so this keeps the three pages on a consistent treatment.

## Scope

| File | Change |
|---|---|
| `front-end/src/features/pages/frontend-pages/Privacy.tsx` | Drop `<HeroSection>`, drop unused `useLanguage`, add inline `<h1>Privacy Policy</h1>` |
| `front-end/src/features/pages/frontend-pages/Terms.tsx` | Drop `<HeroSection>`, drop unused `useLanguage`, add inline `<h1>Terms of Service</h1>` |
| `front-end/src/features/pages/frontend-pages/Security.tsx` | Drop `<HeroSection>` + `EditableText` body; add inline `<h1>` and 11-section policy body using same `Section` helper / typography as Privacy + Terms |

No backend, no schema, no nginx. Public routes only — same React SPA bundle.

## Why

Privacy / Terms shipped via OMOD-1447 with both a hero and a body header; running the page in a browser made the hero feel like noise. Operator confirmed: drop it. Security still had the legacy editable-draft placeholder — replaced with the real policy text supplied by the operator.

## Test plan

- [ ] `om-deploy.sh fe` (operator)
- [ ] `https://orthodoxmetrics.com/privacy` — no hero band; body starts with `<h1>Privacy Policy</h1>` then the Effective Date / Website / Company stack
- [ ] `https://orthodoxmetrics.com/terms` — no hero band; same shape; section 16 still says New Jersey governing law
- [ ] `https://orthodoxmetrics.com/security` — 11 numbered sections; sections 9 and 11 link `info@orthodoxmetrics.com`
- [ ] Lighthouse / a11y: each page still has exactly one `<h1>`
- [ ] Search-engine canonical URLs unchanged (`PublicSeo` is still wired with the same `path`)

## Drift / follow-ups (not in scope)

- The dropped i18n keys (`privacy.hero_*` / `terms.hero_*` / `security.hero_*`) still exist in `server/src/routes/i18n.js` `ENGLISH_DEFAULTS` and possibly in DB rows for el/ru/ro/ka. They're now unreferenced — safe to leave; cleaner to prune in a follow-up i18n sweep.
- `EditableText` is no longer used on Security; the import was removed.

## Refs

- Work item: [OMOD-1449](https://orthodoxmetrics.com/admin/control-panel/om-daily/items/1449)
- Branch (auto-emitted): `feature/omd-1449/...` per documented `omd-` / `omod-` prefix drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)