### PR TITLE
OMOD-1502: tenant portal config registry (Phase 5 of OMSD-1491)

### DIFF
--- a/front-end/src/features/admin/tenant-portal-config/TenantPortalConfigPage.tsx
+++ b/front-end/src/features/admin/tenant-portal-config/TenantPortalConfigPage.tsx
@@ -1,0 +1,491 @@
+/**
+ * TenantPortalConfigPage — operator UI for the per-tenant portal config registry.
+ *
+ * OMOD-1502 (Phase 5 of 8 of OMSD-1491). Backed by /api/tenant-config CRUD routes
+ * over orthodoxmetrics_db.tenant_portal_config_items.
+ *
+ * MVP scope: pick a church, list rows, edit/delete inline, JSON editor for the
+ * structured fields. Not a polished UX — this is operator tooling. The bulk of
+ * row authoring will come from the seed script + scripted ingest from the
+ * OMOD-1498 audit, not hand-keying in this UI.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import { apiClient } from '@/api/utils/axiosInstance';
+
+const VALID_CATEGORIES = [
+  'portal', 'records', 'branding', 'church_profile',
+  'navigation', 'permissions', 'uploads', 'analytics',
+  'layout', 'notifications', 'tenant', 'auth',
+] as const;
+
+const VALID_TENANT_SCOPES = [
+  'global', 'per_church', 'per_user', 'per_role', 'per_record_type',
+] as const;
+
+type Category = typeof VALID_CATEGORIES[number];
+type TenantScope = typeof VALID_TENANT_SCOPES[number];
+
+interface ConfigItem {
+  id?: number;
+  church_id: number;
+  config_key: string;
+  display_name?: string | null;
+  category: Category;
+  owning_system?: string;
+  target_surface?: string | null;
+  user_roles?: string[] | null;
+  tenant_scope?: TenantScope;
+  current_source?: Record<string, unknown> | null;
+  current_behavior?: string | null;
+  configurable_fields?: unknown[] | null;
+  layout_contract?: Record<string, unknown> | null;
+  dependencies?: Record<string, unknown> | null;
+  omstudio_package_relevance?: Record<string, unknown> | null;
+  gaps_or_risks?: unknown[] | null;
+  is_active?: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
+
+interface ChurchListEntry {
+  id: number;
+  name?: string;
+  email?: string | null;
+  database_name?: string | null;
+  is_active?: boolean | number;
+}
+
+const EMPTY_ITEM: ConfigItem = {
+  church_id: 0,
+  config_key: '',
+  display_name: '',
+  category: 'portal',
+  owning_system: 'OM',
+  target_surface: '',
+  user_roles: [],
+  tenant_scope: 'per_church',
+  current_source: { hardcoded: false },
+  current_behavior: '',
+  configurable_fields: [],
+  layout_contract: null,
+  dependencies: {},
+  omstudio_package_relevance: {
+    can_be_targeted_by_omstudio: false,
+    package_slot_candidate: false,
+    requires_preflight_validation: true,
+    risk_level: 'low',
+    notes: '',
+  },
+  gaps_or_risks: [],
+  is_active: true,
+};
+
+function jsonText(val: unknown): string {
+  if (val === null || val === undefined) return '';
+  return JSON.stringify(val, null, 2);
+}
+
+function tryParseJson(text: string, fallback: unknown): unknown {
+  const trimmed = text.trim();
+  if (!trimmed) return fallback;
+  try { return JSON.parse(trimmed); } catch { return undefined; }
+}
+
+const TenantPortalConfigPage: React.FC = () => {
+  const [churches, setChurches] = useState<ChurchListEntry[]>([]);
+  const [churchId, setChurchId] = useState<number | ''>('');
+  const [category, setCategory] = useState<Category | 'all'>('all');
+  const [includeInactive, setIncludeInactive] = useState(false);
+
+  const [items, setItems] = useState<ConfigItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editing, setEditing] = useState<ConfigItem | null>(null);
+  const [editingDraft, setEditingDraft] = useState<{
+    item: ConfigItem;
+    user_roles_text: string;
+    current_source_text: string;
+    configurable_fields_text: string;
+    layout_contract_text: string;
+    dependencies_text: string;
+    omstudio_relevance_text: string;
+    gaps_or_risks_text: string;
+    json_errors: Record<string, string>;
+  } | null>(null);
+
+  /* ── load churches ── */
+  useEffect(() => {
+    (async () => {
+      try {
+        const res: any = await apiClient.get('/my/churches');
+        const list: ChurchListEntry[] = Array.isArray(res?.data?.churches)
+          ? res.data.churches
+          : Array.isArray(res?.churches) ? res.churches : [];
+        setChurches(list);
+        if (list.length > 0 && churchId === '') {
+          setChurchId(list[0].id);
+        }
+      } catch (e: any) {
+        setError(`Failed to load churches: ${e?.message || e}`);
+      }
+    })();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /* ── load items ── */
+  const loadItems = useCallback(async () => {
+    if (!churchId || typeof churchId !== 'number') return;
+    setLoading(true);
+    setError(null);
+    try {
+      const body: Record<string, unknown> = { church_id: churchId, include_inactive: includeInactive };
+      if (category !== 'all') body.category = category;
+      const res: any = await apiClient.post('/tenant-config/list', body);
+      const arr: ConfigItem[] = Array.isArray(res?.items) ? res.items : [];
+      setItems(arr);
+    } catch (e: any) {
+      setError(`Failed to load items: ${e?.response?.data?.error || e?.message || e}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [churchId, category, includeInactive]);
+
+  useEffect(() => { loadItems(); }, [loadItems]);
+
+  /* ── editing ── */
+  const startEdit = (it: ConfigItem | 'new') => {
+    const baseRaw = it === 'new'
+      ? { ...EMPTY_ITEM, church_id: typeof churchId === 'number' ? churchId : 0 }
+      : it;
+    const base: ConfigItem = { ...baseRaw };
+    setEditing(base);
+    setEditingDraft({
+      item: base,
+      user_roles_text: (base.user_roles || []).join(', '),
+      current_source_text: jsonText(base.current_source),
+      configurable_fields_text: jsonText(base.configurable_fields),
+      layout_contract_text: jsonText(base.layout_contract),
+      dependencies_text: jsonText(base.dependencies),
+      omstudio_relevance_text: jsonText(base.omstudio_package_relevance),
+      gaps_or_risks_text: jsonText(base.gaps_or_risks),
+      json_errors: {},
+    });
+  };
+
+  const cancelEdit = () => { setEditing(null); setEditingDraft(null); };
+
+  const saveEdit = async () => {
+    if (!editingDraft) return;
+    const d = editingDraft;
+    const errs: Record<string, string> = {};
+
+    const userRoles = d.user_roles_text
+      .split(',').map((s) => s.trim()).filter(Boolean);
+    const currentSource = tryParseJson(d.current_source_text, null);
+    const configurableFields = tryParseJson(d.configurable_fields_text, []);
+    const layoutContract = tryParseJson(d.layout_contract_text, null);
+    const dependencies = tryParseJson(d.dependencies_text, {});
+    const omstudioRelevance = tryParseJson(d.omstudio_relevance_text, null);
+    const gapsOrRisks = tryParseJson(d.gaps_or_risks_text, []);
+
+    if (currentSource === undefined) errs.current_source = 'invalid JSON';
+    if (configurableFields === undefined) errs.configurable_fields = 'invalid JSON';
+    if (layoutContract === undefined) errs.layout_contract = 'invalid JSON';
+    if (dependencies === undefined) errs.dependencies = 'invalid JSON';
+    if (omstudioRelevance === undefined) errs.omstudio_package_relevance = 'invalid JSON';
+    if (gapsOrRisks === undefined) errs.gaps_or_risks = 'invalid JSON';
+
+    if (!d.item.config_key.trim()) errs.config_key = 'required';
+    if (!d.item.church_id) errs.church_id = 'required';
+
+    if (Object.keys(errs).length > 0) {
+      setEditingDraft({ ...d, json_errors: errs });
+      return;
+    }
+
+    try {
+      await apiClient.post('/tenant-config/set', {
+        ...d.item,
+        user_roles: userRoles,
+        current_source: currentSource,
+        configurable_fields: configurableFields,
+        layout_contract: layoutContract,
+        dependencies: dependencies,
+        omstudio_package_relevance: omstudioRelevance,
+        gaps_or_risks: gapsOrRisks,
+      });
+      cancelEdit();
+      loadItems();
+    } catch (e: any) {
+      setError(`Save failed: ${e?.response?.data?.error || e?.message || e}`);
+    }
+  };
+
+  const onDelete = async (id?: number) => {
+    if (!id) return;
+    if (!window.confirm(`Delete config item ${id}? This cannot be undone (FK CASCADE applies).`)) return;
+    try {
+      await apiClient.delete(`/tenant-config/delete/${id}`);
+      loadItems();
+    } catch (e: any) {
+      setError(`Delete failed: ${e?.response?.data?.error || e?.message || e}`);
+    }
+  };
+
+  /* ── rendering ── */
+
+  const churchOptions = useMemo(
+    () => churches
+      .filter((c) => c.is_active)
+      .sort((a, b) => (a.name || '').localeCompare(b.name || '')),
+    [churches],
+  );
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h5" sx={{ mb: 1 }}>
+        Tenant Portal Configuration Registry
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        OMOD-1502 — per-tenant portal config items per OMSD-1491 §C. V1 is informational;
+        OMStudio's preflight validator reads this via{' '}
+        <code>/api/platform/tenant-config/known-slots</code>.
+      </Typography>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>{error}</Alert>}
+
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="flex-start">
+            <FormControl sx={{ minWidth: 280 }} size="small">
+              <InputLabel>Church</InputLabel>
+              <Select
+                label="Church"
+                value={churchId}
+                onChange={(e) => setChurchId(Number(e.target.value) || '')}
+              >
+                {churchOptions.map((c) => (
+                  <MenuItem key={c.id} value={c.id}>{c.name || `Church #${c.id}`} (id={c.id})</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl sx={{ minWidth: 200 }} size="small">
+              <InputLabel>Category</InputLabel>
+              <Select
+                label="Category"
+                value={category}
+                onChange={(e) => setCategory(e.target.value as Category | 'all')}
+              >
+                <MenuItem value="all">All</MenuItem>
+                {VALID_CATEGORIES.map((c) => <MenuItem key={c} value={c}>{c}</MenuItem>)}
+              </Select>
+            </FormControl>
+
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Switch
+                checked={includeInactive}
+                onChange={(e) => setIncludeInactive(e.target.checked)}
+                size="small"
+              />
+              <Typography variant="body2">Include inactive</Typography>
+            </Stack>
+
+            <Box sx={{ flex: 1 }} />
+
+            <Button
+              variant="outlined"
+              startIcon={<AddCircleOutlineIcon />}
+              onClick={() => startEdit('new')}
+              disabled={typeof churchId !== 'number'}
+            >
+              New config item
+            </Button>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent sx={{ p: 0 }}>
+          {loading ? (
+            <Box sx={{ p: 4, textAlign: 'center' }}><CircularProgress size={24} /></Box>
+          ) : items.length === 0 ? (
+            <Typography variant="body2" sx={{ p: 3 }} color="text.secondary">
+              No config items for this church yet. Use the seed script
+              (<code>scripts/seed-tenant-portal-config.js</code>) or click "New config item".
+            </Typography>
+          ) : (
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>config_key</TableCell>
+                  <TableCell>category</TableCell>
+                  <TableCell>tenant_scope</TableCell>
+                  <TableCell>target_surface</TableCell>
+                  <TableCell>active</TableCell>
+                  <TableCell align="right">actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {items.map((it) => (
+                  <TableRow key={it.id} hover>
+                    <TableCell><code>{it.config_key}</code></TableCell>
+                    <TableCell>{it.category}</TableCell>
+                    <TableCell>{it.tenant_scope}</TableCell>
+                    <TableCell sx={{ maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      <Tooltip title={it.target_surface || ''}><span>{it.target_surface || '—'}</span></Tooltip>
+                    </TableCell>
+                    <TableCell>{it.is_active ? '✓' : '—'}</TableCell>
+                    <TableCell align="right">
+                      <Tooltip title="Edit">
+                        <Button size="small" onClick={() => startEdit(it)}><EditOutlinedIcon fontSize="small" /></Button>
+                      </Tooltip>
+                      <Tooltip title="Delete">
+                        <Button size="small" color="error" onClick={() => onDelete(it.id)}><DeleteOutlineIcon fontSize="small" /></Button>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Edit dialog */}
+      <Dialog open={!!editing} onClose={cancelEdit} maxWidth="md" fullWidth>
+        <DialogTitle>{editing?.id ? `Edit config item #${editing.id}` : 'New config item'}</DialogTitle>
+        <DialogContent dividers>
+          {editingDraft && (
+            <Stack spacing={2} sx={{ pt: 1 }}>
+              <Stack direction="row" spacing={2}>
+                <TextField
+                  label="config_key"
+                  value={editingDraft.item.config_key}
+                  onChange={(e) => setEditingDraft({ ...editingDraft, item: { ...editingDraft.item, config_key: e.target.value } })}
+                  size="small" fullWidth required
+                  error={!!editingDraft.json_errors.config_key}
+                  helperText={editingDraft.json_errors.config_key}
+                />
+                <TextField
+                  label="display_name"
+                  value={editingDraft.item.display_name || ''}
+                  onChange={(e) => setEditingDraft({ ...editingDraft, item: { ...editingDraft.item, display_name: e.target.value } })}
+                  size="small" fullWidth
+                />
+              </Stack>
+              <Stack direction="row" spacing={2}>
+                <FormControl size="small" sx={{ minWidth: 180 }}>
+                  <InputLabel>category</InputLabel>
+                  <Select
+                    label="category"
+                    value={editingDraft.item.category}
+                    onChange={(e) => setEditingDraft({ ...editingDraft, item: { ...editingDraft.item, category: e.target.value as Category } })}
+                  >
+                    {VALID_CATEGORIES.map((c) => <MenuItem key={c} value={c}>{c}</MenuItem>)}
+                  </Select>
+                </FormControl>
+                <FormControl size="small" sx={{ minWidth: 180 }}>
+                  <InputLabel>tenant_scope</InputLabel>
+                  <Select
+                    label="tenant_scope"
+                    value={editingDraft.item.tenant_scope || 'per_church'}
+                    onChange={(e) => setEditingDraft({ ...editingDraft, item: { ...editingDraft.item, tenant_scope: e.target.value as TenantScope } })}
+                  >
+                    {VALID_TENANT_SCOPES.map((s) => <MenuItem key={s} value={s}>{s}</MenuItem>)}
+                  </Select>
+                </FormControl>
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <Switch
+                    checked={editingDraft.item.is_active !== false}
+                    onChange={(e) => setEditingDraft({ ...editingDraft, item: { ...editingDraft.item, is_active: e.target.checked } })}
+                  />
+                  <Typography variant="body2">active</Typography>
+                </Stack>
+              </Stack>
+              <TextField
+                label="target_surface"
+                value={editingDraft.item.target_surface || ''}
+                onChange={(e) => setEditingDraft({ ...editingDraft, item: { ...editingDraft.item, target_surface: e.target.value } })}
+                size="small" fullWidth
+              />
+              <TextField
+                label="user_roles (comma-separated)"
+                value={editingDraft.user_roles_text}
+                onChange={(e) => setEditingDraft({ ...editingDraft, user_roles_text: e.target.value })}
+                size="small" fullWidth
+                helperText="e.g. priest, church_admin, super_admin"
+              />
+              <TextField
+                label="current_behavior"
+                value={editingDraft.item.current_behavior || ''}
+                onChange={(e) => setEditingDraft({ ...editingDraft, item: { ...editingDraft.item, current_behavior: e.target.value } })}
+                size="small" fullWidth multiline minRows={2}
+              />
+              {/* JSON fields */}
+              {[
+                { key: 'current_source_text', label: 'current_source (JSON)' },
+                { key: 'configurable_fields_text', label: 'configurable_fields (JSON array)' },
+                { key: 'layout_contract_text', label: 'layout_contract (JSON)' },
+                { key: 'dependencies_text', label: 'dependencies (JSON)' },
+                { key: 'omstudio_relevance_text', label: 'omstudio_package_relevance (JSON)' },
+                { key: 'gaps_or_risks_text', label: 'gaps_or_risks (JSON array)' },
+              ].map(({ key, label }) => {
+                const errKey = key.replace(/_text$/, '').replace('omstudio_relevance', 'omstudio_package_relevance');
+                return (
+                  <TextField
+                    key={key}
+                    label={label}
+                    value={(editingDraft as any)[key]}
+                    onChange={(e) => setEditingDraft({ ...editingDraft, [key]: e.target.value } as any)}
+                    size="small" fullWidth multiline minRows={3}
+                    error={!!editingDraft.json_errors[errKey]}
+                    helperText={editingDraft.json_errors[errKey]}
+                    InputProps={{ style: { fontFamily: 'monospace', fontSize: 12 } }}
+                  />
+                );
+              })}
+            </Stack>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={cancelEdit}>Cancel</Button>
+          <Button variant="contained" onClick={saveEdit}>Save</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default TenantPortalConfigPage;

--- a/front-end/src/routes/Router.tsx
+++ b/front-end/src/routes/Router.tsx
@@ -40,6 +40,8 @@ const Kanban = Loadable(lazy(() => import('../features/apps/kanban/Kanban')));
 const DynamicRecordsPage = Loadable(lazy(() => import('../features/records-centralized/components/dynamic/DynamicRecordsPage')));
 const AnalyticsDashboard = Loadable(lazy(() => import('../features/admin/AnalyticsDashboard')));
 const WebsiteStatsPage = Loadable(lazy(() => import('../features/admin/website-stats/WebsiteStatsPage')));
+// OMOD-1502: Tenant Portal Config Registry (Phase 5 of 8 of OMSD-1491)
+const TenantPortalConfigPage = Loadable(lazy(() => import('../features/admin/tenant-portal-config/TenantPortalConfigPage')));
 const Followers = Loadable(lazy(() => import('../features/apps/user-profile/Followers')));
 const Friends = Loadable(lazy(() => import('../features/apps/user-profile/Friends')));
 const UserProfileGallery = Loadable(lazy(() => import('../features/apps/user-profile/Gallery')));
@@ -385,6 +387,15 @@ const Router = [
         element: (
           <ProtectedRoute requiredRole={['super_admin']}>
             <ChurchSetupWizard />
+          </ProtectedRoute>
+        )
+      },
+      // OMOD-1502: Tenant Portal Config Registry (Phase 5 of OMSD-1491)
+      {
+        path: '/admin/tenant-portal-config',
+        element: (
+          <ProtectedRoute requiredRole={['super_admin', 'admin']}>
+            <TenantPortalConfigPage />
           </ProtectedRoute>
         )
       },

--- a/server/database/migrations/20260508_create_tenant_portal_config_items.sql
+++ b/server/database/migrations/20260508_create_tenant_portal_config_items.sql
@@ -1,0 +1,99 @@
+-- OMOD-1502: tenant_portal_config_items
+-- Per-tenant portal configuration registry for the OM Church Portal Master Plan
+-- Phase 5 of 8 (parent OMSD-1491). Schema follows registry-contracts.md §C.
+--
+-- Lives in the platform DB (orthodoxmetrics_db). Each row describes ONE config-item
+-- for ONE church tenant. OMStudio's preflight validator reads this through the
+-- service-token-gated endpoint /api/platform/tenant-config/known-slots — see
+-- server/src/routes/platform.js for the read surface.
+--
+-- Reversal: DROP TABLE IF EXISTS tenant_portal_config_items;
+
+CREATE TABLE IF NOT EXISTS tenant_portal_config_items (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+
+  church_id INT NOT NULL,
+
+  -- Stable machine key per §C ("portal.dashboard.hero_image", etc.). Together
+  -- with church_id this is the natural key — UNIQUE below.
+  config_key VARCHAR(255) NOT NULL,
+
+  -- Per §C
+  display_name VARCHAR(255) DEFAULT NULL,
+
+  -- Per §C category enum, plus 'auth' which §C omits but the OMOD-1498 audit
+  -- identified as a real category (9 cross-cutting auth config-items).
+  category ENUM(
+    'portal',
+    'records',
+    'branding',
+    'church_profile',
+    'navigation',
+    'permissions',
+    'uploads',
+    'analytics',
+    'layout',
+    'notifications',
+    'tenant',
+    'auth'
+  ) NOT NULL,
+
+  owning_system VARCHAR(50) NOT NULL DEFAULT 'OM',
+
+  -- Free-form "page/component/route" identifier per §C
+  target_surface VARCHAR(500) DEFAULT NULL,
+
+  -- §C user_roles[] — array of role strings
+  user_roles JSON DEFAULT NULL,
+
+  tenant_scope ENUM(
+    'global',
+    'per_church',
+    'per_user',
+    'per_role',
+    'per_record_type'
+  ) NOT NULL DEFAULT 'per_church',
+
+  -- §C current_source: { frontend_file, backend_route, db_table, db_column, hardcoded }
+  current_source JSON DEFAULT NULL,
+
+  current_behavior TEXT DEFAULT NULL,
+
+  -- §C configurable_fields[] (default empty array)
+  configurable_fields JSON DEFAULT NULL,
+
+  -- §C layout_contract: { slot_name, width_behavior, responsive_behavior,
+  --                       dark_mode_requirement, theme_tokens_used, visual_constraints }
+  layout_contract JSON DEFAULT NULL,
+
+  -- §C dependencies (default empty object)
+  dependencies JSON DEFAULT NULL,
+
+  -- §C omstudio_package_relevance: {
+  --   can_be_targeted_by_omstudio, package_slot_candidate,
+  --   requires_preflight_validation, risk_level, notes
+  -- }
+  omstudio_package_relevance JSON DEFAULT NULL,
+
+  -- §C gaps_or_risks[] (default empty array)
+  gaps_or_risks JSON DEFAULT NULL,
+
+  -- Soft-disable a row without deleting (preserves audit history for §D resolver
+  -- to detect "this slot existed but was retired")
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+  -- Audit columns
+  created_by_user_id INT DEFAULT NULL,
+  updated_by_user_id INT DEFAULT NULL,
+
+  UNIQUE KEY uk_tpci_church_config (church_id, config_key),
+  INDEX idx_tpci_church_category (church_id, category),
+  INDEX idx_tpci_category (category),
+  INDEX idx_tpci_active (is_active),
+
+  CONSTRAINT fk_tpci_church
+    FOREIGN KEY (church_id) REFERENCES churches(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -621,6 +621,11 @@ console.log('✅ [Server] Mounted /api/parish-settings route');
 const parishStatsRouter = require('./routes/parish-stats');
 app.use('/api/parish-stats', parishStatsRouter);
 console.log('✅ [Server] Mounted /api/parish-stats route');
+// OMOD-1502: Tenant Portal Config Registry (per-tenant rows, §C of OMSD-1491).
+// Platform-side known-slots read endpoint lives in routes/platform.js.
+const tenantConfigRouter = require('./routes/tenant-config');
+app.use('/api/tenant-config', tenantConfigRouter);
+console.log('✅ [Server] Mounted /api/tenant-config route');
 // Church records landing page branding
 const churchRecordsLandingRouter = require('./routes/church-records-landing');
 app.use('/api/churches', churchRecordsLandingRouter);

--- a/server/src/routes/platform.js
+++ b/server/src/routes/platform.js
@@ -767,4 +767,217 @@ router.get('/build-runs/summary', async (req, res) => {
   }
 });
 
+// ─── /tenant-config/known-slots ────────────────────────────────────────
+// OMOD-1502 — read-only known-slots endpoint that OMStudio's preflight
+// validator consumes (CS-OM-TENANT-PORTAL-CONFIG-REGISTRY-V1).
+//
+// Auth: X-Service-Token + X-On-Behalf-Of-Email (same pattern as
+// /work-sessions/active and /build-runs/summary). Additionally requires
+// X-Source-System: omstudio — defense in depth so a leaked service token
+// can't be used by a non-OMStudio caller.
+//
+// Returns the shape OMStudio's lib/packages/compatibility.js consumes
+// from tenantConfigResolver(tenant_id):
+//   {
+//     exists,                                  // bool
+//     modules: { "<category>.<module_key>": bool, ... },
+//     known_slots: ["<config_key>", ...],      // flat array of layout-slot keys
+//     active_roles: ["priest", "church_admin", ...],
+//     branding: { logo_position, ... } | null,
+//     theme_modes: ["light", "dark"]
+//   }
+//
+// IMPORTANT: returns 404 — NOT 200 with {exists:false} — when the tenant_id
+// doesn't match any active church. OMStudio's resolver distinguishes
+// "registry not shipped" (null from connector) from "tenant not found"
+// (404 → log + null) — see lib/packages/index.js / compatibility.js. Per
+// the connector contract, 4xx (other than 404) and 5xx are graceful
+// degrade (degraded), while 404 is a clean negative answer.
+
+const KNOWN_SLOT_DEFAULTS = {
+  // Slots that exist by virtue of OM shipping the portal at all — present
+  // for every active church regardless of whether someone has explicitly
+  // populated rows in tenant_portal_config_items yet. V1 is informational;
+  // V2 will narrow these to "rows that exist AND are is_active=1".
+  baseline_known_slots: [
+    'portal.layout.chrome',
+    'portal.dashboard.hub_root',
+    'portal.dashboard.search_box',
+    'portal.dashboard.recent_activity',
+    'portal.dashboard.record_pipeline',
+    'records.baptism.list',
+    'records.marriage.list',
+    'records.funeral.list',
+    'church_profile.name',
+    'church_profile.contact_email',
+    'navigation.role_default_landing',
+    'analytics.parish_summary',
+  ],
+  baseline_modules: {
+    'records.baptism': true,
+    'records.marriage': true,
+    'records.funeral': true,
+    'records.batches': true,
+    'analytics.charts': true,
+    'analytics.parish_summary': true,
+    'auth.login': true,
+    'auth.sessions': true,
+  },
+  baseline_active_roles: [
+    'super_admin', 'admin', 'church_admin', 'priest', 'deacon', 'editor',
+  ],
+  baseline_theme_modes: ['light', 'dark'],
+};
+
+router.get('/tenant-config/known-slots', async (req, res) => {
+  try {
+    // 1. on-behalf-of-email
+    const rawEmail = req.serviceCaller && typeof req.serviceCaller.email === 'string'
+      ? req.serviceCaller.email.trim()
+      : '';
+    if (!rawEmail) {
+      return res.status(400).json({
+        ok: false,
+        error: 'missing_on_behalf_of_email',
+        message: 'X-On-Behalf-Of-Email header is required for this endpoint.',
+      });
+    }
+    if (!EMAIL_RE.test(rawEmail)) {
+      return res.status(400).json({
+        ok: false,
+        error: 'invalid_email',
+        message: 'X-On-Behalf-Of-Email is not a valid email format.',
+      });
+    }
+
+    // 2. source system gate — must be omstudio
+    const sourceSystem = (req.serviceCaller && req.serviceCaller.sourceSystem)
+      || req.get('X-Source-System')
+      || '';
+    if ((sourceSystem || '').toLowerCase() !== 'omstudio') {
+      return res.status(403).json({
+        ok: false,
+        error: 'source_system_not_allowed',
+        message: 'X-Source-System: omstudio header is required for this endpoint.',
+      });
+    }
+
+    // 3. tenant_id
+    const tenantIdRaw = req.query.tenant_id;
+    const tenantId = parseInt(tenantIdRaw, 10);
+    if (!Number.isFinite(tenantId) || tenantId <= 0) {
+      return res.status(400).json({
+        ok: false,
+        error: 'missing_tenant_id',
+        message: 'tenant_id query param is required (positive integer).',
+      });
+    }
+
+    // 4. resolve church — 404 if not found OR not active. The connector
+    //    treats 404 as "tenant not found" (clean negative); other errors
+    //    degrade.
+    const [churches] = await queryPlatform(
+      `SELECT id, name, church_name, primary_color, secondary_color,
+              logo_path, logo_dark_path, favicon_path,
+              has_baptism_records, has_marriage_records, has_funeral_records,
+              is_active, setup_complete
+       FROM churches WHERE id = ? LIMIT 1`,
+      [tenantId],
+    );
+    if (!churches.length || !churches[0].is_active) {
+      return res.status(404).json({
+        ok: false,
+        error: 'tenant_not_found',
+        message: `No active church with tenant_id=${tenantId}.`,
+      });
+    }
+    const church = churches[0];
+
+    // 5. registry rows for this tenant
+    const [rows] = await queryPlatform(
+      `SELECT config_key, category, target_surface, user_roles, current_source,
+              layout_contract, omstudio_package_relevance
+       FROM tenant_portal_config_items
+       WHERE church_id = ? AND is_active = 1`,
+      [tenantId],
+    );
+
+    // 6. compose response
+    //
+    // known_slots: every active registry row's config_key, unioned with the
+    // baseline. Baseline covers the case where this tenant has no rows yet
+    // — V1 is informational, so we return the safe-known-good set rather
+    // than an empty array, and downstream OMStudio still gets a valid
+    // pass/fail signal.
+    const slotSet = new Set(KNOWN_SLOT_DEFAULTS.baseline_known_slots);
+    const moduleMap = { ...KNOWN_SLOT_DEFAULTS.baseline_modules };
+    const roleSet = new Set(KNOWN_SLOT_DEFAULTS.baseline_active_roles);
+
+    for (const r of rows) {
+      slotSet.add(r.config_key);
+
+      // Per-row module signal: row config_key 'records.baptism.list' →
+      // module 'records.baptism' enabled. We take the first two
+      // dot-segments (or the whole key if only one).
+      const firstDot = r.config_key.indexOf('.');
+      if (firstDot > 0) {
+        const secondDot = r.config_key.indexOf('.', firstDot + 1);
+        const moduleKey = secondDot > 0
+          ? r.config_key.slice(0, secondDot)
+          : r.config_key;
+        moduleMap[moduleKey] = true;
+      }
+
+      // user_roles influences the active_roles set
+      let userRoles = null;
+      try {
+        userRoles = typeof r.user_roles === 'string'
+          ? JSON.parse(r.user_roles)
+          : r.user_roles;
+      } catch { userRoles = null; }
+      if (Array.isArray(userRoles)) {
+        for (const role of userRoles) {
+          if (typeof role === 'string') roleSet.add(role);
+        }
+      }
+    }
+
+    // has_*_records flags from the church row override module presence
+    moduleMap['records.baptism']  = !!church.has_baptism_records;
+    moduleMap['records.marriage'] = !!church.has_marriage_records;
+    moduleMap['records.funeral']  = !!church.has_funeral_records;
+
+    const branding = (church.primary_color || church.logo_path) ? {
+      primary_color:    church.primary_color || null,
+      secondary_color:  church.secondary_color || null,
+      logo_path:        church.logo_path || null,
+      logo_dark_path:   church.logo_dark_path || null,
+      favicon_path:     church.favicon_path || null,
+    } : null;
+
+    return res.json({
+      ok: true,
+      exists: true,
+      tenant_id: tenantId,
+      tenant_name: church.church_name || church.name || null,
+      modules: moduleMap,
+      known_slots: Array.from(slotSet).sort(),
+      active_roles: Array.from(roleSet).sort(),
+      branding,
+      theme_modes: KNOWN_SLOT_DEFAULTS.baseline_theme_modes,
+      registry_row_count: rows.length,
+      registry_version: 'v1_informational',
+    });
+  } catch (err) {
+    console.error(
+      '[platform] tenant-config/known-slots failed:',
+      err && err.message ? err.message : err,
+    );
+    return res.status(500).json({
+      ok: false,
+      error: 'tenant_config_known_slots_failed',
+    });
+  }
+});
+
 module.exports = router;

--- a/server/src/routes/tenant-config.js
+++ b/server/src/routes/tenant-config.js
@@ -1,0 +1,292 @@
+/**
+ * Tenant Portal Config Registry — CRUD routes (OMOD-1502).
+ *
+ * Per-tenant portal configuration items per OMSD-1491 §C schema.
+ * Backed by orthodoxmetrics_db.tenant_portal_config_items.
+ *
+ * Endpoints:
+ *   POST   /api/tenant-config/list           — list rows for a church (filter by category)
+ *   GET    /api/tenant-config/get/:id        — single row by id
+ *   POST   /api/tenant-config/set            — upsert by (church_id, config_key)  [admin/super_admin]
+ *   DELETE /api/tenant-config/delete/:id     — delete row                          [admin/super_admin]
+ *
+ * The platform-side read endpoint (/api/platform/tenant-config/known-slots) lives
+ * in routes/platform.js — it has different auth (service-token + on-behalf-of-email).
+ */
+
+const express = require('express');
+const router = express.Router();
+const { getAppPool } = require('../config/db');
+const { requireAuth, requireRole } = require('../middleware/auth');
+
+const VALID_CATEGORIES = [
+  'portal', 'records', 'branding', 'church_profile',
+  'navigation', 'permissions', 'uploads', 'analytics',
+  'layout', 'notifications', 'tenant', 'auth',
+];
+
+const VALID_TENANT_SCOPES = [
+  'global', 'per_church', 'per_user', 'per_role', 'per_record_type',
+];
+
+// Reasonable cap on JSON payload sizes per row to prevent runaway writes.
+const MAX_JSON_FIELD_BYTES = 64 * 1024;
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function parseId(raw) {
+  const id = parseInt(raw, 10);
+  return Number.isFinite(id) && id > 0 ? id : null;
+}
+
+/** mysql2 returns JSON columns either as parsed objects or as strings, depending
+ *  on driver options. Normalize to a JS value, returning null on parse failure. */
+function readJsonColumn(val) {
+  if (val === null || val === undefined) return null;
+  if (typeof val === 'string') {
+    try { return JSON.parse(val); } catch { return null; }
+  }
+  return val;
+}
+
+/** Validate + serialize a JSON-shaped column on write. Returns null on null/undefined,
+ *  a string ready for INSERT/UPDATE on a valid value, or throws an Error with a
+ *  client-safe message on invalid input. */
+function writeJsonColumn(val, fieldName) {
+  if (val === undefined || val === null) return null;
+  let s;
+  try { s = JSON.stringify(val); }
+  catch { throw new Error(`${fieldName} is not JSON-serializable`); }
+  if (Buffer.byteLength(s, 'utf8') > MAX_JSON_FIELD_BYTES) {
+    throw new Error(`${fieldName} exceeds ${MAX_JSON_FIELD_BYTES}-byte limit`);
+  }
+  return s;
+}
+
+/** Shape a DB row for the API response. */
+function shapeRow(row) {
+  return {
+    id: row.id,
+    church_id: row.church_id,
+    config_key: row.config_key,
+    display_name: row.display_name,
+    category: row.category,
+    owning_system: row.owning_system,
+    target_surface: row.target_surface,
+    user_roles: readJsonColumn(row.user_roles),
+    tenant_scope: row.tenant_scope,
+    current_source: readJsonColumn(row.current_source),
+    current_behavior: row.current_behavior,
+    configurable_fields: readJsonColumn(row.configurable_fields),
+    layout_contract: readJsonColumn(row.layout_contract),
+    dependencies: readJsonColumn(row.dependencies),
+    omstudio_package_relevance: readJsonColumn(row.omstudio_package_relevance),
+    gaps_or_risks: readJsonColumn(row.gaps_or_risks),
+    is_active: !!row.is_active,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    created_by_user_id: row.created_by_user_id,
+    updated_by_user_id: row.updated_by_user_id,
+  };
+}
+
+// ── POST /api/tenant-config/list ─────────────────────────────────────────
+//
+// Body: { church_id: number, category?: string, include_inactive?: boolean }
+// Returns: { items: [...] }
+
+router.post('/list', requireAuth, async (req, res) => {
+  try {
+    const { church_id, category, include_inactive } = req.body || {};
+    const churchId = parseId(church_id);
+    if (!churchId) {
+      return res.status(400).json({ error: 'church_id required (positive integer)' });
+    }
+    if (category !== undefined && !VALID_CATEGORIES.includes(category)) {
+      return res.status(400).json({
+        error: `invalid category; allowed: ${VALID_CATEGORIES.join(', ')}`,
+      });
+    }
+
+    const where = ['church_id = ?'];
+    const params = [churchId];
+    if (category) {
+      where.push('category = ?');
+      params.push(category);
+    }
+    if (!include_inactive) {
+      where.push('is_active = 1');
+    }
+
+    const [rows] = await getAppPool().query(
+      `SELECT * FROM tenant_portal_config_items
+       WHERE ${where.join(' AND ')}
+       ORDER BY category, config_key`,
+      params,
+    );
+
+    res.json({ items: rows.map(shapeRow) });
+  } catch (err) {
+    console.error('[tenant-config] list error:', err);
+    res.status(500).json({ error: 'Failed to list tenant config items' });
+  }
+});
+
+// ── GET /api/tenant-config/get/:id ───────────────────────────────────────
+
+router.get('/get/:id', requireAuth, async (req, res) => {
+  try {
+    const id = parseId(req.params.id);
+    if (!id) return res.status(400).json({ error: 'invalid id' });
+
+    const [rows] = await getAppPool().query(
+      'SELECT * FROM tenant_portal_config_items WHERE id = ?',
+      [id],
+    );
+    if (!rows.length) return res.status(404).json({ error: 'not found' });
+
+    res.json({ item: shapeRow(rows[0]) });
+  } catch (err) {
+    console.error('[tenant-config] get error:', err);
+    res.status(500).json({ error: 'Failed to fetch tenant config item' });
+  }
+});
+
+// ── POST /api/tenant-config/set ──────────────────────────────────────────
+//
+// Upsert by natural key (church_id, config_key). Body shape mirrors §C plus id
+// (optional — if present, behaves as an update by primary key for that single
+// row; otherwise UPSERT semantics on the natural key).
+
+router.post('/set', requireRole(['super_admin', 'admin']), async (req, res) => {
+  try {
+    const b = req.body || {};
+    const churchId = parseId(b.church_id);
+    const configKey = typeof b.config_key === 'string' ? b.config_key.trim() : '';
+
+    if (!churchId) return res.status(400).json({ error: 'church_id required' });
+    if (!configKey) return res.status(400).json({ error: 'config_key required' });
+    if (configKey.length > 255) {
+      return res.status(400).json({ error: 'config_key too long (max 255)' });
+    }
+    if (!VALID_CATEGORIES.includes(b.category)) {
+      return res.status(400).json({
+        error: `category required; allowed: ${VALID_CATEGORIES.join(', ')}`,
+      });
+    }
+    const tenantScope = b.tenant_scope || 'per_church';
+    if (!VALID_TENANT_SCOPES.includes(tenantScope)) {
+      return res.status(400).json({
+        error: `invalid tenant_scope; allowed: ${VALID_TENANT_SCOPES.join(', ')}`,
+      });
+    }
+
+    let userRolesJson, currentSourceJson, configurableFieldsJson,
+        layoutContractJson, dependenciesJson, omstudioRelevanceJson, gapsJson;
+    try {
+      userRolesJson           = writeJsonColumn(b.user_roles,                  'user_roles');
+      currentSourceJson       = writeJsonColumn(b.current_source,              'current_source');
+      configurableFieldsJson  = writeJsonColumn(b.configurable_fields,         'configurable_fields');
+      layoutContractJson      = writeJsonColumn(b.layout_contract,             'layout_contract');
+      dependenciesJson        = writeJsonColumn(b.dependencies,                'dependencies');
+      omstudioRelevanceJson   = writeJsonColumn(b.omstudio_package_relevance,  'omstudio_package_relevance');
+      gapsJson                = writeJsonColumn(b.gaps_or_risks,               'gaps_or_risks');
+    } catch (validationErr) {
+      return res.status(400).json({ error: validationErr.message });
+    }
+
+    // Ensure the church actually exists — protects FK invariant and gives a
+    // cleaner error than the InnoDB FK violation surface.
+    const [churchCheck] = await getAppPool().query(
+      'SELECT id FROM churches WHERE id = ? LIMIT 1', [churchId],
+    );
+    if (!churchCheck.length) {
+      return res.status(400).json({ error: `church_id ${churchId} does not exist` });
+    }
+
+    const userId = req.session?.user?.id || req.user?.userId || req.user?.id || null;
+
+    const [result] = await getAppPool().query(
+      `INSERT INTO tenant_portal_config_items (
+         church_id, config_key, display_name, category, owning_system,
+         target_surface, user_roles, tenant_scope, current_source,
+         current_behavior, configurable_fields, layout_contract,
+         dependencies, omstudio_package_relevance, gaps_or_risks,
+         is_active, created_by_user_id, updated_by_user_id
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         display_name = VALUES(display_name),
+         category = VALUES(category),
+         owning_system = VALUES(owning_system),
+         target_surface = VALUES(target_surface),
+         user_roles = VALUES(user_roles),
+         tenant_scope = VALUES(tenant_scope),
+         current_source = VALUES(current_source),
+         current_behavior = VALUES(current_behavior),
+         configurable_fields = VALUES(configurable_fields),
+         layout_contract = VALUES(layout_contract),
+         dependencies = VALUES(dependencies),
+         omstudio_package_relevance = VALUES(omstudio_package_relevance),
+         gaps_or_risks = VALUES(gaps_or_risks),
+         is_active = VALUES(is_active),
+         updated_by_user_id = VALUES(updated_by_user_id)`,
+      [
+        churchId,
+        configKey,
+        b.display_name || null,
+        b.category,
+        b.owning_system || 'OM',
+        b.target_surface || null,
+        userRolesJson,
+        tenantScope,
+        currentSourceJson,
+        b.current_behavior || null,
+        configurableFieldsJson,
+        layoutContractJson,
+        dependenciesJson,
+        omstudioRelevanceJson,
+        gapsJson,
+        b.is_active === false ? 0 : 1,
+        userId,
+        userId,
+      ],
+    );
+
+    // Fetch the resulting row by natural key — works for both INSERT and UPDATE.
+    const [rows] = await getAppPool().query(
+      'SELECT * FROM tenant_portal_config_items WHERE church_id = ? AND config_key = ?',
+      [churchId, configKey],
+    );
+
+    res.json({
+      item: shapeRow(rows[0]),
+      action: result.affectedRows === 1 ? 'inserted' : 'updated',
+    });
+  } catch (err) {
+    console.error('[tenant-config] set error:', err);
+    res.status(500).json({ error: 'Failed to upsert tenant config item' });
+  }
+});
+
+// ── DELETE /api/tenant-config/delete/:id ─────────────────────────────────
+
+router.delete('/delete/:id', requireRole(['super_admin', 'admin']), async (req, res) => {
+  try {
+    const id = parseId(req.params.id);
+    if (!id) return res.status(400).json({ error: 'invalid id' });
+
+    const [result] = await getAppPool().query(
+      'DELETE FROM tenant_portal_config_items WHERE id = ?',
+      [id],
+    );
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'not found' });
+    }
+    res.json({ ok: true, deleted_id: id });
+  } catch (err) {
+    console.error('[tenant-config] delete error:', err);
+    res.status(500).json({ error: 'Failed to delete tenant config item' });
+  }
+});
+
+module.exports = router;

--- a/server/src/scripts/seed-tenant-portal-config.js
+++ b/server/src/scripts/seed-tenant-portal-config.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * OMOD-1502 — seed tenant_portal_config_items for a given church_id.
+ *
+ * Usage:
+ *   node server/src/scripts/seed-tenant-portal-config.js <church_id>
+ *   node server/src/scripts/seed-tenant-portal-config.js 46
+ *
+ * Idempotent — uses INSERT ... ON DUPLICATE KEY UPDATE on the natural key
+ * (church_id, config_key). Safe to re-run; will refresh existing rows to
+ * the canonical OMOD-1498 audit defaults without overwriting is_active=0
+ * status (preserves operator soft-disables).
+ *
+ * V1 baseline drawn from the OMOD-1498 audit categories (12 categories,
+ * including 'auth' which §C omits but the audit identified as a real
+ * cross-cutting category — table enum already extends §C to include it).
+ *
+ * This is a SEED, not a migration — opt-in per church. The migration only
+ * creates the table; this populates it with the safe-known-good baseline
+ * derived from the live OM code at audit time.
+ */
+
+'use strict';
+
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
+
+const mysql = require('mysql2/promise');
+
+const SEED_CONFIG_KEY = 'OMOD-1502:v1';
+
+// One row per audit config-item. Keys mirror the §C schema. Each row applies
+// to ANY church (the audit is structural — what the portal exposes, not
+// what data lives there). Operator can disable individual rows for a tenant
+// after seeding via the admin UI.
+const SEED_ROWS = [
+  // ── portal ────────────────────────────────────────────────────────────
+  { config_key: 'portal.layout.chrome', display_name: 'Portal layout chrome', category: 'portal', target_surface: 'front-end/src/layouts/portal/ChurchPortalLayout.tsx', user_roles: ['super_admin','admin','church_admin','priest','deacon','editor'], current_source: { frontend_file: 'front-end/src/layouts/portal/ChurchPortalLayout.tsx', hardcoded: true }, current_behavior: 'HpHeader + Container + SiteFooter', omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'low' } },
+  { config_key: 'portal.layout.unauthenticated_redirect', display_name: 'Unauthenticated redirect target', category: 'portal', target_surface: 'front-end/src/layouts/portal/ChurchPortalLayout.tsx:27', current_source: { frontend_file: 'front-end/src/layouts/portal/ChurchPortalLayout.tsx', hardcoded: true }, current_behavior: 'Redirects to /auth/login', omstudio_package_relevance: { can_be_targeted_by_omstudio: false, package_slot_candidate: false, requires_preflight_validation: false, risk_level: 'low' } },
+  { config_key: 'portal.dashboard.hub_root', display_name: 'Portal dashboard hub root', category: 'portal', target_surface: 'front-end/src/features/portal/ChurchPortalHub.tsx', user_roles: ['super_admin','admin','church_admin','priest','deacon','editor'], current_source: { frontend_file: 'front-end/src/features/portal/ChurchPortalHub.tsx', hardcoded: false }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'medium' } },
+  { config_key: 'portal.dashboard.hero_image', display_name: 'Hero banner image', category: 'portal', target_surface: 'front-end/src/features/portal/HeroBanner.tsx:9-13', current_source: { frontend_file: 'front-end/src/features/portal/HeroBanner.tsx', hardcoded: true, db_column: null }, current_behavior: 'HARDCODED HERO_IMAGES map; only church 46 has an entry today', gaps_or_risks: ['No DB column or admin UI controls hero image; Phase 5 must add this'], omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'high', notes: 'High-priority gap from OMOD-1498 audit' } },
+  { config_key: 'portal.dashboard.greeting_text', display_name: 'Welcome greeting', category: 'portal', target_surface: 'front-end/src/features/portal/ChurchPortalHub.tsx:71-82', current_source: { frontend_file: 'front-end/src/features/portal/ChurchPortalHub.tsx', hardcoded: true }, current_behavior: 'Composed from useAuth() user profile', omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: false, requires_preflight_validation: false, risk_level: 'low' } },
+  { config_key: 'portal.dashboard.role_label', display_name: 'Role chip label', category: 'portal', target_surface: 'front-end/src/features/portal/ChurchPortalHub.tsx:71-82', current_source: { frontend_file: 'front-end/src/features/portal/ChurchPortalHub.tsx', db_column: 'users.role', hardcoded: false }, omstudio_package_relevance: { can_be_targeted_by_omstudio: false, package_slot_candidate: false, requires_preflight_validation: false, risk_level: 'low' } },
+  { config_key: 'portal.dashboard.state_machine', display_name: 'Onboarding/Pipeline/Dashboard tri-state', category: 'portal', target_surface: 'front-end/src/features/portal/ChurchPortalHub.tsx:530-537', current_source: { frontend_file: 'front-end/src/features/portal/ChurchPortalHub.tsx', hardcoded: true }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: false, requires_preflight_validation: true, risk_level: 'medium' } },
+  { config_key: 'portal.dashboard.search_box', display_name: 'Global search box', category: 'portal', target_surface: 'front-end/src/features/portal/ChurchPortalHub.tsx:317-421', current_source: { frontend_file: 'front-end/src/features/portal/ChurchPortalHub.tsx', backend_route: '/api/{baptism,marriage,funeral}-records?search=' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'medium' } },
+  { config_key: 'portal.dashboard.recent_activity', display_name: 'Recent activity panel', category: 'portal', target_surface: 'front-end/src/features/portal/ChurchPortalHub.tsx:442-469', current_source: { frontend_file: 'front-end/src/features/portal/ChurchPortalHub.tsx', backend_route: '/api/{baptism,marriage,funeral}-records?limit=5' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'medium' } },
+  { config_key: 'portal.dashboard.record_pipeline', display_name: 'Record pipeline stage bar', category: 'portal', target_surface: 'front-end/src/features/portal/RecordPipelineStatus.tsx', current_source: { frontend_file: 'front-end/src/features/portal/RecordPipelineStatus.tsx', backend_route: '/api/record-batches/summary', db_table: 'record_batches', db_column: 'status' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'medium' } },
+  { config_key: 'portal.dashboard.scope_resolution', display_name: 'Active church scope resolution', category: 'portal', target_surface: 'front-end/src/features/portal/ChurchPortalHub.tsx:269', current_source: { backend_route: '/api/my/churches', db_table: 'churches' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: false, package_slot_candidate: false, requires_preflight_validation: true, risk_level: 'low' } },
+
+  // ── records ───────────────────────────────────────────────────────────
+  { config_key: 'records.baptism.list', display_name: 'Baptism records list', category: 'records', target_surface: '/portal/records/baptism', user_roles: ['super_admin','admin','church_admin','priest','deacon','editor'], current_source: { frontend_file: 'front-end/src/features/records-centralized/components/baptism/BaptismRecordsPage.tsx', backend_route: '/api/baptism-records', db_table: 'baptism_records' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'medium' } },
+  { config_key: 'records.baptism.detail', display_name: 'Baptism record detail', category: 'records', target_surface: '/portal/records/baptism/:id', current_source: { backend_route: '/api/baptism-records/:id', db_table: 'baptism_records' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: false, requires_preflight_validation: true, risk_level: 'low' } },
+  { config_key: 'records.baptism.add', display_name: 'Add baptism record', category: 'records', target_surface: '/portal/records/baptism/new', current_source: { backend_route: 'POST /api/baptism-records', db_table: 'baptism_records' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: false, requires_preflight_validation: true, risk_level: 'low' } },
+  { config_key: 'records.baptism.edit', display_name: 'Edit baptism record', category: 'records', target_surface: '/portal/records/baptism/edit/:id', current_source: { backend_route: 'PUT /api/baptism-records/:id', db_table: 'baptism_records' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: false, requires_preflight_validation: true, risk_level: 'low' } },
+  { config_key: 'records.marriage.list', display_name: 'Marriage records list', category: 'records', target_surface: '/portal/records/marriage', current_source: { backend_route: '/api/marriage-records', db_table: 'marriage_records' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'medium' } },
+  { config_key: 'records.marriage.add', display_name: 'Add marriage record', category: 'records', target_surface: '/portal/records/marriage/new', current_source: { backend_route: 'POST /api/marriage-records', db_table: 'marriage_records' } },
+  { config_key: 'records.marriage.edit', display_name: 'Edit marriage record', category: 'records', target_surface: '/portal/records/marriage/edit/:id', current_source: { backend_route: 'PUT /api/marriage-records/:id', db_table: 'marriage_records' } },
+  { config_key: 'records.funeral.list', display_name: 'Funeral records list', category: 'records', target_surface: '/portal/records/funeral', current_source: { backend_route: '/api/funeral-records', db_table: 'funeral_records' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'medium' } },
+  { config_key: 'records.funeral.add', display_name: 'Add funeral record', category: 'records', target_surface: '/portal/records/funeral/new', current_source: { backend_route: 'POST /api/funeral-records', db_table: 'funeral_records' } },
+  { config_key: 'records.funeral.edit', display_name: 'Edit funeral record', category: 'records', target_surface: '/portal/records/funeral/edit/:id', current_source: { backend_route: 'PUT /api/funeral-records/:id', db_table: 'funeral_records' } },
+  { config_key: 'records.batches.summary', display_name: 'Record batches summary', category: 'records', target_surface: 'front-end/src/features/portal/RecordPipelineStatus.tsx', current_source: { backend_route: '/api/record-batches/summary', db_table: 'record_batches' } },
+  { config_key: 'records.dropdown_options', display_name: 'Record entry dropdown options', category: 'records', target_surface: 'records entry pages', current_source: { backend_route: '/api/{type}-records/dropdown-options/:field' }, gaps_or_risks: ['Source table not verified — values may come from records or a lookup table'] },
+
+  // ── branding ──────────────────────────────────────────────────────────
+  { config_key: 'branding.logo_path', display_name: 'Logo image path', category: 'branding', target_surface: 'Account → Branding', user_roles: ['super_admin','admin','church_admin'], current_source: { frontend_file: 'front-end/src/features/account/AccountBrandingPage.tsx', backend_route: 'POST /api/my/church-branding/:field', db_column: 'churches.logo_path' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'low' } },
+  { config_key: 'branding.logo_dark_path', display_name: 'Dark-mode logo path', category: 'branding', target_surface: 'Account → Branding', current_source: { db_column: 'churches.logo_dark_path' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'low' } },
+  { config_key: 'branding.favicon_path', display_name: 'Favicon path', category: 'branding', target_surface: 'Account → Branding', current_source: { db_column: 'churches.favicon_path' }, omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: false, requires_preflight_validation: false, risk_level: 'low' } },
+  { config_key: 'branding.primary_color', display_name: 'Primary brand color', category: 'branding', target_surface: 'Theme Studio + church profile', current_source: { backend_route: '/api/parish-settings/:id/theme', db_table: 'parish_settings + churches.primary_color' }, gaps_or_risks: ['DUAL source of truth: parish_settings.theme + churches.primary_color column'], omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'high' } },
+  { config_key: 'branding.secondary_color', display_name: 'Secondary brand color', category: 'branding', target_surface: 'Theme Studio', current_source: { db_table: 'parish_settings + churches.secondary_color' }, gaps_or_risks: ['Same dual-source as primary_color'] },
+  { config_key: 'branding.hero_image', display_name: 'Hero banner image (per-tenant)', category: 'branding', target_surface: 'front-end/src/features/portal/HeroBanner.tsx', current_source: { frontend_file: 'front-end/src/features/portal/HeroBanner.tsx', hardcoded: true, db_column: null }, gaps_or_risks: ['No DB column or admin UI; hardcoded for church 46 only'], omstudio_package_relevance: { can_be_targeted_by_omstudio: true, package_slot_candidate: true, requires_preflight_validation: true, risk_level: 'high' } },
+  { config_key: 'branding.theme_full', display_name: 'Full theme preset', category: 'branding', target_surface: 'parish-management/ThemeStudioPage.tsx', current_source: { backend_route: '/api/admin/churches/:id/themes', db_table: 'orthodoxmetrics_db.church_themes' }, gaps_or_risks: ['Third theme storage location — registry must collapse three sources'] },
+  { config_key: 'branding.landing_page_image', display_name: 'Landing page branding image', category: 'branding', target_surface: 'parish-management/LandingPageBrandingPage.tsx', current_source: { backend_route: 'POST /api/my/church-branding/:field' } },
+
+  // ── church_profile ────────────────────────────────────────────────────
+  { config_key: 'church_profile.name', display_name: 'Church name', category: 'church_profile', target_surface: 'Account → Church Details', current_source: { backend_route: '/api/my/church-settings', db_column: 'churches.name + church_name (legacy)' } },
+  { config_key: 'church_profile.contact_email', display_name: 'Contact email', category: 'church_profile', current_source: { db_column: 'churches.email' } },
+  { config_key: 'church_profile.phone', display_name: 'Phone', category: 'church_profile', current_source: { db_column: 'churches.phone' } },
+  { config_key: 'church_profile.website', display_name: 'Website URL', category: 'church_profile', current_source: { db_column: 'churches.website' } },
+  { config_key: 'church_profile.address.line1', display_name: 'Address', category: 'church_profile', current_source: { db_column: 'churches.address' } },
+  { config_key: 'church_profile.address.city', display_name: 'City', category: 'church_profile', current_source: { db_column: 'churches.city' } },
+  { config_key: 'church_profile.address.state', display_name: 'State/province', category: 'church_profile', current_source: { db_column: 'churches.state_province' } },
+  { config_key: 'church_profile.address.postal', display_name: 'Postal code', category: 'church_profile', current_source: { db_column: 'churches.postal_code' } },
+  { config_key: 'church_profile.address.country', display_name: 'Country', category: 'church_profile', current_source: { db_column: 'churches.country' } },
+  { config_key: 'church_profile.preferred_language', display_name: 'Preferred language', category: 'church_profile', current_source: { db_column: 'churches.preferred_language' } },
+  { config_key: 'church_profile.timezone', display_name: 'Timezone', category: 'church_profile', current_source: { db_column: 'churches.timezone' } },
+  { config_key: 'church_profile.currency', display_name: 'Currency', category: 'church_profile', current_source: { db_column: 'churches.currency' } },
+  { config_key: 'church_profile.calendar_type', display_name: 'Calendar type', category: 'church_profile', current_source: { db_column: 'churches.calendar_type' } },
+  { config_key: 'church_profile.tax_id', display_name: 'Tax ID', category: 'church_profile', current_source: { db_column: 'churches.tax_id' } },
+  { config_key: 'church_profile.jurisdiction', display_name: 'Jurisdiction', category: 'church_profile', current_source: { backend_route: '/api/jurisdictions', db_table: 'jurisdictions + churches.jurisdiction_id' } },
+  { config_key: 'church_profile.description_multilang', display_name: 'Multilang description', category: 'church_profile', current_source: { db_column: 'churches.description_multilang' } },
+  { config_key: 'church_profile.short_name', display_name: 'Short name (slug)', category: 'church_profile', current_source: { db_column: 'churches.short_name' } },
+  { config_key: 'church_profile.is_active', display_name: 'Church active flag', category: 'church_profile', user_roles: ['super_admin'], current_source: { db_column: 'churches.is_active' } },
+  { config_key: 'church_profile.setup_complete', display_name: 'Onboarding complete flag', category: 'church_profile', user_roles: ['super_admin'], current_source: { db_column: 'churches.setup_complete' } },
+  { config_key: 'church_profile.has_records', display_name: 'has_*_records flags', category: 'church_profile', current_source: { db_column: 'churches.has_baptism_records|has_marriage_records|has_funeral_records' }, gaps_or_risks: ['Flags exist but are NOT consulted in ChurchPortalHub.tsx — cards always render all three'] },
+
+  // ── navigation ────────────────────────────────────────────────────────
+  { config_key: 'navigation.role_default_landing', display_name: 'Role-based default landing', category: 'navigation', target_surface: 'Router.tsx:201-215', current_source: { frontend_file: 'front-end/src/routes/Router.tsx', hardcoded: true }, gaps_or_risks: ['Old default_landing_page column was explicitly removed from churches schema'] },
+  { config_key: 'navigation.portal.sidebar_items', display_name: 'Portal sidebar items', category: 'navigation', target_surface: 'ChurchPortalLayout uses HpHeader (no sidebar)', current_source: { hardcoded: true } },
+  { config_key: 'navigation.menu_permissions', display_name: 'Per-role menu visibility', category: 'navigation', current_source: { frontend_file: 'Router.tsx ProtectedRoute requiredRole', backend_route: '/api/menu-permissions' }, gaps_or_risks: ['Portal uses Router requiredRole; menu_permissions table not consulted — registry must unify'] },
+  { config_key: 'navigation.footer_text', display_name: 'Footer text', category: 'navigation', current_source: { frontend_file: 'SiteFooter component', hardcoded: true } },
+  { config_key: 'navigation.brand_header', display_name: 'Brand header text', category: 'navigation', current_source: { frontend_file: 'HpHeader', db_column: 'churches.name' } },
+
+  // ── permissions (subset — full set in audit) ───────────────────────────
+  { config_key: 'permissions.records.view', display_name: 'View records', category: 'permissions', user_roles: ['super_admin','admin','church_admin','priest','deacon','editor'], target_surface: '/portal/records/*', current_source: { frontend_file: 'portalRoutes.tsx' } },
+  { config_key: 'permissions.records.add', display_name: 'Add record', category: 'permissions', user_roles: ['super_admin','admin','church_admin','priest','deacon','editor'], target_surface: '/portal/records/{type}/new' },
+  { config_key: 'permissions.records.edit', display_name: 'Edit record', category: 'permissions', user_roles: ['super_admin','admin','church_admin','priest','deacon','editor'], target_surface: '/portal/records/{type}/edit/:id' },
+  { config_key: 'permissions.upload', display_name: 'Upload records', category: 'permissions', user_roles: ['super_admin','admin','church_admin','priest'], target_surface: '/portal/upload', current_behavior: 'Drops deacon + editor' },
+  { config_key: 'permissions.charts', display_name: 'Charts', category: 'permissions', user_roles: ['super_admin','admin','church_admin','priest'], target_surface: '/portal/charts' },
+  { config_key: 'permissions.certificates', display_name: 'Certificates', category: 'permissions', user_roles: ['super_admin','admin','church_admin','priest','deacon','editor'], target_surface: '/portal/certificates' },
+  { config_key: 'permissions.settings', display_name: 'Portal settings', category: 'permissions', user_roles: ['super_admin','admin','church_admin','priest'], target_surface: '/portal/settings' },
+  { config_key: 'permissions.ocr', display_name: 'OCR access', category: 'permissions', user_roles: ['super_admin','admin','church_admin','priest'], target_surface: '/portal/ocr*' },
+  { config_key: 'permissions.parish_management', display_name: 'Parish management hub', category: 'permissions', target_surface: '/account/parish-management/*', gaps_or_risks: ['Route-level role gate missing; only API enforces; non-admins see chrome'] },
+
+  // ── uploads ───────────────────────────────────────────────────────────
+  { config_key: 'uploads.records_csv', display_name: 'Records CSV import', category: 'uploads', current_source: { backend_route: 'POST /api/{type}-records/import' } },
+  { config_key: 'uploads.ocr_image', display_name: 'OCR image upload', category: 'uploads', user_roles: ['super_admin','admin','church_admin','priest'], current_source: { backend_route: 'POST /api/ocr/jobs/upload', db_table: 'ocr_jobs' } },
+  { config_key: 'uploads.ocr_retry', display_name: 'OCR job retry', category: 'uploads', current_source: { backend_route: 'POST /api/church/:churchId/ocr/jobs/:id/retry' } },
+  { config_key: 'uploads.ocr_review_status', display_name: 'OCR job review-status PATCH', category: 'uploads', current_source: { backend_route: 'PATCH /api/church/:churchId/ocr/jobs/:id/review-status' } },
+  { config_key: 'uploads.branding_image', display_name: 'Branding image upload', category: 'uploads', current_source: { backend_route: 'POST /api/my/church-branding/:field' } },
+
+  // ── analytics ─────────────────────────────────────────────────────────
+  { config_key: 'analytics.parish_summary', display_name: 'Parish summary stats', category: 'analytics', current_source: { backend_route: '/api/parish-stats/:churchId', db_table: 'baptism/marriage/funeral_records' } },
+  { config_key: 'analytics.feast_day_breakdown', display_name: 'Feast day breakdown', category: 'analytics', user_roles: ['admin','super_admin'], current_source: { backend_route: '/api/analytics/by-feast-day' } },
+  { config_key: 'analytics.charts', display_name: 'OM charts', category: 'analytics', user_roles: ['super_admin','admin','church_admin','priest'], target_surface: '/portal/charts', current_source: { backend_route: '/api/churches/:churchId/charts' } },
+  { config_key: 'analytics.clergy_tenure', display_name: 'Clergy tenure', category: 'analytics', current_source: { backend_route: '/api/churches/:churchId/clergy-tenure' } },
+
+  // ── layout ────────────────────────────────────────────────────────────
+  { config_key: 'layout.theme.studio', display_name: 'Theme Studio', category: 'layout', current_source: { backend_route: '/api/parish-settings/:id/theme', db_table: 'parish_settings (category=theme)' } },
+  { config_key: 'layout.theme.ui', display_name: 'UI theme', category: 'layout', current_source: { backend_route: '/api/parish-settings/:id/ui', db_table: 'parish_settings (category=ui)' } },
+  { config_key: 'layout.user_table_prefs', display_name: 'Per-user table prefs', category: 'layout', current_source: { backend_route: '/api/my/ui-preferences', db_table: 'user_table_settings' } },
+  { config_key: 'layout.landing_page_branding', display_name: 'Landing page branding', category: 'layout', current_source: { backend_route: 'POST /api/my/church-branding/:field' } },
+  { config_key: 'layout.search_configuration', display_name: 'Search configuration', category: 'layout', current_source: { backend_route: '/api/parish-settings/:id/search', db_table: 'parish_settings (category=search)' } },
+  { config_key: 'layout.system_behavior', display_name: 'System behavior', category: 'layout', current_source: { backend_route: '/api/parish-settings/:id/system', db_table: 'parish_settings (category=system)' } },
+  { config_key: 'layout.record_settings', display_name: 'Record settings', category: 'layout', gaps_or_risks: ['Persistence path not located in audit'] },
+  { config_key: 'layout.field_mapper', display_name: 'Field mapper', category: 'layout', current_source: { backend_route: '/api/admin/churches/:id/field-mapper', db_table: 'orthodoxmetrics_db.field_mapper_settings' } },
+  { config_key: 'layout.themes_admin', display_name: 'Admin theme writer', category: 'layout', user_roles: ['super_admin','admin'], current_source: { db_table: 'orthodoxmetrics_db.church_themes' }, gaps_or_risks: ['Third theme storage location'] },
+
+  // ── notifications ─────────────────────────────────────────────────────
+  { config_key: 'notifications.preferences', display_name: 'Notification preferences', category: 'notifications', current_source: { backend_route: '/api/notifications/preferences' } },
+  { config_key: 'notifications.list', display_name: 'Notification list', category: 'notifications', current_source: { backend_route: '/api/notifications', db_table: 'notifications' } },
+  { config_key: 'notifications.unread_counts', display_name: 'Unread counts', category: 'notifications', current_source: { backend_route: '/api/notifications/counts' } },
+  { config_key: 'notifications.queue_workflow', display_name: 'Notification queue', category: 'notifications', current_source: { db_table: 'notification_queue' } },
+
+  // ── tenant ────────────────────────────────────────────────────────────
+  { config_key: 'tenant.id', display_name: 'Active tenant id', category: 'tenant', tenant_scope: 'global', current_source: { backend_route: '/api/my/churches', db_table: 'churches' } },
+  { config_key: 'tenant.database_name', display_name: 'Tenant database name', category: 'tenant', current_source: { db_column: 'churches.database_name' } },
+  { config_key: 'tenant.crm_link', display_name: 'CRM link', category: 'tenant', current_source: { db_column: 'us_churches.provisioned_church_id' } },
+  { config_key: 'tenant.is_active', display_name: 'Tenant active flag', category: 'tenant', current_source: { db_column: 'churches.is_active' } },
+  { config_key: 'tenant.setup_complete', display_name: 'Tenant onboarding complete', category: 'tenant', current_source: { db_column: 'churches.setup_complete' } },
+
+  // ── auth (cross-cutting; §C omits, audit identified) ──────────────────
+  { config_key: 'auth.login', display_name: 'Login', category: 'auth', tenant_scope: 'global', current_source: { backend_route: 'POST /api/auth/login', db_table: 'users' } },
+  { config_key: 'auth.logout', display_name: 'Logout', category: 'auth', current_source: { backend_route: 'POST /api/auth/logout' } },
+  { config_key: 'auth.forgot_password', display_name: 'Forgot password', category: 'auth', current_source: { backend_route: 'POST /api/auth/forgot-password' } },
+  { config_key: 'auth.password_change', display_name: 'Change password', category: 'auth', current_source: { backend_route: 'PUT /api/user/profile/password' } },
+  { config_key: 'auth.security_status', display_name: 'Account security status', category: 'auth', current_source: { backend_route: '/api/user/profile/security-status' } },
+  { config_key: 'auth.email_verification_resend', display_name: 'Resend email verification', category: 'auth', current_source: { backend_route: 'POST /api/user/profile/resend-verification' } },
+  { config_key: 'auth.sessions.list', display_name: 'List active sessions', category: 'auth', current_source: { backend_route: '/api/user/sessions', db_table: 'refresh_tokens' } },
+  { config_key: 'auth.sessions.revoke_one', display_name: 'Revoke one session', category: 'auth', current_source: { backend_route: 'DELETE /api/user/sessions/:id' } },
+  { config_key: 'auth.sessions.revoke_others', display_name: 'Revoke other sessions', category: 'auth', current_source: { backend_route: 'POST /api/user/sessions/revoke-others' } },
+];
+
+async function main() {
+  const churchIdArg = parseInt(process.argv[2], 10);
+  if (!Number.isFinite(churchIdArg) || churchIdArg <= 0) {
+    console.error('Usage: node seed-tenant-portal-config.js <church_id>');
+    process.exit(2);
+  }
+
+  const pool = mysql.createPool({
+    host: process.env.DB_HOST || 'localhost',
+    user: process.env.DB_USER || 'orthodoxapps',
+    password: process.env.DB_PASSWORD || process.env.DB_PASS,
+    database: process.env.DB_NAME || 'orthodoxmetrics_db',
+    waitForConnections: true,
+    connectionLimit: 4,
+    connectTimeout: 30000,
+  });
+
+  try {
+    const [churches] = await pool.query(
+      'SELECT id, name, is_active FROM churches WHERE id = ?',
+      [churchIdArg],
+    );
+    if (!churches.length) {
+      console.error(`No church with id=${churchIdArg}`);
+      process.exit(3);
+    }
+    if (!churches[0].is_active) {
+      console.error(`Church ${churchIdArg} is inactive — refusing to seed`);
+      process.exit(4);
+    }
+    console.log(`Seeding ${SEED_ROWS.length} rows for church id=${churchIdArg} (${churches[0].name || 'unnamed'})...`);
+
+    let inserted = 0;
+    let updated = 0;
+    for (const row of SEED_ROWS) {
+      const userRolesJson = row.user_roles ? JSON.stringify(row.user_roles) : null;
+      const currentSourceJson = row.current_source ? JSON.stringify(row.current_source) : null;
+      const configurableFieldsJson = row.configurable_fields ? JSON.stringify(row.configurable_fields) : JSON.stringify([]);
+      const layoutContractJson = row.layout_contract ? JSON.stringify(row.layout_contract) : null;
+      const dependenciesJson = row.dependencies ? JSON.stringify(row.dependencies) : JSON.stringify({});
+      const omstudioRelevanceJson = row.omstudio_package_relevance ? JSON.stringify(row.omstudio_package_relevance) : null;
+      const gapsJson = row.gaps_or_risks ? JSON.stringify(row.gaps_or_risks) : JSON.stringify([]);
+
+      const [result] = await pool.query(
+        `INSERT INTO tenant_portal_config_items (
+           church_id, config_key, display_name, category, owning_system,
+           target_surface, user_roles, tenant_scope, current_source,
+           current_behavior, configurable_fields, layout_contract,
+           dependencies, omstudio_package_relevance, gaps_or_risks,
+           is_active
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+         ON DUPLICATE KEY UPDATE
+           display_name              = VALUES(display_name),
+           category                  = VALUES(category),
+           target_surface            = VALUES(target_surface),
+           user_roles                = VALUES(user_roles),
+           tenant_scope              = VALUES(tenant_scope),
+           current_source            = VALUES(current_source),
+           current_behavior          = VALUES(current_behavior),
+           configurable_fields       = VALUES(configurable_fields),
+           layout_contract           = VALUES(layout_contract),
+           dependencies              = VALUES(dependencies),
+           omstudio_package_relevance = VALUES(omstudio_package_relevance),
+           gaps_or_risks             = VALUES(gaps_or_risks)
+           -- NB: is_active intentionally NOT in the UPDATE clause — preserves
+           -- operator soft-disables across re-seeds.`,
+        [
+          churchIdArg,
+          row.config_key,
+          row.display_name || null,
+          row.category,
+          row.owning_system || 'OM',
+          row.target_surface || null,
+          userRolesJson,
+          row.tenant_scope || 'per_church',
+          currentSourceJson,
+          row.current_behavior || null,
+          configurableFieldsJson,
+          layoutContractJson,
+          dependenciesJson,
+          omstudioRelevanceJson,
+          gapsJson,
+        ],
+      );
+      // mysql2 returns affectedRows=1 on insert, 2 on update of existing
+      if (result.affectedRows === 1) inserted += 1;
+      else if (result.affectedRows === 2) updated += 1;
+    }
+
+    console.log(`Done. inserted=${inserted} updated=${updated} total=${SEED_ROWS.length} (seed=${SEED_CONFIG_KEY})`);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary

Implements the OM-side per-tenant portal configuration registry per OMSD-1491 §C — Phase 5 of 8. Materializes the §C schema as a SQL table + CRUD endpoints, plus a service-token-gated platform endpoint that OMStudio's preflight validator reads. Unblocks the warn-cascade in OMStudio's `lib/packages/index.js` (`tenantConfigResolver` flips from null stub to real HTTP call in a follow-up OMSD slice — out of scope for this PR).

7 files / +1,369 lines. No edits under `/var/www/omai` or `/var/www/omstudio`.

## Files

| File | Purpose |
|---|---|
| `server/database/migrations/20260508_create_tenant_portal_config_items.sql` | Migration. FK `churches.id` ON DELETE CASCADE, UNIQUE(church_id, config_key), JSON columns per §C. Category enum extends §C with `auth` (the cross-cutting category OMOD-1498 audit identified). |
| `server/src/routes/tenant-config.js` | CRUD: POST `/list` (filter by category + include_inactive), GET `/get/:id`, POST `/set` (admin/super_admin, upsert by natural key), DELETE `/delete/:id` (admin/super_admin). |
| `server/src/routes/platform.js` | Adds GET `/tenant-config/known-slots` (X-Service-Token + X-On-Behalf-Of-Email + X-Source-System=omstudio gates). Returns the compatibility.js-shaped object: `{exists, modules, known_slots, active_roles, branding, theme_modes, registry_row_count, registry_version}`. **Returns 404** for unknown church (NOT 200{exists:false}) so OMStudio's resolver distinguishes "registry not shipped" (null from connector) from "tenant not found" (404 → null, but logged differently). Per the connector contract. |
| `server/src/index.ts` | Mounts `/api/tenant-config`. |
| `front-end/src/features/admin/tenant-portal-config/TenantPortalConfigPage.tsx` | Operator UI: church picker, category filter, list, MUI dialog with JSON editors for the structured fields, soft-delete toggle. |
| `front-end/src/routes/Router.tsx` | New `/admin/tenant-portal-config` route, `<ProtectedRoute requiredRole={['super_admin','admin']}>`. |
| `server/src/scripts/seed-tenant-portal-config.js` | Operator-runnable seed. 101 baseline config-items derived from OMOD-1498 audit. Idempotent (`INSERT … ON DUPLICATE KEY UPDATE`); preserves operator soft-disables (does not overwrite `is_active=0`). |

## Verification

### Pre-merge

- [x] `node -c` parse on all 3 new/modified `.js` files
- [x] Migration applied cleanly against `orthodoxmetrics_db` on .241; SHOW CREATE TABLE confirmed FK + UNIQUE + JSON CHECK constraints all present
- [x] SQL-level INSERT/upsert/JSON-roundtrip/list/cleanup smoke against church 46
- [x] FK gate verified (`ER_NO_REFERENCED_ROW_2` on bad church_id)

### Post-deploy (this build, on .239 prod)

- [x] Backend deployed via `om-deploy.sh be` — build 1.0.0.84 — service restarted, `/api/system/health` 200
- [x] Frontend deployed via `om-deploy.sh fe` — build 1.0.0.85
- [x] Seed run `node src/scripts/seed-tenant-portal-config.js 46` produced 101 rows across all 12 categories (portal:11, records:12, branding:8, church_profile:20, navigation:5, permissions:9, uploads:5, analytics:4, layout:9, notifications:4, tenant:5, auth:9)
- [x] Idempotency: re-running the seed produces no row count change
- [x] **Cross-system handshake on `/api/platform/tenant-config/known-slots`** all gates pass:
  - 401 `missing_service_token` when token absent
  - 403 `source_system_not_allowed` when `X-Source-System` ≠ `omstudio`
  - 400 `missing_on_behalf_of_email` when on-behalf header missing
  - 400 `invalid_email` on malformed email
  - 400 `missing_tenant_id` on missing query param
  - 404 `tenant_not_found` on unknown church_id
  - 200 with full shape on valid headers + tenant_id=46 (101 known_slots, 76 modules, 6 active_roles)
- [x] CRUD `/api/tenant-config/*` all gates pass:
  - 401 on writes without auth
  - 200 on POST `/list` filtered by category
  - 200 on GET `/get/:id` with JSON columns parsed correctly
  - 200 on POST `/set` (insert action) by super_admin
  - 200 on DELETE `/delete/:id` (then 404 on repeat)

### Smoke test commands (for reviewer)

```bash
SVC_TOKEN=$(grep '^OMSTUDIO_SERVICE_TOKEN=' /var/www/orthodoxmetrics/prod/server/.env | cut -d= -f2-)
curl -sS "http://127.0.0.1:3001/api/platform/tenant-config/known-slots?tenant_id=46" \
  -H "X-Service-Token: $SVC_TOKEN" \
  -H "X-On-Behalf-Of-Email: omsvc@orthodoxmetrics.com" \
  -H "X-Source-System: omstudio" | jq .registry_row_count
# → 101
```

## Cross-system contract notes

- Endpoint headers match OMStudio's `services/platformConnections/connector.js`: `X-Service-Token`, `X-On-Behalf-Of-Email`, `X-Source-System`. Connector sends `X-Source-System: omstudio`; we validate it explicitly (defense in depth — leaked service token alone is not enough).
- 404 vs 200{exists:false}: returns 404 for unknown church_id so OMStudio's resolver can distinguish the two states. Per `compatibility.js` lines 67-71.
- No ETag/caching in V1. The connector's `getJson()` doesn't send `If-None-Match`. Matches the documented connector contract.
- V1 is informational. V2 (separate work item) will activate enforcement gates.

## Reversibility

- **Migration:** `CREATE TABLE IF NOT EXISTS` (idempotent). Reversal: `DROP TABLE tenant_portal_config_items;`
- **Backend:** purely additive. Reversal: remove `app.use('/api/tenant-config', …)` in `index.ts` and the new endpoint block in `platform.js`.
- **Frontend:** new admin page + new gated route. Reversal: remove the route + page file.
- **Seed:** opt-in script, never auto-runs. Reversal: delete the file.
- **OMStudio side:** zero changes here. The OMSD slice that flips `tenantConfigResolver` from null to a real HTTP call is a separate work item.

## Plan-type / governance

- Plan type: `feature.implementation` v4
- Bundles applied at start: `om.claude.global` v3, `cross-system.agent.global` v3, `cross-system.workflow.work-item-lifecycle` v2
- Resolver warnings: `feature.implementation` plan_type owning_system=omstudio (used intentionally per master plan); substrate scope filter not yet implemented (cosmetic).
- Allowed paths honored: only `/var/www/orthodoxmetrics/prod/**` touched (via `/var/www/om-workspaces/agent-claude2`). No edits to OMAI or OMStudio source.

## Closes / unblocks

- Phase 5 of `OMSD-1491` (Church Portal Configuration Master Plan).
- Unblocks the OMSD follow-up where OMStudio's `lib/packages/index.js` flips `tenantConfigResolver` from null stub to a real HTTP call against this endpoint.
- Sibling: `OMSD-1499` (OMStudio Package Intake Compatibility Registry — defines the consumer contract this endpoint serves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)