### PR TITLE
OMOD-1592: superadmin Ecosystem Roadmap page (read-only OMStudio proxy)

### DIFF
--- a/front-end/src/features/admin/ecosystem-roadmap/EcosystemRoadmapPage.tsx
+++ b/front-end/src/features/admin/ecosystem-roadmap/EcosystemRoadmapPage.tsx
@@ -1,0 +1,197 @@
+/**
+ * EcosystemRoadmapPage — superadmin/admin-only read-only view of the canonical
+ * Component Maturity Roadmap owned by OMStudio.
+ *
+ * Data is fetched from OM's thin proxy at /api/admin/ecosystem-roadmap, which
+ * forwards server-to-server to OMStudio /api/governance/component-roadmap.
+ * The page never writes; OMStudio remains the canonical owner.
+ */
+
+import { apiClient } from '@/api/utils/axiosInstance';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Divider,
+  Link,
+  Paper,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import RoadmapGantt from './RoadmapGantt';
+import RoadmapTable from './RoadmapTable';
+import type { EcosystemRoadmapResponse, RoadmapComponent } from './types';
+
+type View = 'table' | 'gantt';
+
+const EcosystemRoadmapPage: React.FC = () => {
+  const [response, setResponse] = useState<EcosystemRoadmapResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<View>('table');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiClient.get<EcosystemRoadmapResponse>('/admin/ecosystem-roadmap');
+      setResponse(res.data);
+    } catch (err: any) {
+      const msg =
+        err?.response?.data?.detail ||
+        err?.response?.data?.error ||
+        err?.message ||
+        'Failed to load roadmap';
+      setError(String(msg));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const components: RoadmapComponent[] = useMemo(() => {
+    if (!response || !response.available) return [];
+    const data = response.data;
+    if (!data || !Array.isArray(data.components)) return [];
+    return data.components;
+  }, [response]);
+
+  return (
+    <Container maxWidth="xl" sx={{ py: 3 }}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} alignItems={{ sm: 'center' }} spacing={2} sx={{ mb: 2 }}>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="h4" component="h1" fontWeight={600}>
+            Ecosystem Roadmap
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Read-only view of the canonical Component Maturity Roadmap. Canonical
+            source: <strong>OMStudio</strong>. OM does not store or modify this data.
+          </Typography>
+        </Box>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={load}
+          startIcon={<RefreshIcon />}
+          disabled={loading}
+        >
+          Refresh
+        </Button>
+      </Stack>
+
+      <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 }, mb: 2 }}>
+        {loading && (
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <CircularProgress size={18} />
+            <Typography variant="body2" color="text.secondary">
+              Loading roadmap from OMStudio…
+            </Typography>
+          </Stack>
+        )}
+
+        {!loading && error && (
+          <Alert severity="error">
+            <AlertTitle>Failed to load roadmap</AlertTitle>
+            <Typography variant="body2">{error}</Typography>
+            <Box sx={{ mt: 1 }}>
+              <Button size="small" onClick={load}>
+                Retry
+              </Button>
+            </Box>
+          </Alert>
+        )}
+
+        {!loading && !error && response && !response.available && (
+          <Alert
+            severity={
+              response.error === 'endpoint_not_yet_published' ? 'info' : 'warning'
+            }
+          >
+            <AlertTitle>
+              {response.error === 'endpoint_not_yet_published'
+                ? 'Upstream endpoint not yet available'
+                : 'OMStudio reachability issue'}
+            </AlertTitle>
+            <Typography variant="body2">
+              {response.detail ||
+                'The OMStudio component-roadmap endpoint is not currently available.'}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+              Upstream: <code>{response.upstream}</code>
+            </Typography>
+          </Alert>
+        )}
+
+        {!loading && !error && response && response.available && (
+          <Stack spacing={1}>
+            <Stack direction="row" spacing={2} alignItems="baseline" flexWrap="wrap">
+              <Typography variant="caption" color="text.secondary">
+                Fetched: {new Date(response.fetched_at).toLocaleString()}
+              </Typography>
+              {response.data?.generated_at && (
+                <Typography variant="caption" color="text.secondary">
+                  Roadmap generated: {new Date(response.data.generated_at).toLocaleString()}
+                </Typography>
+              )}
+              {response.data?.source_url && (
+                <Link
+                  href={response.data.source_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="caption"
+                >
+                  Source
+                </Link>
+              )}
+              <Typography variant="caption" color="text.secondary">
+                Components: {components.length}
+              </Typography>
+            </Stack>
+            {response.data?.notes && (
+              <Typography variant="body2" color="text.secondary">
+                {response.data.notes}
+              </Typography>
+            )}
+          </Stack>
+        )}
+      </Paper>
+
+      {!loading && !error && response && response.available && (
+        <>
+          <Tabs
+            value={view}
+            onChange={(_e, v) => setView(v)}
+            sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+            variant="scrollable"
+            allowScrollButtonsMobile
+          >
+            <Tab value="table" label="Component table" />
+            <Tab value="gantt" label="Gantt / milestones" />
+          </Tabs>
+
+          {view === 'table' && <RoadmapTable components={components} />}
+          {view === 'gantt' && <RoadmapGantt components={components} />}
+
+          <Divider sx={{ my: 3 }} />
+          <Typography variant="caption" color="text.secondary">
+            OM is a read-only consumer. To update the roadmap, change the source
+            in OMStudio. Any roadmap data displayed here reflects what OMStudio
+            published at the time of fetch.
+          </Typography>
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default EcosystemRoadmapPage;

--- a/front-end/src/features/admin/ecosystem-roadmap/RoadmapGantt.tsx
+++ b/front-end/src/features/admin/ecosystem-roadmap/RoadmapGantt.tsx
@@ -1,0 +1,272 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Stack,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import type { RoadmapComponent, RoadmapPhase } from './types';
+
+interface Props {
+  components: RoadmapComponent[];
+}
+
+interface Span {
+  componentId: string;
+  componentName: string;
+  phase: RoadmapPhase;
+  startMs: number;
+  endMs: number;
+}
+
+const STATUS_HUE: Record<string, string> = {
+  green: '#2e7d32',
+  done: '#2e7d32',
+  in_progress: '#1976d2',
+  planning: '#0288d1',
+  yellow: '#ed6c02',
+  red: '#d32f2f',
+  blocked: '#d32f2f',
+};
+
+function parseDate(s: string): number | null {
+  if (!s) return null;
+  const ms = Date.parse(s);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function formatTickLabel(ms: number) {
+  const d = new Date(ms);
+  return d.toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
+}
+
+function buildTicks(minMs: number, maxMs: number, count = 5): number[] {
+  if (count <= 1 || maxMs <= minMs) return [minMs];
+  const step = (maxMs - minMs) / (count - 1);
+  return Array.from({ length: count }, (_, i) => minMs + i * step);
+}
+
+const RoadmapGantt: React.FC<Props> = ({ components }) => {
+  const theme = useTheme();
+
+  const { rows, minMs, maxMs } = useMemo(() => {
+    const spans: Span[] = [];
+    let lo = Infinity;
+    let hi = -Infinity;
+    for (const c of components) {
+      for (const p of c.phases || []) {
+        const startMs = parseDate(p.start_date);
+        const endMs = parseDate(p.end_date);
+        if (startMs === null || endMs === null || endMs < startMs) continue;
+        if (startMs < lo) lo = startMs;
+        if (endMs > hi) hi = endMs;
+        spans.push({
+          componentId: c.id,
+          componentName: c.name,
+          phase: p,
+          startMs,
+          endMs,
+        });
+      }
+    }
+    const byComponent = new Map<string, Span[]>();
+    for (const s of spans) {
+      const arr = byComponent.get(s.componentId) || [];
+      arr.push(s);
+      byComponent.set(s.componentId, arr);
+    }
+    return {
+      rows: Array.from(byComponent.entries()).map(([id, list]) => ({
+        id,
+        name: list[0].componentName,
+        spans: list.sort((a, b) => a.startMs - b.startMs),
+      })),
+      minMs: Number.isFinite(lo) ? lo : 0,
+      maxMs: Number.isFinite(hi) ? hi : 0,
+    };
+  }, [components]);
+
+  if (rows.length === 0) {
+    return (
+      <Box
+        sx={{
+          py: 4,
+          textAlign: 'center',
+          border: `1px dashed ${theme.palette.divider}`,
+          borderRadius: 1,
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          No phase or milestone dates reported. The Gantt visual will populate
+          once OMStudio publishes phase data with start/end dates.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const ticks = buildTicks(minMs, maxMs, 5);
+  const spanRange = Math.max(1, maxMs - minMs);
+  const leftLabelCol = 200;
+
+  return (
+    <Box
+      sx={{
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: 1,
+        overflowX: 'auto',
+        backgroundColor: theme.palette.background.paper,
+      }}
+    >
+      <Box sx={{ minWidth: 700 }}>
+        {/* Header / time axis */}
+        <Box
+          sx={{
+            display: 'flex',
+            borderBottom: `1px solid ${theme.palette.divider}`,
+            backgroundColor: theme.palette.action.hover,
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+          }}
+        >
+          <Box sx={{ width: leftLabelCol, p: 1 }}>
+            <Typography variant="caption" fontWeight={600}>
+              Component
+            </Typography>
+          </Box>
+          <Box sx={{ flex: 1, position: 'relative', height: 32 }}>
+            {ticks.map((t, i) => (
+              <Box
+                key={i}
+                sx={{
+                  position: 'absolute',
+                  top: 0,
+                  bottom: 0,
+                  left: `${((t - minMs) / spanRange) * 100}%`,
+                  borderLeft: `1px dashed ${theme.palette.divider}`,
+                  pl: 0.5,
+                  display: 'flex',
+                  alignItems: 'center',
+                }}
+              >
+                <Typography variant="caption" color="text.secondary">
+                  {formatTickLabel(t)}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+
+        {/* Rows */}
+        {rows.map((row) => (
+          <Box
+            key={row.id}
+            sx={{
+              display: 'flex',
+              borderBottom: `1px solid ${theme.palette.divider}`,
+              minHeight: 40,
+            }}
+          >
+            <Box
+              sx={{
+                width: leftLabelCol,
+                p: 1,
+                borderRight: `1px solid ${theme.palette.divider}`,
+              }}
+            >
+              <Typography variant="body2" fontWeight={500} noWrap>
+                {row.name}
+              </Typography>
+            </Box>
+            <Box sx={{ flex: 1, position: 'relative' }}>
+              {/* Background grid lines */}
+              {ticks.map((t, i) => (
+                <Box
+                  key={i}
+                  sx={{
+                    position: 'absolute',
+                    top: 0,
+                    bottom: 0,
+                    left: `${((t - minMs) / spanRange) * 100}%`,
+                    borderLeft: `1px dashed ${theme.palette.divider}`,
+                  }}
+                />
+              ))}
+              {/* Spans */}
+              {row.spans.map((s, i) => {
+                const left = ((s.startMs - minMs) / spanRange) * 100;
+                const width = Math.max(
+                  0.8,
+                  ((s.endMs - s.startMs) / spanRange) * 100,
+                );
+                const hue =
+                  STATUS_HUE[String(s.phase.status || '').toLowerCase()] ||
+                  theme.palette.primary.main;
+                return (
+                  <Tooltip
+                    key={i}
+                    arrow
+                    title={
+                      <Stack spacing={0.5}>
+                        <Typography variant="caption" fontWeight={600}>
+                          {s.phase.name}
+                        </Typography>
+                        <Typography variant="caption">
+                          {new Date(s.startMs).toLocaleDateString()} —{' '}
+                          {new Date(s.endMs).toLocaleDateString()}
+                        </Typography>
+                        {s.phase.status && (
+                          <Typography variant="caption">
+                            status: {s.phase.status}
+                          </Typography>
+                        )}
+                        {typeof s.phase.progress_pct === 'number' && (
+                          <Typography variant="caption">
+                            progress: {s.phase.progress_pct}%
+                          </Typography>
+                        )}
+                      </Stack>
+                    }
+                  >
+                    <Box
+                      sx={{
+                        position: 'absolute',
+                        top: 8,
+                        height: 22,
+                        left: `${left}%`,
+                        width: `${width}%`,
+                        backgroundColor: hue,
+                        borderRadius: 1,
+                        opacity: theme.palette.mode === 'dark' ? 0.85 : 0.9,
+                        display: 'flex',
+                        alignItems: 'center',
+                        px: 0.5,
+                        overflow: 'hidden',
+                        cursor: 'default',
+                      }}
+                    >
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: theme.palette.getContrastText(hue),
+                          whiteSpace: 'nowrap',
+                          textOverflow: 'ellipsis',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        {s.phase.name}
+                      </Typography>
+                    </Box>
+                  </Tooltip>
+                );
+              })}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default RoadmapGantt;

--- a/front-end/src/features/admin/ecosystem-roadmap/RoadmapTable.tsx
+++ b/front-end/src/features/admin/ecosystem-roadmap/RoadmapTable.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import {
+  Box,
+  Chip,
+  LinearProgress,
+  Link,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import LaunchIcon from '@mui/icons-material/Launch';
+import type { RoadmapComponent, RoadmapPriority, RoadmapStatus } from './types';
+
+const STATUS_COLOR: Record<string, 'success' | 'warning' | 'error' | 'info' | 'default'> = {
+  green: 'success',
+  done: 'success',
+  yellow: 'warning',
+  in_progress: 'info',
+  planning: 'info',
+  red: 'error',
+  blocked: 'error',
+};
+
+const PRIORITY_COLOR: Record<string, 'error' | 'warning' | 'info' | 'default'> = {
+  high: 'error',
+  medium: 'warning',
+  low: 'info',
+};
+
+function statusChipColor(status?: RoadmapStatus) {
+  if (!status) return 'default';
+  return STATUS_COLOR[String(status).toLowerCase()] || 'default';
+}
+
+function priorityChipColor(priority?: RoadmapPriority) {
+  if (!priority) return 'default';
+  return PRIORITY_COLOR[String(priority).toLowerCase()] || 'default';
+}
+
+function progressValue(n?: number): number {
+  if (typeof n !== 'number' || Number.isNaN(n)) return 0;
+  return Math.max(0, Math.min(100, n));
+}
+
+interface Props {
+  components: RoadmapComponent[];
+}
+
+const RoadmapTable: React.FC<Props> = ({ components }) => {
+  const theme = useTheme();
+
+  return (
+    <TableContainer
+      sx={{
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: 1,
+        overflowX: 'auto',
+      }}
+    >
+      <Table size="small" stickyHeader aria-label="Component maturity roadmap">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ minWidth: 180 }}>Component</TableCell>
+            <TableCell sx={{ minWidth: 110 }}>Status</TableCell>
+            <TableCell sx={{ minWidth: 100 }}>Priority</TableCell>
+            <TableCell sx={{ minWidth: 180 }}>Current milestone</TableCell>
+            <TableCell sx={{ minWidth: 180 }}>Next milestone</TableCell>
+            <TableCell sx={{ minWidth: 140 }}>Progress</TableCell>
+            <TableCell sx={{ minWidth: 220 }}>Risks / blockers</TableCell>
+            <TableCell sx={{ minWidth: 200 }}>Next action</TableCell>
+            <TableCell sx={{ minWidth: 160 }}>Evidence</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {components.map((c) => {
+            const risks = [...(c.risks || []), ...(c.blockers || [])];
+            const pct = progressValue(c.progress_pct);
+            return (
+              <TableRow key={c.id} hover>
+                <TableCell>
+                  <Typography variant="body2" fontWeight={600}>
+                    {c.name}
+                  </Typography>
+                  {c.category && (
+                    <Typography variant="caption" color="text.secondary">
+                      {c.category}
+                    </Typography>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    size="small"
+                    label={c.status || '—'}
+                    color={statusChipColor(c.status)}
+                    variant={statusChipColor(c.status) === 'default' ? 'outlined' : 'filled'}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    size="small"
+                    label={c.priority || '—'}
+                    color={priorityChipColor(c.priority)}
+                    variant="outlined"
+                  />
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2">{c.current_milestone || '—'}</Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2">{c.next_milestone || '—'}</Typography>
+                </TableCell>
+                <TableCell>
+                  <Stack spacing={0.5}>
+                    <LinearProgress
+                      variant="determinate"
+                      value={pct}
+                      sx={{ height: 8, borderRadius: 1 }}
+                    />
+                    <Typography variant="caption" color="text.secondary">
+                      {pct}%
+                    </Typography>
+                  </Stack>
+                </TableCell>
+                <TableCell>
+                  {risks.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                      —
+                    </Typography>
+                  ) : (
+                    <Stack spacing={0.5}>
+                      {risks.map((r, i) => (
+                        <Typography key={i} variant="caption">
+                          • {r}
+                        </Typography>
+                      ))}
+                    </Stack>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2">{c.next_action || '—'}</Typography>
+                </TableCell>
+                <TableCell>
+                  {!c.evidence || c.evidence.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                      —
+                    </Typography>
+                  ) : (
+                    <Stack spacing={0.5}>
+                      {c.evidence.map((e, i) => (
+                        <Link
+                          key={i}
+                          href={e.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="hover"
+                          variant="caption"
+                          sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                        >
+                          {e.label}
+                          <LaunchIcon sx={{ fontSize: 12 }} />
+                        </Link>
+                      ))}
+                    </Stack>
+                  )}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+          {components.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={9}>
+                <Box sx={{ py: 4, textAlign: 'center' }}>
+                  <Typography variant="body2" color="text.secondary">
+                    No components reported in the roadmap.
+                  </Typography>
+                </Box>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default RoadmapTable;

--- a/front-end/src/features/admin/ecosystem-roadmap/types.ts
+++ b/front-end/src/features/admin/ecosystem-roadmap/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Contract for the OMStudio Component Maturity Roadmap.
+ * OM is a read-only consumer. The shape mirrors what the OM proxy returns
+ * (which in turn passes through OMStudio's response unchanged).
+ */
+
+export type RoadmapStatus =
+  | 'green'
+  | 'yellow'
+  | 'red'
+  | 'blocked'
+  | 'done'
+  | 'planning'
+  | 'in_progress'
+  | string;
+
+export type RoadmapPriority = 'high' | 'medium' | 'low' | string;
+
+export interface RoadmapEvidenceLink {
+  label: string;
+  url: string;
+}
+
+export interface RoadmapPhase {
+  name: string;
+  start_date: string; // ISO date or date-time
+  end_date: string;
+  status?: RoadmapStatus;
+  progress_pct?: number;
+}
+
+export interface RoadmapComponent {
+  id: string;
+  name: string;
+  category?: string;
+  owner?: string;
+  current_milestone?: string | null;
+  next_milestone?: string | null;
+  progress_pct?: number;
+  status?: RoadmapStatus;
+  priority?: RoadmapPriority;
+  risks?: string[];
+  blockers?: string[];
+  evidence?: RoadmapEvidenceLink[];
+  next_action?: string;
+  phases?: RoadmapPhase[];
+  updated_at?: string;
+}
+
+export interface RoadmapPayload {
+  components: RoadmapComponent[];
+  generated_at?: string;
+  source_url?: string;
+  notes?: string;
+}
+
+export type EcosystemRoadmapResponse =
+  | {
+      available: true;
+      upstream: string;
+      fetched_at: string;
+      data: RoadmapPayload;
+    }
+  | {
+      available: false;
+      upstream: string;
+      error: string;
+      detail?: string;
+    };

--- a/front-end/src/layouts/full/vertical/sidebar/MenuItems.ts
+++ b/front-end/src/layouts/full/vertical/sidebar/MenuItems.ts
@@ -453,6 +453,12 @@ const Menuitems: MenuitemsType[] = [
         icon: IconClock,
         href: '/devel-tools/work-session-admin',
       },
+      {
+        id: uniqueId(),
+        title: 'Ecosystem Roadmap',
+        icon: IconChartBar,
+        href: '/admin/ecosystem-roadmap',
+      },
     ],
   },
   {

--- a/front-end/src/routes/adminRoutes.tsx
+++ b/front-end/src/routes/adminRoutes.tsx
@@ -54,6 +54,7 @@ const OMAIDiscoveryPanelMobile = Loadable(lazy(() => import('../features/admin/O
 const LogSearch = Loadable(lazy(() => import('../features/admin/dashboard/LogSearch')));
 const ChurchAdminList = Loadable(lazy(() => import('../features/admin/ChurchAdminList')));
 const ChurchAdminPanel = Loadable(lazy(() => import('../features/admin/ChurchAdminPanelWorking')));
+const EcosystemRoadmapPage = Loadable(lazy(() => import('../features/admin/ecosystem-roadmap/EcosystemRoadmapPage')));
 
 /**
  * All /admin/* route definitions.
@@ -522,5 +523,15 @@ export const adminRoutes = [
         <ChurchAdminPanel />
       </ProtectedRoute>
     )
+  },
+  {
+    path: '/admin/ecosystem-roadmap',
+    element: (
+      <ProtectedRoute requiredRole={['super_admin', 'admin']}>
+        <AdminErrorBoundary>
+          <EcosystemRoadmapPage />
+        </AdminErrorBoundary>
+      </ProtectedRoute>
+    ),
   },
 ];

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -235,6 +235,7 @@ const demoChurchesRouter = require('./routes/admin/demo-churches');
 const churchDecomRouter = require('./routes/admin/church-decom');
 const analyticsRouter = require('./routes/analytics'); // US Church Map analytics
 const websiteStatsRouter = require('./routes/website-stats'); // public site traffic stats (admin-only)
+const ecosystemRoadmapRouter = require('./routes/admin/ecosystemRoadmap'); // read-only proxy to OMStudio component-maturity roadmap
 const omChartsRouter = require('./api/om-charts'); // OM Charts: graphical charts from church records
 const dashboardHomeRouter = require('./api/dashboard-home'); // Dashboard Home: summary data for church dashboard
 const systemRoutesRouter = require('./api/systemRoutes'); // Route introspection (kept for OMAI dual-target proxy)
@@ -651,6 +652,7 @@ app.use('/api/admin/church', churchAdminRouter);
 
 app.use('/api/admin/system', adminSystemRouter);
 app.use('/api/admin', websiteStatsRouter); // mounts GET /api/admin/website-stats
+app.use('/api/admin', ecosystemRoadmapRouter); // mounts GET /api/admin/ecosystem-roadmap (OMStudio proxy)
 // Admin churches routes - mount compatibility router first to catch legacy paths
 const churchesCompatRouter = require('./routes/admin/churches-compat');
 // Mount compatibility router for both /churches (plural) and /church (singular) paths

--- a/server/src/routes/admin/ecosystemRoadmap.js
+++ b/server/src/routes/admin/ecosystemRoadmap.js
@@ -1,0 +1,90 @@
+/**
+ * /api/admin/ecosystem-roadmap — read-only proxy to the canonical Component
+ * Maturity Roadmap hosted by OMStudio.
+ *
+ * OM is intentionally NOT canonical. We forward server-to-server to OMStudio
+ * (no auth header by default — adjust if upstream gates the endpoint), pass
+ * the response shape through unchanged, and surface structured empty / error
+ * states when upstream is unavailable so the admin page can render an empty
+ * shell instead of crashing.
+ */
+
+const express = require('express');
+const { requireRole } = require('../../middleware/auth');
+
+const router = express.Router();
+
+function omstudioBase() {
+  const raw = process.env.OMSTUDIO_URL || 'http://192.168.1.242';
+  return raw.replace(/\/$/, '');
+}
+
+router.get(
+  '/ecosystem-roadmap',
+  requireRole(['super_admin', 'admin']),
+  async (_req, res) => {
+    const base = omstudioBase();
+    const upstream = `${base}/api/governance/component-roadmap`;
+
+    let upstreamRes;
+    try {
+      upstreamRes = await fetch(upstream, {
+        headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(8000),
+      });
+    } catch (err) {
+      return res.status(502).json({
+        available: false,
+        upstream,
+        error: 'omstudio_unreachable',
+        detail: String(err?.message || err),
+      });
+    }
+
+    if (upstreamRes.status === 404) {
+      return res.status(200).json({
+        available: false,
+        upstream,
+        error: 'endpoint_not_yet_published',
+        detail: 'OMStudio has not yet published /api/governance/component-roadmap. The page will render once upstream is available.',
+      });
+    }
+
+    if (!upstreamRes.ok) {
+      let detail = `upstream HTTP ${upstreamRes.status}`;
+      try {
+        const body = await upstreamRes.text();
+        if (body) detail += ` — ${body.slice(0, 500)}`;
+      } catch {
+        // ignore
+      }
+      return res.status(502).json({
+        available: false,
+        upstream,
+        error: 'upstream_error',
+        detail,
+      });
+    }
+
+    let payload;
+    try {
+      payload = await upstreamRes.json();
+    } catch (err) {
+      return res.status(502).json({
+        available: false,
+        upstream,
+        error: 'upstream_invalid_json',
+        detail: String(err?.message || err),
+      });
+    }
+
+    res.json({
+      available: true,
+      upstream,
+      fetched_at: new Date().toISOString(),
+      data: payload,
+    });
+  },
+);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- Adds **/admin/ecosystem-roadmap** (super_admin/admin only) under Devel Tools → Development Console
- Renders the canonical Component Maturity Roadmap from OMStudio via a thin OM proxy
- OM stays a read-only consumer; no roadmap data is stored or written on the OM side

## Data flow

```
Browser  →  GET /api/admin/ecosystem-roadmap    (OM, super_admin/admin gate)
            ↓ server-to-server
OM       →  GET ${OMSTUDIO_URL}/api/governance/component-roadmap   (default: http://192.168.1.242)
            ↓
OMStudio →  canonical roadmap JSON
```

The OM proxy returns:
- `{ available: true, fetched_at, upstream, data }` when OMStudio responds
- `{ available: false, error: 'endpoint_not_yet_published', detail, upstream }` on 404 — OMStudio is building this endpoint in parallel
- `{ available: false, error: 'omstudio_unreachable' | 'upstream_error' | 'upstream_invalid_json', detail, upstream }` otherwise

## Files changed
- `server/src/routes/admin/ecosystemRoadmap.js` (new) — server-to-server proxy
- `server/src/index.ts` — mount under `/api/admin`
- `front-end/src/features/admin/ecosystem-roadmap/EcosystemRoadmapPage.tsx` (new) — page shell, fetch, tabs
- `front-end/src/features/admin/ecosystem-roadmap/RoadmapTable.tsx` (new) — component maturity table (status/priority chips, progress bar, risks/blockers, next action, evidence links)
- `front-end/src/features/admin/ecosystem-roadmap/RoadmapGantt.tsx` (new) — Gantt-style milestone visual
- `front-end/src/features/admin/ecosystem-roadmap/types.ts` (new) — OMStudio response contract
- `front-end/src/routes/adminRoutes.tsx` — route definition with `AdminErrorBoundary` + `super_admin/admin` gate
- `front-end/src/layouts/full/vertical/sidebar/MenuItems.ts` — menu entry under Development Console

## Visibility / auth
- Route gated by `<ProtectedRoute requiredRole={['super_admin', 'admin']}>`
- Backend gated by `requireRole(['super_admin', 'admin'])`
- Menu container (`'🛠️ Developer Tools'` subheader) is already hidden for non-super_admin by an existing filter in MenuItems.ts — the new item inherits that filtering automatically

## Hard constraints respected
- Read-only page — no POST/PUT/DELETE wired
- No duplicate canonical storage in `orthodoxmetrics_db`
- No church-facing portal routes touched
- No automation/scheduler/evaluator behavior
- No new env vars required (uses optional `OMSTUDIO_URL`, defaults to `http://192.168.1.242`)

## Build + smoke results
- `npx tsc --noEmit` (front-end): clean for new files (3 pre-existing tsconfig warnings remain unchanged)
- `om-deploy.sh` (full): backend restarted, frontend built, deploy metadata `build 1.0.0.90`, health endpoint healthy
- `GET /api/admin/ecosystem-roadmap` (unauthed): `HTTP 401` ✅
- `GET /api/admin/ecosystem-roadmap` (super_admin): `HTTP 200` with `available: false, error: endpoint_not_yet_published` — correct empty-state path because upstream hasn't shipped yet ✅
- Frontend bundle: `EcosystemRoadmapPage-BI5ee8rk.js` present in `front-end/dist/assets/`
- Menu bundle contains "Ecosystem Roadmap" entry

## UI verification (manual)
Browser snapshots not captured in this PR because the agent host's DNS for `orthodoxmetrics.com` routes to the external IP, which Playwright cannot reach via NAT-loopback from this host. Reviewer should verify:

- [ ] As super_admin: `https://orthodoxmetrics.com/admin/ecosystem-roadmap` renders, shows the empty-state "Upstream endpoint not yet available" Alert until OMStudio ships the endpoint
- [ ] Menu shows "Ecosystem Roadmap" under Devel Tools → Development Console for super_admin
- [ ] As non-admin (e.g. priest / church_admin): both the menu item and the route are hidden / blocked
- [ ] Toggle light/dark — chips, progress bars, and Alert colors remain legible
- [ ] Resize to tablet/mobile — table is scrollable; Gantt scrolls horizontally; header stack collapses to column

Once OMStudio publishes `/api/governance/component-roadmap`, no OM change should be needed — the page will switch from empty-state to populated automatically.

## OMStudio dependency
The endpoint `/api/governance/component-roadmap` on OMStudio is being built in parallel (per the prompt). The OM proxy is contract-ready and will rehydrate on first successful upstream response.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)