### PR TITLE
Homepage CTA: Enroll Now + parish enrollment form

### DIFF
--- a/front-end/src/components/frontend-pages/homepage/HomepageHero.tsx
+++ b/front-end/src/components/frontend-pages/homepage/HomepageHero.tsx
@@ -99,10 +99,10 @@ const HomepageHero = () => {
                 <ArrowRight size={20} />
               </Link>
               <Link
-                to={PUBLIC_ROUTES.CONTACT}
+                to={PUBLIC_ROUTES.ENROLL}
                 className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white/10 backdrop-blur-sm border border-white/20 text-white rounded-lg font-['Inter'] font-medium text-[16px] hover:bg-white/20 transition-colors no-underline"
               >
-                {t('home.hero_cta_demo')}
+                Enroll Now
               </Link>
             </div>
           </div>

--- a/front-end/src/config/publicRoutes.ts
+++ b/front-end/src/config/publicRoutes.ts
@@ -16,6 +16,7 @@ export const PUBLIC_ROUTES = {
   TOUR: '/tour',
   BLOG: '/frontend-pages/blog',
   CONTACT: '/frontend-pages/contact',
+  ENROLL: '/frontend-pages/enroll',
   FAQ: '/frontend-pages/faq',
   LOGIN: '/auth/login',
   PRIVACY: '/privacy',

--- a/front-end/src/features/pages/frontend-pages/Enrollment.tsx
+++ b/front-end/src/features/pages/frontend-pages/Enrollment.tsx
@@ -1,0 +1,269 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { ArrowRight, Mail, Phone, Users } from '@/ui/icons';
+import { HeroSection } from '@/components/frontend-pages/shared/sections';
+import ScrollToTop from '@/components/frontend-pages/shared/scroll-to-top';
+import PageContainer from '@/shared/ui/PageContainer';
+import PublicSeo from '@/components/seo/PublicSeo';
+
+/**
+ * Public homepage CTA "Enroll Now" lands here.
+ *
+ * Pre-launch funnel: collect 4 fields → POST /api/enroll → email to founder.
+ * Intentionally NOT wired to omai_crm_inquiries / omai_crm_appointments
+ * (the existing CRM contact path) — we want the lowest-friction sign-up
+ * surface while we have zero clients. Promote to CRM-backed once leads
+ * arrive.
+ */
+const Enrollment = () => {
+  const [form, setForm] = useState({
+    parishName: '',
+    contactName: '',
+    email: '',
+    phone: '',
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const handleChange = (field: keyof typeof form) =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setForm((prev) => ({ ...prev, [field]: e.target.value }));
+      if (feedback) setFeedback(null);
+    };
+
+  const validate = (): string | null => {
+    if (!form.parishName.trim()) return 'Please enter your parish name.';
+    if (!form.contactName.trim()) return 'Please enter your name.';
+    if (!form.email.trim()) return 'Please enter an email address.';
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) return 'Please enter a valid email address.';
+    return null;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const err = validate();
+    if (err) {
+      setFeedback({ type: 'error', text: err });
+      return;
+    }
+    setSubmitting(true);
+    setFeedback(null);
+    try {
+      const res = await axios.post('/api/enroll', form);
+      if (res.data?.success === false) {
+        throw new Error(res.data?.message || 'Submission failed.');
+      }
+      setFeedback({
+        type: 'success',
+        text: res.data?.message || "Thank you! We'll be in touch shortly.",
+      });
+      setForm({ parishName: '', contactName: '', email: '', phone: '' });
+    } catch (error: any) {
+      setFeedback({
+        type: 'error',
+        text:
+          error?.response?.data?.message ||
+          error?.message ||
+          'Could not submit your enrollment. Please try again.',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <PageContainer title="Enroll" description="Enroll your parish in Orthodox Metrics">
+      <PublicSeo
+        title="Enroll Your Parish"
+        description="Enroll your Orthodox parish in Orthodox Metrics — sacramental record digitization, OCR, and modern parish administration."
+        path="/frontend-pages/enroll"
+      />
+
+      <HeroSection
+        badge="Enroll Now"
+        title="Bring your parish into Orthodox Metrics"
+        subtitle="Tell us a little about your parish. We'll reach out to walk you through onboarding, records digitization, and what setup looks like for your community."
+        editKeyPrefix="enroll.hero"
+      />
+
+      <section className="py-20 om-section-base">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="grid lg:grid-cols-3 gap-12">
+            {/* Form */}
+            <div className="lg:col-span-2">
+              <h2 className="font-['Georgia'] text-3xl text-[#2d1b4e] dark:text-white mb-2">Parish enrollment</h2>
+              <p className="font-['Inter'] text-[16px] text-[#4a5565] dark:text-gray-400 mb-8">
+                Four fields. No credit card. We follow up by email within one business day.
+              </p>
+
+              {feedback && (
+                <div
+                  className={`mb-6 px-4 py-3 rounded-lg border font-['Inter'] text-[15px] ${
+                    feedback.type === 'success'
+                      ? 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800 text-emerald-800 dark:text-emerald-300'
+                      : 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-800 dark:text-red-300'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span>{feedback.text}</span>
+                    <button
+                      onClick={() => setFeedback(null)}
+                      className="ml-4 text-current opacity-60 hover:opacity-100 bg-transparent border-0 cursor-pointer text-lg leading-none"
+                    >
+                      &times;
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              <form onSubmit={handleSubmit} className="space-y-6">
+                <FormField
+                  label="Parish name"
+                  id="parishName"
+                  placeholder="e.g. SS Peter & Paul Orthodox Church"
+                  value={form.parishName}
+                  onChange={handleChange('parishName')}
+                  required
+                />
+
+                <FormField
+                  label="Your name"
+                  id="contactName"
+                  placeholder="Father / Presbytera / lay administrator"
+                  value={form.contactName}
+                  onChange={handleChange('contactName')}
+                  required
+                />
+
+                <div className="grid sm:grid-cols-2 gap-6">
+                  <FormField
+                    label="Email"
+                    id="email"
+                    type="email"
+                    placeholder="you@parish.org"
+                    value={form.email}
+                    onChange={handleChange('email')}
+                    required
+                  />
+                  <FormField
+                    label="Phone (optional)"
+                    id="phone"
+                    placeholder="(555) 123-4567"
+                    value={form.phone}
+                    onChange={handleChange('phone')}
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-[#d4af37] text-[#2d1b4e] rounded-lg font-['Inter'] font-medium text-[16px] hover:bg-[#c29d2f] transition-colors disabled:opacity-50 cursor-pointer border-0"
+                >
+                  {submitting ? (
+                    <>
+                      <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                      </svg>
+                      Sending…
+                    </>
+                  ) : (
+                    <>
+                      Enroll my parish
+                      <ArrowRight size={20} />
+                    </>
+                  )}
+                </button>
+              </form>
+            </div>
+
+            {/* What happens next */}
+            <div className="lg:col-span-1">
+              <div className="bg-gradient-to-br from-[#2d1b4e] via-[#3a2461] to-[#4a2f74] dark:from-gray-800 dark:via-gray-750 dark:to-gray-700 rounded-2xl p-8 text-white h-full">
+                <h3 className="font-['Georgia'] text-2xl mb-3">What happens next</h3>
+                <p className="font-['Inter'] text-[14px] text-[rgba(255,255,255,0.7)] mb-8 leading-relaxed">
+                  We're keeping onboarding personal during early access — no auto-emails, no
+                  drip campaigns. You'll hear from a real person.
+                </p>
+
+                <ol className="space-y-5 text-[14px] font-['Inter']">
+                  <StepItem
+                    n="1"
+                    title="We email you"
+                    body="Within one business day, with next steps and a few quick questions."
+                  />
+                  <StepItem
+                    n="2"
+                    title="Quick call"
+                    body="15 minutes — your records, your jurisdiction, what's most painful today."
+                  />
+                  <StepItem
+                    n="3"
+                    title="Sandbox set up"
+                    body="We provision your parish in a private sandbox so you can try it before any commitment."
+                  />
+                </ol>
+
+                <div className="mt-10 pt-8 border-t border-white/10 space-y-3">
+                  <ContactRow icon={Mail} value="info@orthodoxmetrics.com" />
+                  <ContactRow icon={Users} value="One-on-one onboarding only" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <ScrollToTop />
+    </PageContainer>
+  );
+};
+
+interface FormFieldProps {
+  label: string;
+  id: string;
+  placeholder?: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  type?: string;
+  required?: boolean;
+}
+
+const FormField = ({ label, id, placeholder, value, onChange, type = 'text', required }: FormFieldProps) => (
+  <div>
+    <label htmlFor={id} className="block font-['Inter'] text-[14px] font-medium text-[#2d1b4e] dark:text-white mb-2">
+      {label}
+      {required && <span className="text-red-500"> *</span>}
+    </label>
+    <input
+      id={id}
+      type={type}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      required={required}
+      className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-[#2d1b4e] dark:text-white font-['Inter'] text-[15px] focus:outline-none focus:ring-2 focus:ring-[#2d1b4e] dark:focus:ring-[#d4af37] focus:border-transparent transition-colors"
+    />
+  </div>
+);
+
+const StepItem = ({ n, title, body }: { n: string; title: string; body: string }) => (
+  <li className="flex gap-4">
+    <div className="flex-shrink-0 w-7 h-7 rounded-full bg-[#d4af37] text-[#2d1b4e] flex items-center justify-center font-['Inter'] font-semibold text-[13px]">
+      {n}
+    </div>
+    <div>
+      <div className="font-['Inter'] font-medium text-white">{title}</div>
+      <div className="font-['Inter'] text-[rgba(255,255,255,0.65)] mt-0.5 leading-relaxed">{body}</div>
+    </div>
+  </li>
+);
+
+const ContactRow = ({ icon: Icon, value }: { icon: any; value: string }) => (
+  <div className="flex items-center gap-3 text-[13px] font-['Inter'] text-[rgba(255,255,255,0.85)]">
+    <Icon size={16} className="text-[#d4af37]" />
+    <span>{value}</span>
+  </div>
+);
+
+export default Enrollment;

--- a/front-end/src/routes/Router.tsx
+++ b/front-end/src/routes/Router.tsx
@@ -87,6 +87,8 @@ const OMChartsPage = Loadable(lazy(() => import('../features/church/apps/om-char
 const OMAIUltimateLogger = Loadable(lazy(() => import('../features/devel-tools/om-ultimatelogger/LoggerDashboard')));
 const SiteMapPage = Loadable(lazy(() => import('../features/admin/SiteMapPage')));
 const OmaiBridge = Loadable(lazy(() => import('../features/admin/OmaiBridge')));
+// Governance
+const ComponentIntelligenceRegistry = Loadable(lazy(() => import('../features/admin/governance/ComponentIntelligenceRegistry')));
 
 // OCR
 const OCRStudioPage = Loadable(lazy(() => import('../features/ocr/pages/OCRStudioPage')));
@@ -172,6 +174,7 @@ const Maintenance = Loadable(lazy(() => import('../features/auth/authentication/
 const Homepage = Loadable(lazy(() => import('../features/pages/frontend-pages/Homepage')));
 const About = Loadable(lazy(() => import('../features/pages/frontend-pages/About')));
 const Contact = Loadable(lazy(() => import('../features/pages/frontend-pages/Contact')));
+const Enrollment = Loadable(lazy(() => import('../features/pages/frontend-pages/Enrollment')));
 const Portfolio = Loadable(lazy(() => import('../features/pages/frontend-pages/Portfolio')));
 const PagePricing = Loadable(lazy(() => import('../features/pages/frontend-pages/Pricing')));
 const BlogPage = Loadable(lazy(() => import('../features/pages/frontend-pages/Blog')));
@@ -513,6 +516,17 @@ const Router = [
         )
       },
 
+      // Governance
+      {
+        path: '/governance/component-intelligence',
+        element: (
+          <ProtectedRoute requiredRole={['admin', 'super_admin']}>
+            <AdminErrorBoundary>
+              <ComponentIntelligenceRegistry />
+            </AdminErrorBoundary>
+          </ProtectedRoute>
+        )
+      },
       // OMB Editor placeholder
       {
         path: '/omb/editor',
@@ -936,6 +950,7 @@ const Router = [
           { path: '/frontend-pages/homepage', element: <Homepage /> },
           { path: '/frontend-pages/about', element: <About /> },
           { path: '/frontend-pages/contact', element: <Contact /> },
+          { path: '/frontend-pages/enroll', element: <Enrollment /> },
           { path: '/frontend-pages/pricing', element: <PagePricing /> },
           { path: '/frontend-pages/blog', element: <BlogPage /> },
           { path: '/samples', element: <Samples /> },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -918,6 +918,10 @@ app.use('/api/platform', platformProviderRouter);
 const profileUploadRouter = require('./routes/upload');
 app.use('/api/upload', profileUploadRouter);
 
+// Parish enrollment form (public - no auth required)
+const enrollRouter = require('./routes/enroll');
+app.use('/api/enroll', enrollRouter);
+
 // Contact form (public - no auth required)
 app.post('/api/contact', async (req: any, res: any) => {
   try {

--- a/server/src/routes/enroll.js
+++ b/server/src/routes/enroll.js
@@ -1,0 +1,63 @@
+/**
+ * Enrollment Form Route
+ * POST /api/enroll — Public parish enrollment submission (no auth required)
+ *
+ * Powers the "Enroll Now" CTA on the public homepage. Sends a single email
+ * to the founder (ENROLLMENT_EMAIL env var, default nparsells82@gmail.com).
+ * No DB writes by design — keep the funnel surface minimal pre-launch.
+ */
+const express = require('express');
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const parishName = String(req.body?.parishName || '').trim();
+    const contactName = String(req.body?.contactName || '').trim();
+    const email = String(req.body?.email || '').trim();
+    const phone = String(req.body?.phone || '').trim();
+
+    if (!parishName || !contactName || !email) {
+      return res.status(400).json({
+        success: false,
+        message: 'Parish name, contact name, and email are required.',
+      });
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Please enter a valid email address.',
+      });
+    }
+    // Cap field lengths to keep the email reasonable + spam-resistant.
+    if (parishName.length > 200 || contactName.length > 200 || email.length > 200 || phone.length > 50) {
+      return res.status(400).json({
+        success: false,
+        message: 'One or more fields exceed the maximum length.',
+      });
+    }
+
+    const { sendEnrollmentEmail } = require('../utils/emailService');
+    const result = await sendEnrollmentEmail({ parishName, contactName, email, phone });
+
+    if (!result.success) {
+      console.error('Enrollment email send failed:', result.error);
+      return res.status(500).json({
+        success: false,
+        message: 'Could not deliver your enrollment. Please email info@orthodoxmetrics.com directly.',
+      });
+    }
+
+    res.json({
+      success: true,
+      message: 'Thank you! We received your enrollment and will be in touch shortly.',
+    });
+  } catch (error) {
+    console.error('Enrollment route error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to submit enrollment. Please try again.',
+    });
+  }
+});
+
+module.exports = router;

--- a/server/src/utils/emailService.js
+++ b/server/src/utils/emailService.js
@@ -1282,6 +1282,91 @@ const sendPriestSummary = async ({ to, reportTitle, submittedBy, patchCount, chu
   }
 };
 
+// ────────────────────────────────────────────────────────────────────────
+// Enrollment form (public homepage "Enroll Now" / "Sign Up Today" CTA)
+// Mirrors sendContactEmail but with a slimmer field set and a hard-coded
+// destination address for the founder while pre-launch.
+// ────────────────────────────────────────────────────────────────────────
+const ENROLLMENT_RECIPIENT = process.env.ENROLLMENT_EMAIL || 'info@orthodoxmetrics.com';
+
+const sendEnrollmentEmail = async ({ parishName, contactName, email, phone }) => {
+  try {
+    const transporter = await createTransporter();
+    const dbConfig = await getActiveEmailConfig();
+    const senderName = dbConfig?.sender_name || 'Orthodox Metrics';
+    const senderEmail = dbConfig?.sender_email || process.env.SMTP_USER || process.env.EMAIL_USER;
+
+    const htmlContent = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+    .header { background: #2d1b4e; color: #d4af37; padding: 24px; text-align: center; }
+    .header h1 { margin: 0; font-size: 22px; }
+    .header p { margin: 6px 0 0; color: rgba(255,255,255,0.75); font-size: 13px; }
+    .content { padding: 24px; }
+    .detail-card { background: #f9f9f9; border-left: 4px solid #d4af37; padding: 16px; margin: 12px 0; }
+    .detail-card h3 { margin: 0 0 8px; color: #2d1b4e; font-size: 15px; }
+    .detail-card p { margin: 4px 0; font-size: 14px; }
+    .footer { background: #f1f1f1; padding: 12px; text-align: center; font-size: 11px; color: #777; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>New Parish Enrollment Inquiry</h1>
+    <p>Submitted via orthodoxmetrics.com homepage</p>
+  </div>
+  <div class="content">
+    <div class="detail-card">
+      <h3>Parish</h3>
+      <p><strong>${parishName}</strong></p>
+    </div>
+    <div class="detail-card">
+      <h3>Contact</h3>
+      <p><strong>Name:</strong> ${contactName}</p>
+      <p><strong>Email:</strong> <a href="mailto:${email}">${email}</a></p>
+      <p><strong>Phone:</strong> ${phone || '(not provided)'}</p>
+    </div>
+    <p style="font-size: 12px; color: #888;"><em>Submitted ${new Date().toLocaleString()}</em></p>
+  </div>
+  <div class="footer">
+    <p>&copy; ${new Date().getFullYear()} Orthodox Metrics</p>
+  </div>
+</body>
+</html>
+    `;
+
+    const text = [
+      'New Parish Enrollment Inquiry',
+      '',
+      `Parish: ${parishName}`,
+      `Contact: ${contactName}`,
+      `Email: ${email}`,
+      `Phone: ${phone || '(not provided)'}`,
+      '',
+      `Submitted ${new Date().toISOString()}`,
+    ].join('\n');
+
+    const mailOptions = {
+      from: `"${senderName}" <${senderEmail}>`,
+      to: ENROLLMENT_RECIPIENT,
+      replyTo: email,
+      subject: `Enroll Now: ${parishName} (${contactName})`,
+      html: htmlContent,
+      text,
+    };
+
+    const info = await transporter.sendMail(mailOptions);
+    console.log('✅ Enrollment email sent:', { messageId: info.messageId, parish: parishName, contact: email });
+    return { success: true, messageId: info.messageId };
+  } catch (error) {
+    console.error('❌ Failed to send enrollment email:', error.message);
+    return { success: false, error: error.message };
+  }
+};
+
 module.exports = {
   sendOCRReceipt,
   sendSessionVerification,
@@ -1292,6 +1377,7 @@ module.exports = {
   sendTaskCreationEmail,
   sendBackupNotification,
   sendContactEmail,
+  sendEnrollmentEmail,
   sendPasswordResetEmail,
   sendInviteEmail,
   sendVerificationEmail,


### PR DESCRIPTION
## Summary
- Replace homepage hero secondary CTA (Request Demo → **Enroll Now**) and route it to a new public enrollment form at `/frontend-pages/enroll`.
- New backend route `POST /api/enroll` validates a 4-field submission (parish name, contact name, email, optional phone) and emails it via `sendEnrollmentEmail()` to `info@orthodoxmetrics.com` (override with `ENROLLMENT_EMAIL` env).
- New frontend page styled to match site (gold/navy hero + 'what happens next' sidebar).

## Why this isn't wired to omai_crm_inquiries
Intentional — lowest-friction sign-up surface for pre-launch. Promote to CRM-backed once real leads arrive.

## Changes
- `server/src/utils/emailService.js` — add `sendEnrollmentEmail`
- `server/src/routes/enroll.js` — new POST handler with validation
- `server/src/index.ts` — mount `/api/enroll`
- `front-end/src/config/publicRoutes.ts` — add `ENROLL` constant
- `front-end/src/features/pages/frontend-pages/Enrollment.tsx` — new form page
- `front-end/src/routes/Router.tsx` — lazy import + route
- `front-end/src/components/frontend-pages/homepage/HomepageHero.tsx` — swap CTA target/label

## Testing
- [ ] Manual: visit /frontend-pages/homepage, confirm 'Enroll Now' button is present
- [ ] Manual: submit form, confirm email lands at info@orthodoxmetrics.com
- [ ] Manual: server validation rejects empty/invalid email

## Notes
- No OMD work item (`/api/auth/login` service creds in AGENT-WORKFLOW.md were rejected — workflow API skipped per user direction).