### PR TITLE
Hotfix: drop orphan ComponentIntelligenceRegistry import (broke build)

### DIFF
--- a/front-end/src/routes/Router.tsx
+++ b/front-end/src/routes/Router.tsx
@@ -87,8 +87,6 @@ const OMChartsPage = Loadable(lazy(() => import('../features/church/apps/om-char
 const OMAIUltimateLogger = Loadable(lazy(() => import('../features/devel-tools/om-ultimatelogger/LoggerDashboard')));
 const SiteMapPage = Loadable(lazy(() => import('../features/admin/SiteMapPage')));
 const OmaiBridge = Loadable(lazy(() => import('../features/admin/OmaiBridge')));
-// Governance
-const ComponentIntelligenceRegistry = Loadable(lazy(() => import('../features/admin/governance/ComponentIntelligenceRegistry')));
 
 // OCR
 const OCRStudioPage = Loadable(lazy(() => import('../features/ocr/pages/OCRStudioPage')));
@@ -516,17 +514,6 @@ const Router = [
         )
       },
 
-      // Governance
-      {
-        path: '/governance/component-intelligence',
-        element: (
-          <ProtectedRoute requiredRole={['admin', 'super_admin']}>
-            <AdminErrorBoundary>
-              <ComponentIntelligenceRegistry />
-            </AdminErrorBoundary>
-          </ProtectedRoute>
-        )
-      },
       // OMB Editor placeholder
       {
         path: '/omb/editor',


### PR DESCRIPTION
## Summary
- PR #913 contaminated Router.tsx with an in-flight import of `../features/admin/governance/ComponentIntelligenceRegistry` and its route. That file is not in the repo — Vite build fails, site is in maintenance mode.
- This PR removes the 3 orphan chunks. Enrollment functionality from #913 is untouched.

## Root cause
The Router.tsx I rsync'd to .239 to build PR #913 was a wholesale copy from a non-git working tree on .251 that had un-merged work mixed in. The contamination wasn't caught before merge.

## Testing
- [ ] `npm run build` succeeds
- [ ] Homepage 'Enroll Now' button still works
- [ ] `rm /var/www/orthodoxmetrics/maintenance.on` after successful deploy

## Followup
- Worth auditing the rest of .251's working copy for other drift before any future rsync-based pushes.