### PR TITLE
fix: remove double header/footer on /frontend-pages/enroll

### DIFF
--- a/front-end/src/routes/Router.tsx
+++ b/front-end/src/routes/Router.tsx
@@ -937,7 +937,6 @@ const Router = [
           { path: '/frontend-pages/homepage', element: <Homepage /> },
           { path: '/frontend-pages/about', element: <About /> },
           { path: '/frontend-pages/contact', element: <Contact /> },
-          { path: '/frontend-pages/enroll', element: <Enrollment /> },
           { path: '/frontend-pages/pricing', element: <PagePricing /> },
           { path: '/frontend-pages/blog', element: <BlogPage /> },
           { path: '/samples', element: <Samples /> },
@@ -949,6 +948,9 @@ const Router = [
           { path: '/security', element: <Security /> },
         ],
       },
+      // Enrollment wizard brings its own header/footer chrome — keep it
+      // outside PublicLayout so HpHeader/SiteFooter don't double up.
+      { path: '/frontend-pages/enroll', element: <Enrollment /> },
       { path: '/greek_baptism_table_demo.html', element: <GreekRecordsViewer /> },
       { path: '/russian_wedding_table_demo.html', element: <HTMLViewer htmlFile="/russian_wedding_table_demo.html" /> },
       { path: '/romanian_funeral_table_demo.html', element: <HTMLViewer htmlFile="/romanian_funeral_table_demo.html" /> },


### PR DESCRIPTION
## Summary
The om-church-onboarding component (#915) brings its own header (Landing + Onboarding both render their own \`<header>\`) and its own footer (Landing renders a \`<footer>\`). Because \`/frontend-pages/enroll\` was nested under \`<PublicLayout>\` in Router.tsx, HpHeader + workshop header stack at the top and SiteFooter + workshop footer stack at the bottom.

Move the route to a sibling of the \`PublicLayout\` block (still inside \`BlankLayout\`) so the page renders only the chrome the component itself provides.

## Build verified
\`vite build\` succeeds on \`.239\` before pushing.

## Testing
- [ ] \`/frontend-pages/enroll\` shows **one** header (workshop's purple/gold one) and **one** footer
- [ ] Other public pages (\`/frontend-pages/homepage\`, \`/about\`, \`/contact\`, etc.) still render with HpHeader + SiteFooter